### PR TITLE
feat: server actions — reboot + service restarts (with reboot "why")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-18
+
 ### Added
 - **Server actions: reboot + service restarts.** Press `a` on a server (Servers
   tab or a Search result) to reboot it (`POST /servers/{id}/reboot`) or restart a
@@ -123,7 +125,8 @@ Initial tagged release.
 ### Notes
 - Read-only release: works with a SpinupWP **Read Only** API token.
 
-[Unreleased]: https://github.com/mwender/spinupwp-tui/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/mwender/spinupwp-tui/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/mwender/spinupwp-tui/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/mwender/spinupwp-tui/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/mwender/spinupwp-tui/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/mwender/spinupwp-tui/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+### Added
+- **Server actions: reboot + service restarts.** Press `a` on a server (Servers
+  tab or a Search result) to reboot it (`POST /servers/{id}/reboot`) or restart a
+  service — Nginx / PHP-FPM / MySQL / Redis (`POST /servers/{id}/services/{svc}/restart`).
+  Pick → confirm → the event is tracked to completion in the store, so closing the
+  overlay leaves it running and the server's row keeps a spinner (same model as PHP
+  upgrades). Reboot's confirmation calls out whole-server downtime for all sites on
+  it; a service restart is a brief blip. Needs a Read/Write token.
+- **Reboot visibility + "why".** Servers needing a reboot show a `↻rbt` badge in the
+  Servers list (the Dashboard already listed them). Because the API only exposes a
+  `reboot_required` boolean with no reason, the actions overlay reads Ubuntu's
+  `/var/run/reboot-required` + `.pkgs` over SSH (read-only, reusing the health
+  connection) and shows the pending packages — typically a kernel/security update —
+  labeled as OS-level context, not SpinupWP's internal logic. ServerDetail's
+  "Reboot" field shows the same summary once probed.
+
 ## [0.3.0] - 2026-06-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,10 +51,15 @@ Once you're in, the dashboard looks like this:
 - **Upgrade a site's PHP version** — press `u` on a site to pick a new PHP
   version and apply it (`PUT /sites/{id}/php`), then watch the upgrade event run
   to completion. (See "Upgrading PHP" below.)
+- **Server actions** — press `a` on a server to reboot it or restart a service
+  (Nginx / PHP-FPM / MySQL / Redis). Servers needing a reboot show a `↻rbt`
+  badge, and the overlay reads the box over SSH to show *why* (the pending
+  kernel/security packages). (See "Server actions" below.)
 
 > The tool is **read-only by default** and works great with a Read Only API
-> token. The one write action — upgrading a site's PHP version — needs a
-> **Read/Write** token; everything else keeps working without one.
+> token. The write actions — upgrading a site's PHP version and rebooting /
+> restarting services — need a **Read/Write** token; everything else keeps
+> working without one.
 
 ## Requirements
 
@@ -153,6 +158,7 @@ Both can be set in `config.json` or via an environment variable:
 | `d` | Detect a site's stack via SSH (Servers / Stacks tabs) |
 | `D` | Detect every site in the selected stack (Stacks tab) |
 | `u` | Upgrade a site's PHP version (Servers / Stacks / Search; needs a Read/Write token) |
+| `a` | Server actions: reboot / restart a service (Servers / Search; needs a Read/Write token) |
 | `w` | Open the selected server/site in the SpinupWP web app |
 | `/` | Jump to global search |
 | `r` | Refresh data from the API |
@@ -229,6 +235,28 @@ it finishes.
   spinner and the target version (`→8.3`) until it settles, then refreshes to the
   new version (or flags `⬆!` if it failed). The SiteDetail "PHP" field shows the
   same in-progress state. You can launch upgrades on several sites at once.
+
+## Server actions
+
+Press `a` on a selected server (in the **Servers** tab, or a result in **Search**)
+to open the server-actions overlay: **reboot** the server, or **restart** a single
+service (Nginx / PHP-FPM / MySQL / Redis). Pick → confirm → the app calls
+`POST /servers/{id}/reboot` or `/services/{svc}/restart` and tracks the event to
+completion — same background behavior as PHP upgrades (close the overlay and the
+server's row keeps a spinner).
+
+- **Needs a Read/Write token** (like PHP upgrades).
+- **Reboot visibility.** Servers with a pending reboot show a `↻rbt` badge in the
+  Servers list and on the Dashboard's "Needs attention" panel.
+- **Why a reboot is pending.** The API only exposes a `reboot_required` boolean —
+  no reason. So when you open the overlay on a flagged server, the app reads
+  Ubuntu's `/var/run/reboot-required` + `.pkgs` over SSH (read-only, reusing the
+  health view's connection) and shows the pending packages — typically a
+  **kernel/security update**. This is labeled as OS-level context, not as
+  SpinupWP's internal logic (a fleet-wide check confirmed the boolean tracks that
+  file 1:1).
+- **Reboot is the big one** — its confirmation calls out that it takes the whole
+  server down briefly (every site on it); a service restart is a brief blip.
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spinupwp-tui",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A cool terminal UI for browsing and monitoring your SpinupWP servers and sites.",
   "type": "module",
   "bin": {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -6,6 +6,9 @@
 
 import type { ApiList, ApiSingle, Server, Site, Event } from "./types.ts"
 
+// The restartable services SpinupWP exposes (POST /servers/{id}/services/{svc}/restart).
+export type ServerService = "nginx" | "php" | "mysql" | "redis"
+
 export class ApiError extends Error {
   status: number
   body?: string
@@ -199,5 +202,16 @@ export class SpinupWPClient {
   // it isn't already present. Needs a Read/Write token (see mutate()).
   upgradeSitePhp(siteId: number, phpVersion: string): Promise<{ event_id: number }> {
     return this.mutate<{ event_id: number }>(`/sites/${siteId}/php`, "PUT", { php_version: phpVersion })
+  }
+
+  // Reboot a server. Async → returns an event_id to poll via getEvent().
+  rebootServer(serverId: number): Promise<{ event_id: number }> {
+    return this.mutate<{ event_id: number }>(`/servers/${serverId}/reboot`, "POST")
+  }
+
+  // Restart a single service on a server (nginx / php / mysql / redis). Async →
+  // returns an event_id to poll via getEvent().
+  restartService(serverId: number, service: ServerService): Promise<{ event_id: number }> {
+    return this.mutate<{ event_id: number }>(`/servers/${serverId}/services/${service}/restart`, "POST")
   }
 }

--- a/src/lib/ssh.ts
+++ b/src/lib/ssh.ts
@@ -86,6 +86,66 @@ const SSH_OPTS = [
   "-o", "ControlPersist=30s",
 ]
 
+// Why a server needs a reboot. SpinupWP's `reboot_required` boolean tracks
+// Ubuntu's /var/run/reboot-required (written by unattended-upgrades), which a
+// fleet-wide check confirmed 1:1; the companion .pkgs file lists the packages
+// awaiting a restart. We surface that as accurate OS-level context — labeled as
+// what it is, not as SpinupWP's internal logic. Read-only, like the health view.
+export interface RebootInfo {
+  present: boolean // /var/run/reboot-required exists
+  packages: string[] // de-duplicated package names from .pkgs
+  kernel: boolean // any linux-image* package present (the security-relevant case)
+}
+
+export type RebootInfoResult =
+  | { ok: true; target: string; info: RebootInfo }
+  | { ok: false; target: string; error: string }
+
+const REBOOT_SCRIPT = [
+  "echo ===PRESENT; test -e /var/run/reboot-required && echo yes || echo no",
+  "echo ===PKGS; cat /var/run/reboot-required.pkgs 2>/dev/null",
+  "echo ===END",
+].join("; ")
+
+export async function fetchRebootInfo(
+  server: Server,
+  sites: Site[],
+  sshUser: string | null,
+): Promise<RebootInfoResult> {
+  const target = resolveSshTarget(server, sites, sshUser)
+  if (!target) return { ok: false, target: "(no IP)", error: "Server has no IP address." }
+
+  let proc: ReturnType<typeof Bun.spawn>
+  try {
+    proc = Bun.spawn(["ssh", ...SSH_OPTS, target, REBOOT_SCRIPT], { stdout: "pipe", stderr: "pipe", stdin: "ignore" })
+  } catch (err) {
+    return { ok: false, target, error: `Failed to launch ssh: ${(err as Error).message}` }
+  }
+  const timeout = setTimeout(() => {
+    try {
+      proc.kill()
+    } catch {
+      /* already gone */
+    }
+  }, 12000)
+  const exitCode = await proc.exited
+  clearTimeout(timeout)
+  const stdout = await new Response(proc.stdout as ReadableStream<Uint8Array>).text()
+  const stderr = await new Response(proc.stderr as ReadableStream<Uint8Array>).text()
+
+  if (exitCode !== 0 || !stdout.includes("===END")) {
+    const reason = stderr.trim().split("\n").slice(-2).join(" ") || `ssh exited with code ${exitCode}`
+    return { ok: false, target, error: reason }
+  }
+
+  const s = splitSections(stdout)
+  const present = (s.PRESENT?.[0] || "").trim() === "yes"
+  // .pkgs has duplicate lines in practice; de-dupe while preserving order.
+  const packages = [...new Set((s.PKGS || []).map((l) => l.trim()).filter(Boolean))]
+  const kernel = packages.some((p) => p.startsWith("linux-image"))
+  return { ok: true, target, info: { present, packages, kernel } }
+}
+
 export async function fetchServerHealth(
   server: Server,
   sites: Site[],

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -14,6 +14,7 @@ import { Search } from "./views/Search.tsx"
 import { Events } from "./views/Events.tsx"
 import { Health } from "./views/Health.tsx"
 import { PhpUpgrade } from "./views/PhpUpgrade.tsx"
+import { ServerActions } from "./views/ServerActions.tsx"
 
 const MIN_SPLASH_MS = 1200
 
@@ -31,7 +32,8 @@ export function App() {
   }, [])
 
   // Keep views aware that a modal is open so they pause their own key handling.
-  const overlayActive = showHelp || store.healthServer !== null || store.phpUpgradeSite !== null
+  const overlayActive =
+    showHelp || store.healthServer !== null || store.phpUpgradeSite !== null || store.serverActionsServer !== null
   useEffect(() => {
     store.setOverlayOpen(overlayActive)
   }, [overlayActive, store])
@@ -57,6 +59,9 @@ export function App() {
 
     // The PHP-upgrade overlay owns the keyboard while open.
     if (store.phpUpgradeSite) return
+
+    // The server-actions overlay owns the keyboard while open.
+    if (store.serverActionsServer) return
 
     if (showHelp) {
       if (key.name === "escape" || key.name === "q" || key.name === "?") setShowHelp(false)
@@ -117,6 +122,7 @@ export function App() {
       {showHelp && <HelpOverlay onClose={() => setShowHelp(false)} />}
       {store.healthServer && <Health />}
       {store.phpUpgradeSite && <PhpUpgrade />}
+      {store.serverActionsServer && <ServerActions />}
     </box>
   )
 }

--- a/src/ui/Details.tsx
+++ b/src/ui/Details.tsx
@@ -22,7 +22,7 @@ export function ServerDetail({ server, siteCount }: { server: Server; siteCount:
         : server.reboot_required
           ? rb?.present
             ? `required · ${rb.kernel ? "kernel update" : "pkg updates"} (${rb.packages.length})`
-            : "required — press a"
+            : "required"
           : "not needed"
   const rebootColor =
     op?.status === "failed" ? theme.bad : server.reboot_required || (op && isServerOpInFlight(op)) ? theme.warn : theme.good

--- a/src/ui/Details.tsx
+++ b/src/ui/Details.tsx
@@ -5,12 +5,27 @@ import { formatBytes, diskUsedPct, bar, formatDate, timeAgo, truncate } from "..
 import { Field, StatusBadge } from "./components.tsx"
 import { classifyStack, stackColor } from "../lib/stack.ts"
 import { probeKindColor } from "../lib/probe.ts"
-import { useStore, isUpgradeInFlight } from "./store.tsx"
+import { useStore, isUpgradeInFlight, isServerOpInFlight } from "./store.tsx"
 import type { Server, Site } from "../api/types.ts"
 
 export function ServerDetail({ server, siteCount }: { server: Server; siteCount: number }) {
+  const { rebootInfo, serverOps } = useStore()
   const ds = server.disk_space
   const pct = diskUsedPct(ds?.used, ds?.total)
+  const op = serverOps.get(server.id)
+  const rb = rebootInfo.get(server.id)
+  const rebootValue =
+    op && isServerOpInFlight(op)
+      ? `${op.label}…`
+      : op?.status === "failed"
+        ? "action failed"
+        : server.reboot_required
+          ? rb?.present
+            ? `required · ${rb.kernel ? "kernel update" : "pkg updates"} (${rb.packages.length})`
+            : "required — press a"
+          : "not needed"
+  const rebootColor =
+    op?.status === "failed" ? theme.bad : server.reboot_required || (op && isServerOpInFlight(op)) ? theme.warn : theme.good
   return (
     <box style={{ flexDirection: "column" }}>
       <box style={{ flexDirection: "row" }}>
@@ -43,11 +58,7 @@ export function ServerDetail({ server, siteCount }: { server: Server; siteCount:
       <Field label="Available" value={formatBytes(ds?.available)} />
       <box style={{ height: 1 }} />
 
-      <Field
-        label="Reboot"
-        value={server.reboot_required ? "required" : "not needed"}
-        valueColor={server.reboot_required ? theme.warn : theme.good}
-      />
+      <Field label="Reboot" value={rebootValue} valueColor={rebootColor} />
       <Field
         label="SpinupWP upgrade"
         value={server.upgrade_required ? "required — press w to open" : "up to date"}

--- a/src/ui/Help.tsx
+++ b/src/ui/Help.tsx
@@ -26,6 +26,7 @@ const SECTIONS: { title: string; keys: [string, string][] }[] = [
       ["d", "Detect a site's stack via SSH (Servers / Stacks tabs)"],
       ["D", "Detect every site in the selected stack (Stacks tab)"],
       ["u", "Upgrade a site's PHP version (needs a Read/Write token)"],
+      ["a", "Server actions: reboot or restart a service (Read/Write token)"],
       ["w", "Open the selected server/site in the SpinupWP web app"],
       ["g / G", "Jump to top / bottom"],
     ],
@@ -34,7 +35,7 @@ const SECTIONS: { title: string; keys: [string, string][] }[] = [
     title: "Search tab",
     keys: [
       ["Tab / →", "Hand focus from the search box to the result's actions"],
-      ["o / w / u / h", "Act on the result: open · SpinupWP · PHP upgrade · health"],
+      ["o / w / u / a / h", "Act: open · SpinupWP · PHP · server actions · health"],
       ["← / Esc", "Return to the search box"],
     ],
   },

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -6,10 +6,11 @@
 // trigger a refresh.
 
 import { createContext, useContext, useCallback, useEffect, useRef, useState, type ReactNode } from "react"
-import { SpinupWPClient, ApiError } from "../api/client.ts"
+import { SpinupWPClient, ApiError, type ServerService } from "../api/client.ts"
 import type { Server, Site, Event } from "../api/types.ts"
 import { loadConfig } from "../config.ts"
 import { probeSite } from "../lib/probe.ts"
+import { fetchRebootInfo, type RebootInfo } from "../lib/ssh.ts"
 import { StackCache, siteSignature, type CachedProbe } from "../lib/stackCache.ts"
 import { resolvePhpEolDates, refreshPhpEolDates, isPhpEol as isPhpEolWith, offeredPhpVersions as offeredPhpVersionsWith, type PhpEolDates } from "../lib/phpEol.ts"
 
@@ -30,6 +31,21 @@ const UPGRADE_FAIL = "failed"
 const UPGRADE_POLL_MS = 2500
 
 export function isUpgradeInFlight(p: PhpUpgradeProgress | undefined): boolean {
+  return p != null && p.status !== UPGRADE_DONE && p.status !== UPGRADE_FAIL
+}
+
+// A server-level operation (reboot or a service restart), tracked in the store
+// so progress survives closing the Server-actions overlay (same model as
+// PhpUpgradeProgress, keyed by server id). `label` is a short display verb.
+export type ServerOpKind = "reboot" | ServerService
+export interface ServerOpProgress {
+  kind: ServerOpKind
+  label: string
+  status: string
+  error?: string
+}
+
+export function isServerOpInFlight(p: ServerOpProgress | undefined): boolean {
   return p != null && p.status !== UPGRADE_DONE && p.status !== UPGRADE_FAIL
 }
 
@@ -69,6 +85,19 @@ interface StoreValue extends DataState {
   startPhpUpgrade: (site: Site, version: string) => void
   // Drop a terminal (deployed/failed) entry — e.g. when the modal is dismissed.
   clearPhpUpgrade: (siteId: number) => void
+  // The server whose actions overlay (reboot / service restart) is open, or null.
+  serverActionsServer: Server | null
+  setServerActionsServer: (s: Server | null) => void
+  // In-flight (and just-failed) server operations, keyed by server id.
+  serverOps: Map<number, ServerOpProgress>
+  // Fire a server op (reboot or service restart) and poll its event in the background.
+  startServerOp: (server: Server, kind: ServerOpKind, label: string) => void
+  clearServerOp: (serverId: number) => void
+  // Reboot "why" — SSH-probed Ubuntu reboot-required detail, keyed by server id.
+  rebootInfo: Map<number, RebootInfo>
+  rebootInfoLoading: Set<number>
+  rebootInfoErrors: Map<number, string>
+  loadRebootInfo: (server: Server) => void
   // Optional SSH user override for the health view (from env/config).
   sshUser: string | null
   // SpinupWP account slug (from env/config) for building web deep links.
@@ -120,6 +149,11 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const [healthServer, setHealthServer] = useState<Server | null>(null)
   const [phpUpgradeSite, setPhpUpgradeSite] = useState<Site | null>(null)
   const [phpUpgrades, setPhpUpgrades] = useState<Map<number, PhpUpgradeProgress>>(new Map())
+  const [serverActionsServer, setServerActionsServer] = useState<Server | null>(null)
+  const [serverOps, setServerOps] = useState<Map<number, ServerOpProgress>>(new Map())
+  const [rebootInfo, setRebootInfo] = useState<Map<number, RebootInfo>>(new Map())
+  const [rebootInfoLoading, setRebootInfoLoading] = useState<Set<number>>(new Set())
+  const [rebootInfoErrors, setRebootInfoErrors] = useState<Map<number, string>>(new Map())
 
   // Tier-2 stack-probe cache: hydrate from disk once (read-only at startup; no
   // SSH). Probes run lazily on demand and write through to disk.
@@ -302,6 +336,90 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     [client, refresh, clearPhpUpgrade, phpUpgrades],
   )
 
+  // ---- Server operations (reboot / service restart) ---------------------
+
+  const setOp = (serverId: number, progress: ServerOpProgress) =>
+    setServerOps((prev) => new Map(prev).set(serverId, progress))
+
+  const clearServerOp = useCallback(
+    (serverId: number) =>
+      setServerOps((prev) => {
+        if (!prev.has(serverId)) return prev
+        const next = new Map(prev)
+        next.delete(serverId)
+        return next
+      }),
+    [],
+  )
+
+  const startServerOp = useCallback(
+    (server: Server, kind: ServerOpKind, label: string) => {
+      const existing = serverOps.get(server.id)
+      if (existing && existing.status !== UPGRADE_DONE && existing.status !== UPGRADE_FAIL) return
+
+      const run = async () => {
+        setOp(server.id, { kind, label, status: "queued" })
+        let eventId: number
+        try {
+          const res = kind === "reboot" ? await client.rebootServer(server.id) : await client.restartService(server.id, kind)
+          eventId = res.event_id
+        } catch (err) {
+          const msg = err instanceof ApiError ? err.message : (err as Error).message
+          setOp(server.id, { kind, label, status: UPGRADE_FAIL, error: msg })
+          return
+        }
+
+        const poll = async () => {
+          try {
+            const ev = await client.getEvent(eventId)
+            if (ev.status === UPGRADE_DONE) {
+              await refresh() // reboot clears reboot_required; status may flip too
+              clearServerOp(server.id)
+            } else if (ev.status === UPGRADE_FAIL) {
+              setOp(server.id, { kind, label, status: UPGRADE_FAIL, error: ev.output?.trim() || "The operation failed on SpinupWP." })
+            } else {
+              setOp(server.id, { kind, label, status: ev.status })
+              setTimeout(() => void poll(), UPGRADE_POLL_MS)
+            }
+          } catch (err) {
+            const msg = err instanceof ApiError ? err.message : (err as Error).message
+            setOp(server.id, { kind, label, status: UPGRADE_FAIL, error: msg })
+          }
+        }
+        setTimeout(() => void poll(), UPGRADE_POLL_MS)
+      }
+      void run()
+    },
+    [client, refresh, clearServerOp, serverOps],
+  )
+
+  // SSH-probe a server's Ubuntu reboot-required detail (the "why"). On-demand,
+  // cached in memory for the session (read-only; reuses the health SSH path).
+  const loadRebootInfo = useCallback(
+    (server: Server) => {
+      if (rebootInfoLoading.has(server.id)) return
+      const run = async () => {
+        setRebootInfoLoading((prev) => new Set(prev).add(server.id))
+        setRebootInfoErrors((prev) => {
+          if (!prev.has(server.id)) return prev
+          const next = new Map(prev)
+          next.delete(server.id)
+          return next
+        })
+        const res = await fetchRebootInfo(server, sites, cfgRef.current.sshUser)
+        if (res.ok) setRebootInfo((prev) => new Map(prev).set(server.id, res.info))
+        else setRebootInfoErrors((prev) => new Map(prev).set(server.id, res.error))
+        setRebootInfoLoading((prev) => {
+          const next = new Set(prev)
+          next.delete(server.id)
+          return next
+        })
+      }
+      void run()
+    },
+    [rebootInfoLoading, sites],
+  )
+
   const value: StoreValue = {
     servers,
     sites,
@@ -325,6 +443,15 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     phpUpgrades,
     startPhpUpgrade,
     clearPhpUpgrade,
+    serverActionsServer,
+    setServerActionsServer,
+    serverOps,
+    startServerOp,
+    clearServerOp,
+    rebootInfo,
+    rebootInfoLoading,
+    rebootInfoErrors,
+    loadRebootInfo,
     sshUser: cfgRef.current.sshUser,
     accountSlug: cfgRef.current.accountSlug,
     sitesForServer,

--- a/src/ui/views/Browser.tsx
+++ b/src/ui/views/Browser.tsx
@@ -102,9 +102,10 @@ export function Browser({ rows }: { rows: number }) {
         if (focus === "sites" && sites[siteIndex]) setPhpUpgradeSite(sites[siteIndex])
         return
       case "a":
-        // Open the server-actions overlay (reboot / service restart) for the
-        // focused server — works from either pane.
-        if (server) setServerActionsServer(server)
+        // Server actions (reboot / restart) are server-scoped, so only offered
+        // when the Servers pane is focused — when you've drilled into a site,
+        // the context is the site (server actions are dropped there).
+        if (focus === "servers" && server) setServerActionsServer(server)
         return
       case "h":
         // Open the live health view for the current server (works from either pane).
@@ -133,7 +134,7 @@ export function Browser({ rows }: { rows: number }) {
       ? [
           { key: "↑↓/jk", label: "select" },
           { key: "→/⏎", label: "view sites" },
-          { key: "a", label: "actions" },
+          { key: "a", label: "server actions" },
           { key: "h", label: "health" },
           { key: "w", label: "SpinupWP" },
         ]
@@ -142,7 +143,6 @@ export function Browser({ rows }: { rows: number }) {
           { key: "←/esc", label: "back" },
           { key: "d", label: "detect" },
           { key: "u", label: "upgrade PHP" },
-          { key: "a", label: "server actions" },
           { key: "o", label: "open" },
           { key: "w", label: "SpinupWP" },
           { key: "h", label: "health" },

--- a/src/ui/views/Browser.tsx
+++ b/src/ui/views/Browser.tsx
@@ -10,19 +10,19 @@ import { useKeyboard } from "@opentui/react"
 import { theme, statusColor, statusDot } from "../../lib/theme.ts"
 import { classifyStack, stackColor, stackTag } from "../../lib/stack.ts"
 import { truncate } from "../../lib/format.ts"
-import { Panel, PhpVersionCell } from "../components.tsx"
+import { Panel, PhpVersionCell, Spinner } from "../components.tsx"
 import { List, moveSelection } from "../List.tsx"
 import { ServerDetail, SiteDetail } from "../Details.tsx"
 import { StatusBar } from "../StatusBar.tsx"
 import { openUrl } from "../../lib/open.ts"
 import { serverWebUrl, siteWebUrl } from "../../lib/spinupweb.ts"
-import { useStore } from "../store.tsx"
+import { useStore, isServerOpInFlight } from "../store.tsx"
 
 type Focus = "servers" | "sites"
 
 export function Browser({ rows }: { rows: number }) {
   const store = useStore()
-  const { servers, sitesForServer, route, inputMode, overlayOpen, setHealthServer, runProbe, accountSlug, setPhpUpgradeSite, phpUpgrades } = store
+  const { servers, sitesForServer, route, inputMode, overlayOpen, setHealthServer, runProbe, accountSlug, setPhpUpgradeSite, phpUpgrades, setServerActionsServer, serverOps } = store
 
   const [serverIndex, setServerIndex] = useState(0)
   const [siteIndex, setSiteIndex] = useState(0)
@@ -101,6 +101,11 @@ export function Browser({ rows }: { rows: number }) {
         // Upgrade the selected site's PHP version (first write action).
         if (focus === "sites" && sites[siteIndex]) setPhpUpgradeSite(sites[siteIndex])
         return
+      case "a":
+        // Open the server-actions overlay (reboot / service restart) for the
+        // focused server — works from either pane.
+        if (server) setServerActionsServer(server)
+        return
       case "h":
         // Open the live health view for the current server (works from either pane).
         if (server) setHealthServer(server)
@@ -128,14 +133,16 @@ export function Browser({ rows }: { rows: number }) {
       ? [
           { key: "↑↓/jk", label: "select" },
           { key: "→/⏎", label: "view sites" },
+          { key: "a", label: "actions" },
           { key: "h", label: "health" },
-          { key: "w", label: "open in SpinupWP" },
+          { key: "w", label: "SpinupWP" },
         ]
       : [
           { key: "↑↓/jk", label: "select site" },
           { key: "←/esc", label: "back" },
           { key: "d", label: "detect" },
           { key: "u", label: "upgrade PHP" },
+          { key: "a", label: "server actions" },
           { key: "o", label: "open" },
           { key: "w", label: "SpinupWP" },
           { key: "h", label: "health" },
@@ -155,10 +162,21 @@ export function Browser({ rows }: { rows: number }) {
             emptyText="No servers"
             renderRow={(s, selected) => {
               const count = sitesForServer(s.id).length
+              const op = serverOps.get(s.id)
               return (
                 <>
                   <text content={statusDot(s.connection_status) + " "} fg={statusColor(s.connection_status)} style={{ flexShrink: 0 }} />
                   <text content={truncate(s.name, 22)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
+                  {op && isServerOpInFlight(op) ? (
+                    <box style={{ flexDirection: "row", flexShrink: 0 }}>
+                      <Spinner color={selected ? theme.text : theme.brand} interval={120} />
+                      <text content={`${op.label} `} fg={selected ? theme.text : theme.warn} wrapMode="none" />
+                    </box>
+                  ) : op?.status === "failed" ? (
+                    <text content="op! " fg={selected ? theme.text : theme.bad} style={{ flexShrink: 0 }} />
+                  ) : (
+                    s.reboot_required && <text content="↻rbt " fg={selected ? theme.text : theme.warn} style={{ flexShrink: 0 }} />
+                  )}
                   {s.upgrade_required && <text content="⬆upg " fg={selected ? theme.text : theme.warn} style={{ flexShrink: 0 }} />}
                   <text content={" " + count} fg={selected ? theme.text : theme.textFaint} style={{ flexShrink: 0 }} />
                 </>

--- a/src/ui/views/Search.tsx
+++ b/src/ui/views/Search.tsx
@@ -32,7 +32,7 @@ function score(haystack: string, q: string): number | null {
 
 export function Search({ rows }: { rows: number }) {
   const store = useStore()
-  const { servers, sites, serverById, setInputMode, setRoute, route, overlayOpen, setHealthServer, setPhpUpgradeSite, accountSlug } = store
+  const { servers, sites, serverById, setInputMode, setRoute, route, overlayOpen, setHealthServer, setPhpUpgradeSite, setServerActionsServer, accountSlug } = store
   const [query, setQuery] = useState("")
   const [selected, setSelected] = useState(0)
   // "query" = typing/filtering (input focused); "actions" = input blurred so the
@@ -149,6 +149,17 @@ export function Search({ rows }: { rows: number }) {
         if (srv) setHealthServer(srv)
         return
       }
+      case "a": {
+        // Server actions (reboot / restart) — on the server, or a site's server.
+        const srv =
+          current?.kind === "server"
+            ? current.server
+            : current?.kind === "site"
+              ? serverById(current.site.server_id)
+              : undefined
+        if (srv) setServerActionsServer(srv)
+        return
+      }
     }
   })
 
@@ -164,6 +175,7 @@ export function Search({ rows }: { rows: number }) {
         ? [
             { key: "↑↓", label: "select" },
             { key: "w", label: "SpinupWP" },
+            { key: "a", label: "actions" },
             { key: "h", label: "health" },
             { key: "←/esc", label: "back" },
           ]
@@ -172,6 +184,7 @@ export function Search({ rows }: { rows: number }) {
             { key: "o", label: "open" },
             { key: "w", label: "SpinupWP" },
             { key: "u", label: "upgrade PHP" },
+            { key: "a", label: "server actions" },
             { key: "h", label: "health" },
             { key: "←/esc", label: "back" },
           ]
@@ -265,10 +278,12 @@ function ActionsCard({ result, serverName }: { result: Result; serverName: strin
         ["o", "Open site in browser"],
         ["w", "Open in SpinupWP"],
         ["u", "Upgrade PHP version"],
+        ["a", "Server actions (reboot / restart)"],
         ["h", "Server health"],
       ]
     : [
         ["w", "Open in SpinupWP"],
+        ["a", "Server actions (reboot / restart)"],
         ["h", "Server health"],
       ]
   return (

--- a/src/ui/views/Search.tsx
+++ b/src/ui/views/Search.tsx
@@ -226,17 +226,17 @@ export function Search({ rows }: { rows: number }) {
               if (r.kind === "server") {
                 return (
                   <>
-                    <text content="SRV " fg={theme.purple} style={{ flexShrink: 0 }} />
+                    <text content="SRV " fg={sel ? theme.text : theme.purple} style={{ flexShrink: 0 }} />
                     <text content={statusDot(r.server.connection_status) + " "} fg={statusColor(r.server.connection_status)} style={{ flexShrink: 0 }} />
                     <text content={truncate(r.server.name, 44)} fg={sel ? theme.text : theme.textDim} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1, marginRight: 1 }} />
                     {r.server.reboot_required && <text content="↻rbt " fg={sel ? theme.text : theme.warn} style={{ flexShrink: 0 }} />}
-                    <text content={r.server.provider_name ?? ""} fg={theme.textFaint} style={{ flexShrink: 0 }} />
+                    <text content={r.server.provider_name ?? ""} fg={sel ? theme.text : theme.textFaint} style={{ flexShrink: 0 }} />
                   </>
                 )
               }
               return (
                 <>
-                  <text content="SITE" fg={theme.accent} style={{ flexShrink: 0 }} />
+                  <text content="SITE" fg={sel ? theme.text : theme.accent} style={{ flexShrink: 0 }} />
                   <text content={" " + statusDot(r.site.status) + " "} fg={statusColor(r.site.status)} style={{ flexShrink: 0 }} />
                   <text content={truncate(r.site.domain, 44)} fg={sel ? theme.text : theme.textDim} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1, marginRight: 1 }} />
                   <text content={stackTag(classifyStack(r.site))} fg={stackColor(classifyStack(r.site), sel)} style={{ flexShrink: 0 }} />

--- a/src/ui/views/Search.tsx
+++ b/src/ui/views/Search.tsx
@@ -229,6 +229,7 @@ export function Search({ rows }: { rows: number }) {
                     <text content="SRV " fg={theme.purple} style={{ flexShrink: 0 }} />
                     <text content={statusDot(r.server.connection_status) + " "} fg={statusColor(r.server.connection_status)} style={{ flexShrink: 0 }} />
                     <text content={truncate(r.server.name, 44)} fg={sel ? theme.text : theme.textDim} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1, marginRight: 1 }} />
+                    {r.server.reboot_required && <text content="↻rbt " fg={sel ? theme.text : theme.warn} style={{ flexShrink: 0 }} />}
                     <text content={r.server.provider_name ?? ""} fg={theme.textFaint} style={{ flexShrink: 0 }} />
                   </>
                 )

--- a/src/ui/views/ServerActions.tsx
+++ b/src/ui/views/ServerActions.tsx
@@ -1,0 +1,325 @@
+// Server actions overlay — reboot the server or restart a single service.
+//
+// Opened with `a` on a selected server (Servers tab / Search). Like the PHP
+// upgrade overlay: pick an action → confirm → POST → poll the event. The actual
+// call + polling live in the store (`startServerOp`), so closing the overlay
+// (Esc) leaves it running and the server's row keeps a spinner. When a reboot is
+// pending, we SSH-probe the *why* (Ubuntu's pending-restart packages) and show
+// it — labeled as OS context, not as SpinupWP's internal logic.
+
+import { useEffect, useState } from "react"
+import { useKeyboard } from "@opentui/react"
+import { theme } from "../../lib/theme.ts"
+import { truncate } from "../../lib/format.ts"
+import { Panel, Spinner, Centered } from "../components.tsx"
+import { StatusBar } from "../StatusBar.tsx"
+import { useStore } from "../store.tsx"
+import { moveSelection } from "../List.tsx"
+import type { RebootInfo } from "../../lib/ssh.ts"
+import type { ServerOpKind } from "../store.tsx"
+
+type Phase = "pick" | "confirm" | "tracking" | "done" | "error"
+
+interface Action {
+  kind: ServerOpKind
+  label: string // menu label, e.g. "Restart Nginx"
+  verb: string // short progress verb, e.g. "nginx"
+}
+
+const ACTIONS: Action[] = [
+  { kind: "reboot", label: "Reboot server", verb: "rebooting" },
+  { kind: "nginx", label: "Restart Nginx", verb: "nginx" },
+  { kind: "php", label: "Restart PHP-FPM", verb: "php-fpm" },
+  { kind: "mysql", label: "Restart MySQL", verb: "mysql" },
+  { kind: "redis", label: "Restart Redis", verb: "redis" },
+]
+
+// Short headline for the menu / detail; the full package list is shown on the
+// (wider) confirm screen, one per line.
+function rebootSummary(info: RebootInfo): string {
+  if (!info.present) return "no restart currently flagged on the server"
+  const head = info.kernel ? "kernel update" : "package updates"
+  const n = info.packages.length
+  return `${head} · ${n} package${n === 1 ? "" : "s"}`
+}
+
+export function ServerActions() {
+  const store = useStore()
+  const {
+    serverActionsServer: server,
+    setServerActionsServer,
+    sitesForServer,
+    serverOps,
+    startServerOp,
+    clearServerOp,
+    rebootInfo,
+    rebootInfoLoading,
+    rebootInfoErrors,
+    loadRebootInfo,
+  } = store
+
+  const rebootRequired = !!server?.reboot_required
+  const [phase, setPhase] = useState<Phase>("pick")
+  // Cursor starts on Reboot when one is pending, else on the first restart.
+  const [index, setIndex] = useState(() => (server?.reboot_required ? 0 : 1))
+  const [target, setTarget] = useState<Action | null>(null)
+
+  const siteCount = server ? sitesForServer(server.id).length : 0
+  const info = server ? rebootInfo.get(server.id) : undefined
+  const infoLoading = server ? rebootInfoLoading.has(server.id) : false
+  const infoError = server ? rebootInfoErrors.get(server.id) : undefined
+
+  // Fetch the "why" once when opened on a reboot-required server.
+  useEffect(() => {
+    if (server && rebootRequired && !info && !infoLoading && !infoError) loadRebootInfo(server)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [server?.id])
+
+  const progress = server ? serverOps.get(server.id) : undefined
+  const dp: Phase =
+    phase !== "tracking"
+      ? phase
+      : !progress
+        ? "done"
+        : progress.status === "failed"
+          ? "error"
+          : "tracking"
+
+  const close = () => {
+    if (server && progress?.status === "failed") clearServerOp(server.id)
+    setServerActionsServer(null)
+  }
+
+  useKeyboard((key) => {
+    const name = key.name ?? ""
+    if (name === "escape" || name === "q") return close()
+
+    if (dp === "pick") {
+      switch (name) {
+        case "up":
+        case "k":
+          return setIndex((i) => moveSelection(i, -1, ACTIONS.length))
+        case "down":
+        case "j":
+          return setIndex((i) => moveSelection(i, 1, ACTIONS.length))
+        case "return":
+        case "right":
+        case "l":
+          setTarget(ACTIONS[index])
+          setPhase("confirm")
+          return
+      }
+      return
+    }
+
+    if (dp === "confirm") {
+      if (name === "y") {
+        if (server && target) {
+          startServerOp(server, target.kind, target.verb)
+          setPhase("tracking")
+        }
+        return
+      }
+      if (name === "left" || name === "h") return setPhase("pick")
+      return
+    }
+
+    if (dp === "error") {
+      if (name === "r") {
+        if (server) clearServerOp(server.id)
+        setPhase("pick")
+      }
+      return
+    }
+  })
+
+  if (!server) return null
+
+  return (
+    <box
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        height: "100%",
+        flexDirection: "column",
+        backgroundColor: theme.bg,
+        zIndex: 210,
+      }}
+    >
+      {/* Title bar */}
+      <box
+        style={{
+          flexDirection: "row",
+          height: 1,
+          backgroundColor: theme.bgAlt,
+          paddingLeft: 1,
+          paddingRight: 1,
+          alignItems: "center",
+        }}
+      >
+        <text content="⚙ Server actions  " fg={theme.brand} style={{ flexShrink: 0 }} />
+        <text content={truncate(server.name, 40)} fg={theme.text} wrapMode="none" style={{ flexShrink: 1 }} />
+        <box style={{ flexGrow: 1 }} />
+        <text content={`${siteCount} site${siteCount === 1 ? "" : "s"}`} fg={theme.textFaint} style={{ flexShrink: 0 }} />
+      </box>
+
+      <Centered>{renderBody()}</Centered>
+
+      <StatusBar hints={hints()} showGlobal={false} />
+    </box>
+  )
+
+  function renderBody() {
+    if (dp === "pick") {
+      return (
+        <Panel title=" Choose an action " active>
+          <box style={{ flexDirection: "column", width: 52 }}>
+            {/* Reboot "why" context */}
+            {rebootRequired && (
+              <>
+                <box style={{ flexDirection: "row", height: 1 }}>
+                  <text content="⚠ reboot pending — " fg={theme.warn} style={{ flexShrink: 0 }} />
+                  {infoLoading ? (
+                    <box style={{ flexDirection: "row" }}>
+                      <Spinner interval={120} />
+                      <text content=" checking what's pending…" fg={theme.textDim} wrapMode="none" />
+                    </box>
+                  ) : info ? (
+                    <text content={rebootSummary(info)} fg={theme.textDim} wrapMode="none" style={{ flexShrink: 1 }} />
+                  ) : infoError ? (
+                    <text content="couldn't read detail over SSH" fg={theme.textFaint} wrapMode="none" />
+                  ) : (
+                    <text content="reboot required" fg={theme.textDim} wrapMode="none" />
+                  )}
+                </box>
+                <box style={{ height: 1 }} />
+              </>
+            )}
+            {ACTIONS.map((a, i) => {
+              const selected = i === index
+              const recommended = a.kind === "reboot" && rebootRequired
+              const fg = selected ? theme.text : recommended ? theme.warn : theme.textDim
+              const icon = a.kind === "reboot" ? "↻ " : "⟳ "
+              return (
+                <box
+                  key={a.kind}
+                  style={{ flexDirection: "row", height: 1, backgroundColor: selected ? theme.selectedBg : undefined }}
+                >
+                  <text content={(selected ? "❯ " : "  ") + icon + a.label} fg={fg} style={{ flexGrow: 1 }} wrapMode="none" />
+                  {recommended && <text content="(recommended)" fg={selected ? theme.text : theme.warn} style={{ flexShrink: 0 }} />}
+                </box>
+              )
+            })}
+          </box>
+        </Panel>
+      )
+    }
+
+    if (dp === "confirm") {
+      const isReboot = target?.kind === "reboot"
+      return (
+        <Panel title=" Confirm " active>
+          <box style={{ flexDirection: "column", width: 62, paddingTop: 1, paddingBottom: 1 }}>
+            <box style={{ flexDirection: "row" }}>
+              <text content={isReboot ? "Reboot " : `${target?.label} on `} fg={theme.text} wrapMode="none" />
+              <text content={truncate(server!.name, 30)} fg={theme.accent} wrapMode="none" />
+              <text content="?" fg={theme.text} />
+            </box>
+            <box style={{ height: 1 }} />
+            {isReboot ? (
+              <>
+                <text
+                  content={`Reboots the whole server — downtime for all ${siteCount} site${siteCount === 1 ? "" : "s"}.`}
+                  fg={theme.warn}
+                  wrapMode="none"
+                />
+                {info?.present && (
+                  <>
+                    <box style={{ height: 1 }} />
+                    <text content={`Pending: ${rebootSummary(info)}`} fg={theme.textDim} wrapMode="none" />
+                    {info.packages.slice(0, 6).map((p) => (
+                      <text key={p} content={`  • ${p}`} fg={theme.textFaint} wrapMode="none" />
+                    ))}
+                    {info.packages.length > 6 && (
+                      <text content={`  • …${info.packages.length - 6} more`} fg={theme.textFaint} wrapMode="none" />
+                    )}
+                  </>
+                )}
+              </>
+            ) : (
+              <text content="Brief interruption to that one service; sites stay up otherwise." fg={theme.textDim} wrapMode="none" />
+            )}
+            <box style={{ height: 1 }} />
+            <text content="Press y to confirm · ← to go back · Esc to cancel" fg={theme.textFaint} wrapMode="none" />
+          </box>
+        </Panel>
+      )
+    }
+
+    if (dp === "tracking") {
+      return (
+        <box style={{ flexDirection: "column", alignItems: "center" }}>
+          <box style={{ flexDirection: "row" }}>
+            <Spinner />
+            <text content={`  ${target?.label ?? "Working"} — ${progress?.status ?? "queued"}…`} fg={theme.textDim} />
+          </box>
+          <box style={{ height: 1 }} />
+          <text content="You can press Esc — it keeps running in the background." fg={theme.textFaint} wrapMode="none" />
+        </box>
+      )
+    }
+
+    if (dp === "done") {
+      return (
+        <Panel title=" Done " active>
+          <box style={{ flexDirection: "column", width: 56, paddingTop: 1, paddingBottom: 1 }}>
+            <box style={{ flexDirection: "row" }}>
+              <text content="✓ " fg={theme.good} />
+              <text content={`${target?.label ?? "Action"} completed on ` } fg={theme.text} wrapMode="none" />
+              <text content={truncate(server!.name, 24)} fg={theme.accent} wrapMode="none" />
+            </box>
+            <box style={{ height: 1 }} />
+            <text content="Esc to close" fg={theme.textFaint} />
+          </box>
+        </Panel>
+      )
+    }
+
+    // error
+    return (
+      <Panel title=" Action failed " active>
+        <box style={{ flexDirection: "column", width: 66, paddingTop: 1, paddingBottom: 1 }}>
+          <text content={`✕ ${progress?.error ?? "Something went wrong."}`} fg={theme.bad} />
+          <box style={{ height: 1 }} />
+          <text content="Press r to choose another action · Esc to close" fg={theme.textFaint} wrapMode="none" />
+        </box>
+      </Panel>
+    )
+  }
+
+  function hints() {
+    switch (dp) {
+      case "pick":
+        return [
+          { key: "↑↓/jk", label: "action" },
+          { key: "⏎", label: "choose" },
+          { key: "esc", label: "cancel" },
+        ]
+      case "confirm":
+        return [
+          { key: "y", label: "confirm" },
+          { key: "←", label: "back" },
+          { key: "esc", label: "cancel" },
+        ]
+      case "error":
+        return [
+          { key: "r", label: "retry" },
+          { key: "esc", label: "close" },
+        ]
+      default:
+        return [{ key: "esc", label: "close" }]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

The second **write** feature, reusing the PHP-upgrade scaffolding (`mutate()`, `getEvent` polling, confirm overlay, store-tracked background progress). Press `a` on a server (Servers tab or a Search result) to **reboot** it or **restart** a service.

- **Client:** `rebootServer()` (`POST /servers/{id}/reboot`) and `restartService()` (`POST /servers/{id}/services/{nginx|php|mysql|redis}/restart`), both returning `event_id`.
- **ServerActions overlay:** pick reboot or a service restart → confirm → POST → poll the event. Closing the overlay leaves it running; the server row shows a spinner + verb, and ServerDetail mirrors the state. Reboot's confirm warns about **whole-server downtime for all N sites**; a service restart is a brief blip.
- **Reboot visibility:** `↻rbt` badge in the Servers list (the Dashboard already listed reboot-required servers).
- **Reboot "why":** the API only exposes `reboot_required` (a boolean, no reason). So the overlay reads Ubuntu's `/var/run/reboot-required` + `.pkgs` over SSH (read-only, reusing the health connection) and shows the pending packages — typically a **kernel/security update** — labeled as OS-level context, *not* as SpinupWP's internal logic.

## Verifying the "why"
Before relying on the SSH file, I ran a read-only correlation check across the fleet: **20/20** — all 15 servers the API flags `reboot_required=true` have `/var/run/reboot-required` present (all kernel updates), and all 5 sampled `false` servers don't. So the boolean tracks that file 1:1 in practice.

## Testing
- `bun run typecheck` clean.
- Drove the overlay in a real PTY (read-only): the `a` menu renders, the SSH "why" probe resolves to the pending kernel packages, and the reboot confirm lists them one per line. **No write was triggered during testing** — no reboot/restart was actually fired.

> Note: needs a Read/Write token; with a Read Only token the action surfaces the friendly "token is read-only" message and nothing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)