### PR TITLE
feat: upgrade a site's PHP version (first write action) + Search actions mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,13 @@ conflicts, the store exposes `route`, `inputMode`, and `overlayOpen`; each view'
 handler early-returns unless it is the active route and no input/overlay is
 capturing keys (`App.tsx` handles global keys + quit).
 
+Search has two focus states (query/actions): the search `<input>` is focused only
+in query mode (`inputMode` on, suppressing global shortcuts); pressing `Tab`/`→`
+blurs it and switches to "actions" focus, where the selected result's single-key
+actions (`o`/`w`/`u`/`h`) fire and the Details pane becomes an action menu. `←`/`Esc`
+returns to the box. (While the input is focused only `↑ ↓ Enter Esc` reliably reach
+the view; `Tab`/`→` are handled because the input doesn't consume them.)
+
 ## Visual testing without a TTY
 
 The harness has no interactive terminal. Drive the app through a PTY and
@@ -50,6 +57,9 @@ ST (`ESC \`), not BEL.
 
 ## API
 
-Read-only today (`SpinupWPClient` only implements GETs). The configured token has
-Read Only scope. If adding write actions, gate them behind a token-scope check and
-keep the read-only path working.
+Mostly reads, plus one write: `upgradeSitePhp` (`PUT /sites/{id}/php`). Writes go
+through `SpinupWPClient.mutate()`, which treats a `403` as "token is read-only"
+(the API exposes **no** token-scope endpoint, so attempt-and-handle-403 is the
+detection). Keep the read path fully working regardless of token scope. New write
+actions should reuse `mutate()` + the async-event pattern (`getEvent` polling) and
+the confirm-before-firing overlay (`ui/views/PhpUpgrade.tsx`).

--- a/README.md
+++ b/README.md
@@ -40,16 +40,21 @@ Once you're in, the dashboard looks like this:
   WHMCS, Laravel, Static HTML, and WordPress versions the API can't tell you —
   or `D` to probe a whole stack at once. (See "Stack detection" below.)
 - **Global search** — fuzzy search across every server and site at once by name,
-  domain, or IP. Jump straight to anything.
+  domain, or IP. Tab onto a result to act on it (open, SpinupWP, PHP upgrade,
+  health) right from the results, without leaving the search.
 - **Events feed** — recent provisioning and operation activity, with per-event
   detail and output.
 - **Live server health** — press `h` on any server for a real-time view over
   SSH: CPU (aggregate + per-core + sparkline), load, memory/swap, disk mounts,
   and top processes. Polls every few seconds. (See "Server health" below.)
 - **Open in browser** — press `o` on any site to open it in your default browser.
+- **Upgrade a site's PHP version** — press `u` on a site to pick a new PHP
+  version and apply it (`PUT /sites/{id}/php`), then watch the upgrade event run
+  to completion. (See "Upgrading PHP" below.)
 
-> The tool is **read-only** today (it works great with a Read Only API token).
-> Write actions can be layered on later.
+> The tool is **read-only by default** and works great with a Read Only API
+> token. The one write action — upgrading a site's PHP version — needs a
+> **Read/Write** token; everything else keeps working without one.
 
 ## Requirements
 
@@ -59,7 +64,8 @@ Once you're in, the dashboard looks like this:
   ```
 - A SpinupWP API token — create one at
   [spinupwp.app/account/api](https://spinupwp.app/account/api/). **Read Only**
-  scope is enough.
+  scope is enough to browse; use **Read/Write** if you want to upgrade a site's
+  PHP version.
 
 ## Install & run
 
@@ -146,11 +152,17 @@ Both can be set in `config.json` or via an environment variable:
 | `h` | Live server health (CPU/mem/disk over SSH) |
 | `d` | Detect a site's stack via SSH (Servers / Stacks tabs) |
 | `D` | Detect every site in the selected stack (Stacks tab) |
+| `u` | Upgrade a site's PHP version (Servers / Stacks / Search; needs a Read/Write token) |
 | `w` | Open the selected server/site in the SpinupWP web app |
 | `/` | Jump to global search |
 | `r` | Refresh data from the API |
 | `?` | Toggle the help overlay |
 | `q` / `Ctrl+C` | Quit |
+
+In the **Search** tab the box keeps keyboard focus while you type. Press **Tab**
+(or **→**) to hand focus to the selected result's **action menu** — `o` / `w` /
+`u` / `h` then act on that server or site — and **←** / **Esc** to return to the
+search box.
 
 ## Server health (SSH)
 
@@ -194,6 +206,30 @@ keys, `BatchMode`) and are **read-only**. Results are cached to
 `~/.config/spinupwp-tui/stack-cache.json`, hydrated at startup, so detections
 survive restarts without re-running SSH.
 
+## Upgrading PHP
+
+Press `u` on a selected site (in the **Servers** or **Stacks** tab) to change its
+PHP version. A picker lists the available versions — the current one is marked,
+end-of-life versions are flagged, and the list is sourced from the live PHP
+release schedule (so new versions like 8.5 appear automatically). After you
+confirm, the app calls `PUT /sites/{id}/php` and polls the resulting event until
+it finishes.
+
+- **Needs a Read/Write token.** SpinupWP exposes no token-scope endpoint, so a
+  read-only token is detected when the upgrade comes back `403` — you'll get a
+  clear "token is read-only" message and nothing changes. Swap in a Read/Write
+  token (`spinup login`) to actually apply upgrades.
+- **On-demand install.** If the chosen version isn't installed on the server yet,
+  SpinupWP installs it first; the event simply takes a little longer.
+- **Pending platform upgrade.** If the site's server has a pending SpinupWP
+  platform upgrade, it can't be managed via the API until that runs — the picker
+  is blocked and points you to open the server in the web app (`w`).
+- **Runs in the background.** The upgrade is tracked in the app's store, so you
+  can press `Esc` to close the modal and it keeps going — the site's row shows a
+  spinner and the target version (`→8.3`) until it settles, then refreshes to the
+  new version (or flags `⬆!` if it failed). The SiteDetail "PHP" field shows the
+  same in-progress state. You can launch upgrades on several sites at once.
+
 ## Development
 
 ```sh
@@ -208,19 +244,20 @@ src/
   index.tsx          entry — boots OpenTUI, routes onboarding vs app
   config.ts          token resolution + persistence
   api/
-    client.ts        typed fetch client (pagination, errors, validation)
+    client.ts        typed fetch client (reads + writes, errors, validation)
     types.ts         Server / Site / Event types
   lib/               formatting, theme, open-in-browser, SSH helpers
     stack.ts         Tier-1 stack classification + effective (probe-aware) bucket
     probe.ts         Tier-2 SSH stack probe (WHMCS / Bedrock / Laravel / WP / …)
     stackCache.ts    disk-backed probe cache (hydrate on start, write-through)
+    phpEol.ts        PHP EOL dates + the version set offered by the upgrade picker
   ui/
     App.tsx          shell: splash gating, key routing, layout
     store.tsx        React-context data store
     Splash / Onboarding / Header / StatusBar / Help
     List.tsx         generic windowed keyboard list
     Details.tsx      shared server/site detail panels
-    views/           Dashboard, Browser, Stacks, Search, Events
+    views/           Dashboard, Browser, Stacks, Search, Events, Health, PhpUpgrade
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spinupwp-tui",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A cool terminal UI for browsing and monitoring your SpinupWP servers and sites.",
   "type": "module",
   "bin": {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,5 +1,8 @@
 // Thin typed wrapper around the SpinupWP REST API using fetch + Bearer auth.
-// Read-only by design for now (the configured token has read-only scope).
+// Reads (GET) work with any token. The handful of write methods (e.g.
+// upgradeSitePhp) need a Read/Write-scoped token; since the API exposes no
+// token-scope endpoint, a write that comes back 403 is treated as "token is
+// read-only" (see mutate()).
 
 import type { ApiList, ApiSingle, Server, Site, Event } from "./types.ts"
 
@@ -71,6 +74,50 @@ export class SpinupWPClient {
     return (await res.json()) as T
   }
 
+  // Write request (POST/PUT/PATCH/DELETE) with a JSON body. A 403 here almost
+  // always means the token lacks Read/Write scope — there's no scope endpoint to
+  // check up front, so we detect it by attempting the write and translating the
+  // 403 into an actionable message. All other statuses mirror request().
+  private async mutate<T>(path: string, method: string, body?: unknown): Promise<T> {
+    const url = this.baseUrl + path
+    let res: Response
+    try {
+      res = await fetch(url, {
+        method,
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "User-Agent": "spinupwp-tui",
+        },
+        body: body === undefined ? undefined : JSON.stringify(body),
+      })
+    } catch (err) {
+      throw new ApiError(`Network error reaching the SpinupWP API: ${(err as Error).message}`, 0)
+    }
+
+    if (res.status === 401) {
+      throw new ApiError("Unauthorized — your access token was rejected (401).", 401)
+    }
+    if (res.status === 403) {
+      throw new ApiError(
+        "Your token is read-only — this action needs a Read/Write token. Run `spinup login` to set one.",
+        403,
+      )
+    }
+    if (res.status === 429) {
+      throw new ApiError("Rate limited by the SpinupWP API (429). Try again shortly.", 429)
+    }
+    if (!res.ok) {
+      const errBody = await res.text().catch(() => "")
+      throw new ApiError(`SpinupWP API error (HTTP ${res.status}).`, res.status, errBody)
+    }
+
+    // Some write endpoints (e.g. PHP upgrade) return a bare body, others 204.
+    if (res.status === 204) return undefined as T
+    return (await res.json().catch(() => undefined)) as T
+  }
+
   // Fetch a single page of a list resource.
   private listPage<T>(path: string, page: number, params?: Record<string, string | number | undefined>) {
     return this.request<ApiList<T>>(path, { page, limit: 100, ...params })
@@ -137,5 +184,20 @@ export class SpinupWPClient {
       page += 1
     }
     return all
+  }
+
+  // Fetch a single event by id — used to track an async write to completion.
+  async getEvent(id: number): Promise<Event> {
+    const res = await this.request<ApiSingle<Event>>(`/events/${id}`)
+    return res.data
+  }
+
+  // ---- Writes -----------------------------------------------------------
+
+  // Change a site's PHP version. Async on SpinupWP's side: returns an event_id
+  // to poll via getEvent(). SpinupWP installs the version on the server first if
+  // it isn't already present. Needs a Read/Write token (see mutate()).
+  upgradeSitePhp(siteId: number, phpVersion: string): Promise<{ event_id: number }> {
+    return this.mutate<{ event_id: number }>(`/sites/${siteId}/php`, "PUT", { php_version: phpVersion })
   }
 }

--- a/src/lib/phpEol.ts
+++ b/src/lib/phpEol.ts
@@ -65,6 +65,23 @@ export function isPhpEol(version: string | null | undefined, dates: PhpEolDates,
   return Number.isFinite(t) && t < asOf.getTime()
 }
 
+// The PHP versions to offer in the upgrade picker. Derived dynamically from the
+// (network-refreshed) EOL schedule so it tracks new releases (8.5, 8.6, …) on its
+// own rather than rotting in a hard-coded list. We keep the modern major (8.x),
+// drop ancient 7.x, and always include the site's current version even if the
+// schedule no longer lists it. Not filtered to "installed on the server" —
+// SpinupWP installs a version on demand the first time a site is assigned it.
+export function offeredPhpVersions(dates: PhpEolDates, current?: string | null): string[] {
+  const set = new Set<string>()
+  for (const key of Object.keys(dates)) {
+    const maj = Number.parseInt(key.split(".")[0] ?? "", 10)
+    if (maj >= 8) set.add(key)
+  }
+  const cur = current ? majorMinor(current) : null
+  if (cur) set.add(cur)
+  return [...set].sort((a, b) => phpSortKey(a) - phpSortKey(b))
+}
+
 // Numeric sort key for "8.10" > "8.2" correctness (major*100 + minor).
 export function phpSortKey(version: string | null | undefined): number {
   if (!version) return -1

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -13,6 +13,7 @@ import { Stacks } from "./views/Stacks.tsx"
 import { Search } from "./views/Search.tsx"
 import { Events } from "./views/Events.tsx"
 import { Health } from "./views/Health.tsx"
+import { PhpUpgrade } from "./views/PhpUpgrade.tsx"
 
 const MIN_SPLASH_MS = 1200
 
@@ -30,7 +31,7 @@ export function App() {
   }, [])
 
   // Keep views aware that a modal is open so they pause their own key handling.
-  const overlayActive = showHelp || store.healthServer !== null
+  const overlayActive = showHelp || store.healthServer !== null || store.phpUpgradeSite !== null
   useEffect(() => {
     store.setOverlayOpen(overlayActive)
   }, [overlayActive, store])
@@ -53,6 +54,9 @@ export function App() {
 
     // The health overlay owns the keyboard while open (it handles Esc/q/r/h).
     if (store.healthServer) return
+
+    // The PHP-upgrade overlay owns the keyboard while open.
+    if (store.phpUpgradeSite) return
 
     if (showHelp) {
       if (key.name === "escape" || key.name === "q" || key.name === "?") setShowHelp(false)
@@ -112,6 +116,7 @@ export function App() {
       </box>
       {showHelp && <HelpOverlay onClose={() => setShowHelp(false)} />}
       {store.healthServer && <Health />}
+      {store.phpUpgradeSite && <PhpUpgrade />}
     </box>
   )
 }

--- a/src/ui/Details.tsx
+++ b/src/ui/Details.tsx
@@ -5,7 +5,7 @@ import { formatBytes, diskUsedPct, bar, formatDate, timeAgo, truncate } from "..
 import { Field, StatusBadge } from "./components.tsx"
 import { classifyStack, stackColor } from "../lib/stack.ts"
 import { probeKindColor } from "../lib/probe.ts"
-import { useStore } from "./store.tsx"
+import { useStore, isUpgradeInFlight } from "./store.tsx"
 import type { Server, Site } from "../api/types.ts"
 
 export function ServerDetail({ server, siteCount }: { server: Server; siteCount: number }) {
@@ -59,11 +59,12 @@ export function ServerDetail({ server, siteCount }: { server: Server; siteCount:
 }
 
 export function SiteDetail({ site, serverName }: { site: Site; serverName: string }) {
-  const { probes, probingIds, isProbeStale } = useStore()
+  const { probes, probingIds, isProbeStale, phpUpgrades } = useStore()
   const updates = (site.wp_plugin_updates || 0) + (site.wp_theme_updates || 0) + (site.wp_core_update ? 1 : 0)
   const stack = classifyStack(site)
   const probe = probes.get(site.id)
   const probing = probingIds.has(site.id)
+  const upgrade = phpUpgrades.get(site.id)
   return (
     <box style={{ flexDirection: "column" }}>
       <box style={{ flexDirection: "row" }}>
@@ -82,7 +83,19 @@ export function SiteDetail({ site, serverName }: { site: Site; serverName: strin
         valueColor={probing ? theme.textDim : probe ? probeKindColor(probe.result.kind) : theme.textFaint}
       />
       <Field label="Type" value={site.is_wordpress ? "WordPress" : "Generic"} valueColor={site.is_wordpress ? theme.brand : theme.textDim} />
-      <Field label="PHP" value={site.php_version ?? "—"} />
+      <Field
+        label="PHP"
+        value={
+          upgrade && isUpgradeInFlight(upgrade)
+            ? `${site.php_version ?? "—"} → ${upgrade.target} (${upgrade.status}…)`
+            : upgrade?.status === "failed"
+              ? `${site.php_version ?? "—"} (upgrade failed)`
+              : (site.php_version ?? "—")
+        }
+        valueColor={
+          upgrade && isUpgradeInFlight(upgrade) ? theme.warn : upgrade?.status === "failed" ? theme.bad : theme.text
+        }
+      />
       <Field label="User" value={site.site_user ?? "—"} />
       <Field label="Public dir" value={site.public_folder ?? "/"} />
       <Field

--- a/src/ui/Help.tsx
+++ b/src/ui/Help.tsx
@@ -25,8 +25,17 @@ const SECTIONS: { title: string; keys: [string, string][] }[] = [
       ["h", "Live server health (CPU/mem/disk over SSH)"],
       ["d", "Detect a site's stack via SSH (Servers / Stacks tabs)"],
       ["D", "Detect every site in the selected stack (Stacks tab)"],
+      ["u", "Upgrade a site's PHP version (needs a Read/Write token)"],
       ["w", "Open the selected server/site in the SpinupWP web app"],
       ["g / G", "Jump to top / bottom"],
+    ],
+  },
+  {
+    title: "Search tab",
+    keys: [
+      ["Tab / →", "Hand focus from the search box to the result's actions"],
+      ["o / w / u / h", "Act on the result: open · SpinupWP · PHP upgrade · health"],
+      ["← / Esc", "Return to the search box"],
     ],
   },
 ]
@@ -67,7 +76,7 @@ export function HelpOverlay({ onClose }: { onClose: () => void }) {
             <box style={{ height: 1 }} />
           </box>
         ))}
-        <text content="A read-only SpinupWP control center · built with OpenTUI" fg={theme.textFaint} />
+        <text content="A SpinupWP control center · built with OpenTUI" fg={theme.textFaint} />
       </box>
     </box>
   )

--- a/src/ui/Onboarding.tsx
+++ b/src/ui/Onboarding.tsx
@@ -56,7 +56,7 @@ export function Onboarding({ onComplete }: { onComplete: () => void }) {
         <text content="Let's connect this tool to your SpinupWP account." fg={theme.text} />
         <box style={{ height: 1 }} />
         <text content="1. Open https://spinupwp.app/account/api/" fg={theme.textDim} />
-        <text content="2. Create a token (Read Only is enough to start)" fg={theme.textDim} />
+        <text content="2. Create a token (Read Only to browse; Read/Write to upgrade PHP)" fg={theme.textDim} />
         <text content="3. Paste it below and press Enter" fg={theme.textDim} />
         <box style={{ height: 1 }} />
 

--- a/src/ui/components.tsx
+++ b/src/ui/components.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, type ReactNode } from "react"
 import { theme, statusColor, statusDot } from "../lib/theme.ts"
+import { isUpgradeInFlight, type PhpUpgradeProgress } from "./store.tsx"
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 
@@ -88,6 +89,40 @@ export function StatusBadge({ status, label }: { status: string | null | undefin
 // A small inline pill, e.g. for "reboot required" warnings.
 export function Pill({ text, color }: { text: string; color: string }) {
   return <text content={` ${text} `} fg={theme.bg} bg={color} />
+}
+
+// Trailing PHP-version cell for a site row. Normally the version string; while a
+// PHP upgrade is in flight it shows a spinner + the target (e.g. "⠹→8.3"); a
+// failed upgrade flags the version with "⬆!". Shared by the Servers & Stacks rows.
+export function PhpVersionCell({
+  version,
+  upgrade,
+  selected,
+  eol = false,
+}: {
+  version: string | null | undefined
+  upgrade?: PhpUpgradeProgress
+  selected?: boolean
+  eol?: boolean
+}) {
+  if (upgrade && isUpgradeInFlight(upgrade)) {
+    return (
+      <box style={{ flexDirection: "row", flexShrink: 0 }}>
+        <Spinner color={selected ? theme.text : theme.brand} interval={120} />
+        <text content={`→${upgrade.target}`} fg={selected ? theme.text : theme.warn} wrapMode="none" />
+      </box>
+    )
+  }
+  if (upgrade?.status === "failed") {
+    return <text content={`${version ?? "—"} ⬆!`} fg={selected ? theme.text : theme.bad} style={{ flexShrink: 0 }} />
+  }
+  return (
+    <text
+      content={version ?? "—"}
+      fg={selected ? theme.text : eol ? theme.bad : theme.textFaint}
+      style={{ flexShrink: 0 }}
+    />
+  )
 }
 
 // Centered helper text, often for empty/loading states inside a panel.

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -11,9 +11,27 @@ import type { Server, Site, Event } from "../api/types.ts"
 import { loadConfig } from "../config.ts"
 import { probeSite } from "../lib/probe.ts"
 import { StackCache, siteSignature, type CachedProbe } from "../lib/stackCache.ts"
-import { resolvePhpEolDates, refreshPhpEolDates, isPhpEol as isPhpEolWith, type PhpEolDates } from "../lib/phpEol.ts"
+import { resolvePhpEolDates, refreshPhpEolDates, isPhpEol as isPhpEolWith, offeredPhpVersions as offeredPhpVersionsWith, type PhpEolDates } from "../lib/phpEol.ts"
 
 export type Route = "dashboard" | "servers" | "stacks" | "search" | "events"
+
+// Progress of a PHP-version upgrade, tracked in the store so it survives the
+// modal being closed. `status` mirrors the SpinupWP event status
+// (queued/creating/updating/… → deployed | failed); non-terminal means in-flight.
+export interface PhpUpgradeProgress {
+  target: string
+  status: string
+  error?: string
+}
+
+// SpinupWP event statuses that mean the operation has settled.
+const UPGRADE_DONE = "deployed"
+const UPGRADE_FAIL = "failed"
+const UPGRADE_POLL_MS = 2500
+
+export function isUpgradeInFlight(p: PhpUpgradeProgress | undefined): boolean {
+  return p != null && p.status !== UPGRADE_DONE && p.status !== UPGRADE_FAIL
+}
 
 export interface DataState {
   servers: Server[]
@@ -40,6 +58,17 @@ interface StoreValue extends DataState {
   // The server whose live health view is open, or null. Set by the Browser.
   healthServer: Server | null
   setHealthServer: (s: Server | null) => void
+  // The site whose PHP-upgrade overlay is open, or null. Set by site views.
+  phpUpgradeSite: Site | null
+  setPhpUpgradeSite: (s: Site | null) => void
+  // In-flight (and just-failed) PHP upgrades, keyed by site id. Tracked in the
+  // store — not the overlay — so progress survives closing the modal; site rows
+  // and detail panels read this to show a spinner/marker.
+  phpUpgrades: Map<number, PhpUpgradeProgress>
+  // Fire a PHP upgrade and poll its event to completion in the background.
+  startPhpUpgrade: (site: Site, version: string) => void
+  // Drop a terminal (deployed/failed) entry — e.g. when the modal is dismissed.
+  clearPhpUpgrade: (siteId: number) => void
   // Optional SSH user override for the health view (from env/config).
   sshUser: string | null
   // SpinupWP account slug (from env/config) for building web deep links.
@@ -58,6 +87,8 @@ interface StoreValue extends DataState {
   isProbeStale: (site: Site) => boolean
   // Whether a PHP version is past end-of-life (real dates vs today, refreshed).
   isPhpEol: (version: string | null | undefined) => boolean
+  // PHP versions to offer in the upgrade picker (dynamic; current always included).
+  offeredPhpVersions: (current?: string | null) => string[]
 }
 
 const StoreContext = createContext<StoreValue | null>(null)
@@ -87,6 +118,8 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const [inputMode, setInputMode] = useState(false)
   const [overlayOpen, setOverlayOpen] = useState(false)
   const [healthServer, setHealthServer] = useState<Server | null>(null)
+  const [phpUpgradeSite, setPhpUpgradeSite] = useState<Site | null>(null)
+  const [phpUpgrades, setPhpUpgrades] = useState<Map<number, PhpUpgradeProgress>>(new Map())
 
   // Tier-2 stack-probe cache: hydrate from disk once (read-only at startup; no
   // SSH). Probes run lazily on demand and write through to disk.
@@ -204,6 +237,70 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const isProbeStale = useCallback((site: Site) => cacheRef.current!.isStale(site.id, siteSignature(site)), [])
 
   const isPhpEol = useCallback((version: string | null | undefined) => isPhpEolWith(version, phpEolDates), [phpEolDates])
+  const offeredPhpVersions = useCallback(
+    (current?: string | null) => offeredPhpVersionsWith(phpEolDates, current),
+    [phpEolDates],
+  )
+
+  const setUpgrade = (siteId: number, progress: PhpUpgradeProgress) =>
+    setPhpUpgrades((prev) => new Map(prev).set(siteId, progress))
+
+  const clearPhpUpgrade = useCallback(
+    (siteId: number) =>
+      setPhpUpgrades((prev) => {
+        if (!prev.has(siteId)) return prev
+        const next = new Map(prev)
+        next.delete(siteId)
+        return next
+      }),
+    [],
+  )
+
+  const startPhpUpgrade = useCallback(
+    (site: Site, version: string) => {
+      // Ignore a duplicate request while one is already running for this site.
+      const existing = phpUpgrades.get(site.id)
+      if (existing && existing.status !== UPGRADE_DONE && existing.status !== UPGRADE_FAIL) return
+
+      const run = async () => {
+        setUpgrade(site.id, { target: version, status: "queued" })
+        let eventId: number
+        try {
+          const res = await client.upgradeSitePhp(site.id, version)
+          eventId = res.event_id
+        } catch (err) {
+          const msg = err instanceof ApiError ? err.message : (err as Error).message
+          setUpgrade(site.id, { target: version, status: UPGRADE_FAIL, error: msg })
+          return
+        }
+
+        const poll = async () => {
+          try {
+            const ev = await client.getEvent(eventId)
+            if (ev.status === UPGRADE_DONE) {
+              await refresh() // pull the new php_version into the store…
+              clearPhpUpgrade(site.id) // …then the row reflects truth, no marker needed
+            } else if (ev.status === UPGRADE_FAIL) {
+              setUpgrade(site.id, {
+                target: version,
+                status: UPGRADE_FAIL,
+                error: ev.output?.trim() || "The upgrade event failed on SpinupWP.",
+              })
+            } else {
+              setUpgrade(site.id, { target: version, status: ev.status })
+              setTimeout(() => void poll(), UPGRADE_POLL_MS)
+            }
+          } catch (err) {
+            const msg = err instanceof ApiError ? err.message : (err as Error).message
+            setUpgrade(site.id, { target: version, status: UPGRADE_FAIL, error: msg })
+          }
+        }
+        setTimeout(() => void poll(), UPGRADE_POLL_MS)
+      }
+      void run()
+    },
+    [client, refresh, clearPhpUpgrade, phpUpgrades],
+  )
 
   const value: StoreValue = {
     servers,
@@ -223,6 +320,11 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     setOverlayOpen,
     healthServer,
     setHealthServer,
+    phpUpgradeSite,
+    setPhpUpgradeSite,
+    phpUpgrades,
+    startPhpUpgrade,
+    clearPhpUpgrade,
     sshUser: cfgRef.current.sshUser,
     accountSlug: cfgRef.current.accountSlug,
     sitesForServer,
@@ -234,6 +336,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     runProbeMany,
     isProbeStale,
     isPhpEol,
+    offeredPhpVersions,
   }
 
   return <StoreContext.Provider value={value}>{children}</StoreContext.Provider>

--- a/src/ui/views/Browser.tsx
+++ b/src/ui/views/Browser.tsx
@@ -10,7 +10,7 @@ import { useKeyboard } from "@opentui/react"
 import { theme, statusColor, statusDot } from "../../lib/theme.ts"
 import { classifyStack, stackColor, stackTag } from "../../lib/stack.ts"
 import { truncate } from "../../lib/format.ts"
-import { Panel } from "../components.tsx"
+import { Panel, PhpVersionCell } from "../components.tsx"
 import { List, moveSelection } from "../List.tsx"
 import { ServerDetail, SiteDetail } from "../Details.tsx"
 import { StatusBar } from "../StatusBar.tsx"
@@ -22,7 +22,7 @@ type Focus = "servers" | "sites"
 
 export function Browser({ rows }: { rows: number }) {
   const store = useStore()
-  const { servers, sitesForServer, route, inputMode, overlayOpen, setHealthServer, runProbe, accountSlug } = store
+  const { servers, sitesForServer, route, inputMode, overlayOpen, setHealthServer, runProbe, accountSlug, setPhpUpgradeSite, phpUpgrades } = store
 
   const [serverIndex, setServerIndex] = useState(0)
   const [siteIndex, setSiteIndex] = useState(0)
@@ -97,6 +97,10 @@ export function Browser({ rows }: { rows: number }) {
           setTimeout(() => setFlash(null), 1500)
         }
         return
+      case "u":
+        // Upgrade the selected site's PHP version (first write action).
+        if (focus === "sites" && sites[siteIndex]) setPhpUpgradeSite(sites[siteIndex])
+        return
       case "h":
         // Open the live health view for the current server (works from either pane).
         if (server) setHealthServer(server)
@@ -131,6 +135,7 @@ export function Browser({ rows }: { rows: number }) {
           { key: "↑↓/jk", label: "select site" },
           { key: "←/esc", label: "back" },
           { key: "d", label: "detect" },
+          { key: "u", label: "upgrade PHP" },
           { key: "o", label: "open" },
           { key: "w", label: "SpinupWP" },
           { key: "h", label: "health" },
@@ -180,7 +185,7 @@ export function Browser({ rows }: { rows: number }) {
                   <text content={truncate(s.domain, 40)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
                   <text content={stackTag(stack) + " "} fg={stackColor(stack, selected)} style={{ flexShrink: 0 }} />
                   {updates > 0 && <text content={`↑${updates} `} fg={theme.warn} style={{ flexShrink: 0 }} />}
-                  <text content={s.php_version ?? ""} fg={selected ? theme.text : theme.textFaint} style={{ flexShrink: 0 }} />
+                  <PhpVersionCell version={s.php_version} upgrade={phpUpgrades.get(s.id)} selected={selected} />
                 </>
               )
             }}

--- a/src/ui/views/PhpUpgrade.tsx
+++ b/src/ui/views/PhpUpgrade.tsx
@@ -1,0 +1,301 @@
+// PHP-version upgrade overlay — the app's first *write* action.
+//
+// Opened with `u` on a selected site (Browser / Stacks). Walks through: pick a
+// version → confirm → fire the upgrade. The actual PUT + event polling live in
+// the store (`startPhpUpgrade`), so closing this modal (Esc/q) doesn't abandon
+// the upgrade — the site's row keeps a spinner until it settles. A site whose
+// server has a pending SpinupWP platform upgrade is blocked up front (the API
+// can't manage it until that runs — point the user at the `w` deep link).
+
+import { useState } from "react"
+import { useKeyboard } from "@opentui/react"
+import { theme } from "../../lib/theme.ts"
+import { truncate } from "../../lib/format.ts"
+import { Panel, Spinner, Centered } from "../components.tsx"
+import { StatusBar } from "../StatusBar.tsx"
+import { useStore } from "../store.tsx"
+import { moveSelection } from "../List.tsx"
+
+type Phase = "blocked" | "pick" | "confirm" | "tracking" | "done" | "error"
+
+function majorMinor(v: string | null | undefined): string {
+  if (!v) return "—"
+  const [maj, min] = v.split(".")
+  return min != null ? `${maj}.${min}` : maj
+}
+
+export function PhpUpgrade() {
+  const store = useStore()
+  const {
+    phpUpgradeSite: site,
+    setPhpUpgradeSite,
+    serverById,
+    offeredPhpVersions,
+    isPhpEol,
+    accountSlug,
+    phpUpgrades,
+    startPhpUpgrade,
+    clearPhpUpgrade,
+  } = store
+
+  const server = serverById(site?.server_id)
+  const versions = site ? offeredPhpVersions(site.php_version) : []
+  const current = majorMinor(site?.php_version)
+
+  // Start blocked if the server can't be managed via the API yet.
+  const [phase, setPhase] = useState<Phase>(() => (server?.upgrade_required ? "blocked" : "pick"))
+  // Open the cursor on the current version (orients the user) when present.
+  const [index, setIndex] = useState(() => {
+    const i = versions.indexOf(current)
+    return i >= 0 ? i : 0
+  })
+  const [target, setTarget] = useState<string | null>(null)
+
+  // Background progress for this site, owned by the store. Once we've fired the
+  // upgrade ("tracking"), the screen follows the store's event status: a settled
+  // failure shows the error; a cleared entry (deleted on deploy) means success.
+  const progress = site ? phpUpgrades.get(site.id) : undefined
+  const dp: Phase =
+    phase !== "tracking"
+      ? phase
+      : !progress
+        ? "done"
+        : progress.status === "failed"
+          ? "error"
+          : "tracking"
+
+  const close = () => {
+    // Leave an in-flight upgrade running (its row keeps the spinner); only drop a
+    // settled failure so its marker doesn't linger after the user has seen it.
+    if (site && progress?.status === "failed") clearPhpUpgrade(site.id)
+    setPhpUpgradeSite(null)
+  }
+
+  useKeyboard((key) => {
+    const name = key.name ?? ""
+    // Esc/q always closes — the upgrade keeps running in the background.
+    if (name === "escape" || name === "q") return close()
+
+    if (dp === "pick") {
+      switch (name) {
+        case "up":
+        case "k":
+          return setIndex((i) => moveSelection(i, -1, versions.length))
+        case "down":
+        case "j":
+          return setIndex((i) => moveSelection(i, 1, versions.length))
+        case "return":
+        case "right":
+        case "l": {
+          const v = versions[index]
+          if (!v || v === current) return // no-op on the current version
+          setTarget(v)
+          setPhase("confirm")
+          return
+        }
+      }
+      return
+    }
+
+    if (dp === "confirm") {
+      if (name === "y") {
+        if (site && target) {
+          startPhpUpgrade(site, target)
+          setPhase("tracking")
+        }
+        return
+      }
+      if (name === "left" || name === "h") return setPhase("pick")
+      return
+    }
+
+    if (dp === "error") {
+      if (name === "r") {
+        if (site) clearPhpUpgrade(site.id)
+        setPhase("pick")
+      }
+      return
+    }
+  })
+
+  if (!site) return null
+
+  return (
+    <box
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        height: "100%",
+        flexDirection: "column",
+        backgroundColor: theme.bg,
+        zIndex: 210,
+      }}
+    >
+      {/* Title bar */}
+      <box
+        style={{
+          flexDirection: "row",
+          height: 1,
+          backgroundColor: theme.bgAlt,
+          paddingLeft: 1,
+          paddingRight: 1,
+          alignItems: "center",
+        }}
+      >
+        <text content="⬆ Upgrade PHP  " fg={theme.brand} style={{ flexShrink: 0 }} />
+        <text content={truncate(site.domain, 40)} fg={theme.text} wrapMode="none" style={{ flexShrink: 1 }} />
+        <box style={{ flexGrow: 1 }} />
+        <text content={`current PHP ${current}`} fg={theme.textFaint} style={{ flexShrink: 0 }} />
+      </box>
+
+      <Centered>{renderBody()}</Centered>
+
+      <StatusBar hints={hints()} showGlobal={false} />
+    </box>
+  )
+
+  function renderBody() {
+    if (dp === "blocked") {
+      return (
+        <Panel title=" Can't upgrade yet " active>
+          <box style={{ flexDirection: "column", width: 64, paddingTop: 1, paddingBottom: 1 }}>
+            <text content="This site's server has a pending SpinupWP platform upgrade." fg={theme.warn} wrapMode="none" />
+            <text content="SpinupWP can't manage the site over the API until that runs." fg={theme.textDim} wrapMode="none" />
+            <box style={{ height: 1 }} />
+            <text
+              content={
+                accountSlug
+                  ? "Press w in the Servers view to open the server in SpinupWP."
+                  : "Open the server in SpinupWP to run the upgrade (set accountSlug for a deep link)."
+              }
+              fg={theme.textDim}
+              wrapMode="none"
+            />
+            <box style={{ height: 1 }} />
+            <text content="Esc to close" fg={theme.textFaint} />
+          </box>
+        </Panel>
+      )
+    }
+
+    if (dp === "pick") {
+      return (
+        <Panel title=" Choose a PHP version " active>
+          <box style={{ flexDirection: "column", width: 48 }}>
+            {versions.map((v, i) => {
+              const selected = i === index
+              const isCurrent = v === current
+              const eol = isPhpEol(v)
+              // On the highlighted row, force bright text so it stays legible on
+              // the green selection background (same approach as List/Stacks).
+              const baseFg = isCurrent ? theme.textFaint : eol ? theme.bad : theme.textDim
+              const fg = selected ? theme.text : baseFg
+              const tag = isCurrent ? "  (current)" : eol ? "  (EOL)" : ""
+              const tagFg = selected ? theme.text : isCurrent ? theme.textFaint : theme.bad
+              return (
+                <box
+                  key={v}
+                  style={{ flexDirection: "row", height: 1, backgroundColor: selected ? theme.selectedBg : undefined }}
+                >
+                  <text content={(selected ? "❯ " : "  ") + `PHP ${v}`} fg={fg} style={{ flexGrow: 1 }} wrapMode="none" />
+                  <text content={tag} fg={tagFg} style={{ flexShrink: 0 }} />
+                </box>
+              )
+            })}
+            <box style={{ height: 1 }} />
+            <text content="A version not on the server is installed first." fg={theme.textFaint} wrapMode="none" />
+          </box>
+        </Panel>
+      )
+    }
+
+    if (dp === "confirm") {
+      return (
+        <Panel title=" Confirm upgrade " active>
+          <box style={{ flexDirection: "column", width: 60, paddingTop: 1, paddingBottom: 1 }}>
+            <box style={{ flexDirection: "row" }}>
+              <text content="Upgrade " fg={theme.text} />
+              <text content={truncate(site!.domain, 32)} fg={theme.accent} wrapMode="none" />
+            </box>
+            <box style={{ flexDirection: "row" }}>
+              <text content={`from PHP ${current}`} fg={theme.textDim} />
+              <text content="  →  " fg={theme.textFaint} />
+              <text content={`PHP ${target}`} fg={theme.good} />
+            </box>
+            <box style={{ height: 1 }} />
+            <text content="SpinupWP restarts PHP-FPM (and installs the version first" fg={theme.textDim} wrapMode="none" />
+            <text content="if it isn't present on the server yet)." fg={theme.textDim} wrapMode="none" />
+            <box style={{ height: 1 }} />
+            <text content="Press y to confirm · ← to go back · Esc to cancel" fg={theme.textFaint} wrapMode="none" />
+          </box>
+        </Panel>
+      )
+    }
+
+    if (dp === "tracking") {
+      return (
+        <box style={{ flexDirection: "column", alignItems: "center" }}>
+          <box style={{ flexDirection: "row" }}>
+            <Spinner />
+            <text content={`  Upgrading to PHP ${target} — ${progress?.status ?? "queued"}…`} fg={theme.textDim} />
+          </box>
+          <box style={{ height: 1 }} />
+          <text content="You can press Esc — it keeps running in the background." fg={theme.textFaint} wrapMode="none" />
+        </box>
+      )
+    }
+
+    if (dp === "done") {
+      return (
+        <Panel title=" Done " active>
+          <box style={{ flexDirection: "column", width: 56, paddingTop: 1, paddingBottom: 1 }}>
+            <box style={{ flexDirection: "row" }}>
+              <text content="✓ " fg={theme.good} />
+              <text content={truncate(site!.domain, 32)} fg={theme.accent} wrapMode="none" />
+              <text content={` is now on PHP ${target}`} fg={theme.text} wrapMode="none" />
+            </box>
+            <box style={{ height: 1 }} />
+            <text content="Esc to close" fg={theme.textFaint} />
+          </box>
+        </Panel>
+      )
+    }
+
+    // error
+    return (
+      <Panel title=" Upgrade failed " active>
+        <box style={{ flexDirection: "column", width: 66, paddingTop: 1, paddingBottom: 1 }}>
+          <text content={`✕ ${progress?.error ?? "Something went wrong."}`} fg={theme.bad} />
+          <box style={{ height: 1 }} />
+          <text content="Press r to choose another version · Esc to close" fg={theme.textFaint} wrapMode="none" />
+        </box>
+      </Panel>
+    )
+  }
+
+  function hints() {
+    switch (dp) {
+      case "pick":
+        return [
+          { key: "↑↓/jk", label: "version" },
+          { key: "⏎", label: "choose" },
+          { key: "esc", label: "cancel" },
+        ]
+      case "confirm":
+        return [
+          { key: "y", label: "confirm" },
+          { key: "←", label: "back" },
+          { key: "esc", label: "cancel" },
+        ]
+      case "error":
+        return [
+          { key: "r", label: "retry" },
+          { key: "esc", label: "close" },
+        ]
+      default:
+        return [{ key: "esc", label: "close" }]
+    }
+  }
+}

--- a/src/ui/views/Search.tsx
+++ b/src/ui/views/Search.tsx
@@ -9,11 +9,12 @@ import { useKeyboard } from "@opentui/react"
 import { theme, statusColor, statusDot } from "../../lib/theme.ts"
 import { classifyStack, stackColor, stackTag } from "../../lib/stack.ts"
 import { truncate } from "../../lib/format.ts"
-import { Panel } from "../components.tsx"
+import { Panel, Field, StatusBadge } from "../components.tsx"
 import { List, moveSelection } from "../List.tsx"
 import { ServerDetail, SiteDetail } from "../Details.tsx"
 import { StatusBar } from "../StatusBar.tsx"
 import { openUrl } from "../../lib/open.ts"
+import { serverWebUrl, siteWebUrl } from "../../lib/spinupweb.ts"
 import { useStore } from "../store.tsx"
 import type { Server, Site } from "../../api/types.ts"
 
@@ -31,16 +32,24 @@ function score(haystack: string, q: string): number | null {
 
 export function Search({ rows }: { rows: number }) {
   const store = useStore()
-  const { servers, sites, serverById, setInputMode, setRoute, route, overlayOpen } = store
+  const { servers, sites, serverById, setInputMode, setRoute, route, overlayOpen, setHealthServer, setPhpUpgradeSite, accountSlug } = store
   const [query, setQuery] = useState("")
   const [selected, setSelected] = useState(0)
+  // "query" = typing/filtering (input focused); "actions" = input blurred so the
+  // selected result's single-key actions (o/w/u/h) fire. Tab/→ enters, ←/Esc exits.
+  const [focus, setFocus] = useState<"query" | "actions">("query")
   const [flash, setFlash] = useState<string | null>(null)
+  const flashMsg = (m: string) => {
+    setFlash(m)
+    setTimeout(() => setFlash(null), 1500)
+  }
 
-  // Hold input focus (and suppress global keys) while this tab is mounted.
+  // The input holds focus (suppressing global shortcuts) only in query mode; in
+  // actions mode we blur it so single-key actions can fire.
   useEffect(() => {
-    setInputMode(true)
+    setInputMode(focus === "query")
     return () => setInputMode(false)
-  }, [setInputMode])
+  }, [focus, setInputMode])
 
   const pool = useMemo<Result[]>(() => {
     const s: Result[] = servers.map((server) => ({
@@ -76,29 +85,97 @@ export function Search({ rows }: { rows: number }) {
   }, [results.length])
 
   const isActive = route === "search" && !overlayOpen
+  const current = results[Math.min(selected, Math.max(0, results.length - 1))]
+
+  // If results vanish (e.g. the query changes), fall back to query focus.
+  useEffect(() => {
+    if (results.length === 0) setFocus("query")
+  }, [results.length])
+
+  const openSite = (s: Site) => {
+    openUrl((s.https?.enabled ? "https://" : "http://") + s.domain)
+    flashMsg(`Opening ${s.domain}…`)
+  }
+  const openInSpinup = (url: string) => {
+    openUrl(url)
+    flashMsg(accountSlug ? "Opening in SpinupWP…" : "Set accountSlug for deep links — opening dashboard")
+  }
 
   useKeyboard((key) => {
     if (!isActive) return
-    switch (key.name) {
-      case "up":
-        return setSelected((i) => moveSelection(i, -1, results.length))
-      case "down":
-        return setSelected((i) => moveSelection(i, 1, results.length))
-      case "return": {
-        const r = results[selected]
-        if (r?.kind === "site") {
-          openUrl((r.site.https?.enabled ? "https://" : "http://") + r.site.domain)
-          setFlash(`Opening ${r.site.domain}…`)
-          setTimeout(() => setFlash(null), 1500)
-        }
+    const name = key.name ?? ""
+
+    // Selection movement works in both modes.
+    if (name === "up") return setSelected((i) => moveSelection(i, -1, results.length))
+    if (name === "down") return setSelected((i) => moveSelection(i, 1, results.length))
+
+    if (focus === "query") {
+      switch (name) {
+        case "return":
+          if (current?.kind === "site") openSite(current.site)
+          return
+        case "tab":
+        case "right":
+          if (current) setFocus("actions")
+          return
+        case "escape":
+          return setRoute("dashboard")
+      }
+      return
+    }
+
+    // actions mode (input blurred) — single-key actions on the selected result.
+    switch (name) {
+      case "left":
+      case "escape":
+        return setFocus("query")
+      case "o":
+        if (current?.kind === "site") openSite(current.site)
+        return
+      case "w":
+        if (current?.kind === "site") openInSpinup(siteWebUrl(current.site.id, accountSlug))
+        else if (current?.kind === "server") openInSpinup(serverWebUrl(current.server.id, accountSlug))
+        return
+      case "u":
+        if (current?.kind === "site") setPhpUpgradeSite(current.site)
+        return
+      case "h": {
+        const srv =
+          current?.kind === "server"
+            ? current.server
+            : current?.kind === "site"
+              ? serverById(current.site.server_id)
+              : undefined
+        if (srv) setHealthServer(srv)
         return
       }
-      case "escape":
-        return setRoute("dashboard")
     }
   })
 
-  const current = results[selected]
+  const hints =
+    focus === "query"
+      ? [
+          { key: "↑↓", label: "select" },
+          { key: "⏎", label: "open site" },
+          { key: "Tab/→", label: "actions" },
+          { key: "esc", label: "dashboard" },
+        ]
+      : current?.kind === "server"
+        ? [
+            { key: "↑↓", label: "select" },
+            { key: "w", label: "SpinupWP" },
+            { key: "h", label: "health" },
+            { key: "←/esc", label: "back" },
+          ]
+        : [
+            { key: "↑↓", label: "select" },
+            { key: "o", label: "open" },
+            { key: "w", label: "SpinupWP" },
+            { key: "u", label: "upgrade PHP" },
+            { key: "h", label: "health" },
+            { key: "←/esc", label: "back" },
+          ]
+
   const listRows = Math.max(3, rows - 8) // input box (3) + status bar (1) + chrome
 
   return (
@@ -106,14 +183,14 @@ export function Search({ rows }: { rows: number }) {
       <box style={{ flexDirection: "row", padding: 1, gap: 1 }}>
         <box
           title=" Search "
-          titleColor={theme.brand}
+          titleColor={focus === "query" ? theme.brand : theme.textDim}
           border
-          borderColor={theme.borderActive}
+          borderColor={focus === "query" ? theme.borderActive : theme.border}
           style={{ flexGrow: 1, flexDirection: "row", paddingLeft: 1, paddingRight: 1 }}
         >
           <text content="🔍 " fg={theme.brand} />
           <input
-            focused={isActive}
+            focused={isActive && focus === "query"}
             value={query}
             placeholder="type a server name, domain, or IP…"
             onInput={setQuery}
@@ -124,12 +201,12 @@ export function Search({ rows }: { rows: number }) {
       </box>
 
       <box style={{ flexGrow: 1, flexDirection: "row", paddingLeft: 1, paddingRight: 1, paddingBottom: 1, gap: 1 }}>
-        <Panel title=" Results " active flexGrow={1}>
+        <Panel title=" Results " active={focus === "query"} flexGrow={1}>
           <List
             items={results}
             selectedIndex={selected}
             viewportRows={listRows}
-            focused
+            focused={focus === "query"}
             emptyText={query ? "No matches" : "Start typing to search across your whole account"}
             keyFor={(r, i) => (r.kind === "server" ? `s${r.server.id}` : `w${r.site.id}`) + i}
             renderRow={(r, sel) => {
@@ -155,26 +232,78 @@ export function Search({ rows }: { rows: number }) {
           />
         </Panel>
 
-        <Panel title=" Details " width={44}>
-          {current?.kind === "server" ? (
-            <ServerDetail server={current.server} siteCount={store.sitesForServer(current.server.id).length} />
-          ) : current?.kind === "site" ? (
-            <SiteDetail site={current.site} serverName={serverById(current.site.server_id)?.name ?? "—"} />
-          ) : (
+        <Panel title={focus === "actions" ? " Actions " : " Details "} active={focus === "actions"} width={44}>
+          {!current ? (
             <text content="No selection" fg={theme.textFaint} />
+          ) : focus === "actions" ? (
+            <ActionsCard
+              result={current}
+              serverName={current.kind === "site" ? (serverById(current.site.server_id)?.name ?? "—") : current.server.name}
+            />
+          ) : current.kind === "server" ? (
+            <ServerDetail server={current.server} siteCount={store.sitesForServer(current.server.id).length} />
+          ) : (
+            <SiteDetail site={current.site} serverName={serverById(current.site.server_id)?.name ?? "—"} />
           )}
         </Panel>
       </box>
 
-      <StatusBar
-        hints={[
-          { key: "↑↓", label: "select" },
-          { key: "⏎", label: "open site" },
-          { key: "esc", label: "dashboard" },
-        ]}
-        message={flash ?? undefined}
-        showGlobal={false}
-      />
+      <StatusBar hints={hints} message={flash ?? undefined} showGlobal={false} />
+    </box>
+  )
+}
+
+// Compact action menu shown in the Details pane while in "actions" focus. Lists
+// the keys live for the selected result (a site gets the full suite; a server
+// gets web/health), so the available actions are discoverable, not hidden.
+function ActionsCard({ result, serverName }: { result: Result; serverName: string }) {
+  const isSite = result.kind === "site"
+  const name = isSite ? result.site.domain : result.server.name
+  const status = isSite ? result.site.status : result.server.connection_status
+  const actions: [string, string][] = isSite
+    ? [
+        ["o", "Open site in browser"],
+        ["w", "Open in SpinupWP"],
+        ["u", "Upgrade PHP version"],
+        ["h", "Server health"],
+      ]
+    : [
+        ["w", "Open in SpinupWP"],
+        ["h", "Server health"],
+      ]
+  return (
+    <box style={{ flexDirection: "column" }}>
+      <box style={{ flexDirection: "row" }}>
+        <text content={truncate(name, 30)} fg={theme.text} attributes={1} wrapMode="none" />
+        <box style={{ flexGrow: 1 }} />
+        <StatusBadge status={status} />
+      </box>
+      {isSite ? (
+        <>
+          <text content={(result.site.https?.enabled ? "https://" : "http://") + result.site.domain} fg={theme.accent} wrapMode="none" />
+          <box style={{ height: 1 }} />
+          <Field label="Server" value={truncate(serverName, 28)} labelWidth={8} />
+          <Field label="PHP" value={result.site.php_version ?? "—"} labelWidth={8} />
+          <Field label="Stack" value={classifyStack(result.site)} valueColor={stackColor(classifyStack(result.site))} labelWidth={8} />
+        </>
+      ) : (
+        <>
+          <text content={result.server.ip_address ?? "—"} fg={theme.accent} wrapMode="none" />
+          <box style={{ height: 1 }} />
+          <Field label="Provider" value={result.server.provider_name ?? "—"} labelWidth={9} />
+          <Field label="Region" value={result.server.region ?? "—"} labelWidth={9} />
+        </>
+      )}
+      <box style={{ height: 1 }} />
+      <text content="Actions" fg={theme.accent} />
+      {actions.map(([k, label]) => (
+        <box key={k} style={{ flexDirection: "row" }}>
+          <text content={` ${k} `} fg={theme.bg} bg={theme.brandDim} style={{ flexShrink: 0 }} />
+          <text content={`  ${label}`} fg={theme.text} wrapMode="none" />
+        </box>
+      ))}
+      <box style={{ height: 1 }} />
+      <text content="↑↓ select · ←/Esc back to search" fg={theme.textFaint} wrapMode="none" />
     </box>
   )
 }

--- a/src/ui/views/Stacks.tsx
+++ b/src/ui/views/Stacks.tsx
@@ -17,7 +17,7 @@ import { bar, truncate } from "../../lib/format.ts"
 import { STACKS, effectiveStack, stackColor, type Stack } from "../../lib/stack.ts"
 import { phpSortKey } from "../../lib/phpEol.ts"
 import { probeKindColor, type ProbeKind } from "../../lib/probe.ts"
-import { Panel, Spinner } from "../components.tsx"
+import { Panel, Spinner, PhpVersionCell } from "../components.tsx"
 import { List, moveSelection } from "../List.tsx"
 import { StatusBar } from "../StatusBar.tsx"
 import { openUrl } from "../../lib/open.ts"
@@ -48,7 +48,7 @@ const NONWP_SUBS: { kind: ProbeKind | null; label: string }[] = [
 
 export function Stacks({ rows }: { rows: number }) {
   const store = useStore()
-  const { sites, serverById, route, inputMode, overlayOpen, probes, probingIds, probeErrors, runProbe, runProbeMany, isProbeStale, isPhpEol, accountSlug } =
+  const { sites, serverById, route, inputMode, overlayOpen, probes, probingIds, probeErrors, runProbe, runProbeMany, isProbeStale, isPhpEol, accountSlug, setPhpUpgradeSite, phpUpgrades } =
     store
 
   const [groupIndex, setGroupIndex] = useState(0)
@@ -165,6 +165,10 @@ export function Stacks({ rows }: { rows: number }) {
           flashMsg(`Probing ${s.domain}…`)
         }
         return
+      case "u":
+        // Upgrade the selected site's PHP version (sites pane only).
+        if (focus === "sites" && groupSites[siteIndex]) setPhpUpgradeSite(groupSites[siteIndex])
+        return
       case "D":
         // Probe the ENTIRE selected group, in list order (top→down), regardless
         // of cursor or focus. runProbeMany skips any already in flight; target
@@ -191,7 +195,7 @@ export function Stacks({ rows }: { rows: number }) {
           { key: "↑↓/jk", label: "select site" },
           { key: "←/esc", label: "back" },
           { key: "d", label: "detect" },
-          { key: "D", label: "detect all" },
+          { key: "u", label: "upgrade PHP" },
           { key: "o", label: "open" },
           { key: "w", label: "SpinupWP" },
         ]
@@ -285,11 +289,9 @@ export function Stacks({ rows }: { rows: number }) {
                     wrapMode="none"
                     style={{ flexShrink: 0, marginLeft: 1 }}
                   />
-                  <text
-                    content={" " + (s.php_version ?? "—")}
-                    fg={isPhpEol(s.php_version) ? theme.bad : faint}
-                    style={{ flexShrink: 0 }}
-                  />
+                  <box style={{ flexShrink: 0, marginLeft: 1 }}>
+                    <PhpVersionCell version={s.php_version} upgrade={phpUpgrades.get(s.id)} selected={selected} eol={isPhpEol(s.php_version)} />
+                  </box>
                 </>
               )
             }}


### PR DESCRIPTION
## Summary

The app's first **mutating** feature, plus a Search upgrade that makes results actionable. Releases as **v0.3.0**.

### Upgrade a site's PHP version
Press `u` on a site (Servers / Stacks / Search) → pick a version → confirm → `PUT /sites/{id}/php`, then the upgrade event is tracked to completion.

- **Client write support:** `mutate()` translates a `403` into a friendly "token is read-only" (the API has no token-scope endpoint, so attempt-and-handle-403 is the detection); plus `upgradeSitePhp()` and `getEvent()`. The read path is untouched and works with any token.
- **Dynamic version list:** `offeredPhpVersions()` derives the picker from the (network-refreshed) endoflife.date schedule, so new releases (8.5, …) appear automatically. Current is marked, EOL flagged. Not filtered to "installed" — SpinupWP installs a version on demand the first time a site uses it.
- **Background tracking:** the PUT + event polling live in the store (`startPhpUpgrade` / `phpUpgrades`), so closing the modal (`Esc`) doesn't abandon the upgrade — the site's row shows a spinner + target version (shared `PhpVersionCell`), and the SiteDetail "PHP" field mirrors the in-progress/failed state. Multiple sites can upgrade concurrently.
- **Guard:** a site whose server has a pending SpinupWP platform upgrade is blocked up front and pointed at the `w` web deep link.

### Search actions mode
Search gains a query↔actions focus model: `Tab` / `→` hands focus from the search box to the selected result's **action menu** (`o` / `w` / `u` / `h`) in the Details pane; `←` / `Esc` returns to typing. Search becomes a real command surface.

### Docs
README, Help overlay, CLAUDE.md, and the onboarding copy all updated.

## Testing
- `bun run typecheck` clean.
- Read-only token → the upgrade surfaces the friendly "token is read-only" message; the rest of the app keeps reading fine.
- Read/Write token → a real upgrade on a production site ran end-to-end (`queued → … → deployed`) and the site refreshed to the new version.
- Closing the modal mid-upgrade leaves the row spinner running (verified).
- Search `Tab`/`→` actions mode verified in a real terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)