### PR TITLE
DNS module: host inventory + access detection (read-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,46 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-20
+
+### Added
+- **DNS host inventory.** A new read-only DNS module that answers "where is each
+  domain's DNS hosted?" — the inventory you'd otherwise build by hand to migrate
+  or clone a site. Press `n` on a site to look up its domains' hosts; press `N`
+  on a server for a full, zone-keyed inventory of every domain on it. The unit is
+  the **zone**: `www` and the apex collapse together, and a separate-TLD redirect
+  (e.g. an alternate domain) surfaces as its own zone with its own host, so a full
+  portfolio move doesn't miss anything. Hosts are detected from a live nameserver
+  lookup (no `dig` dependency) and labeled (Cloudflare, AWS Route 53, GoDaddy,
+  …), falling back to the nameserver domain for anything unrecognized. Results
+  are cached with a visible age; `r` refreshes.
+- **DNS access detection.** Each zone also shows whether you can **edit** it:
+  `✓` editable · `↗` web only · `○` needs key · `·` unknown. A zone is `✓` only
+  when a connected account of the provider that actually serves it (its live
+  nameservers) holds it — so a stale or duplicate zone in another account doesn't
+  give a false green. With more than one account connected, an **ACCOUNT** column
+  names the owning account.
+- **Connect DNS providers.** Press `c` on a zone to manage credentials for its
+  provider — **AWS Route 53** (an access key for an IAM user scoped to Route 53
+  reads), **Cloudflare** (a `Zone:Read` scoped token), or **GoDaddy** (a
+  Production API key). Multiple accounts per provider are supported, with a
+  two-pane drill-down into each account's zones. Credentials are verified on the
+  spot (only stored if they work) and kept in `config.json` (chmod 600); standard
+  environment variables (`CLOUDFLARE_API_TOKEN`, `AWS_ACCESS_KEY_ID` /
+  `AWS_SECRET_ACCESS_KEY`, `GODADDY_API_KEY` / `GODADDY_API_SECRET`) are honored too.
+- **GoDaddy web fallback.** GoDaddy's API is only available to larger accounts, so
+  a GoDaddy zone shows `↗` and `w` (from the inventory or the connect overlay)
+  opens your GoDaddy **Clients hub** and copies the domain to your clipboard —
+  with an in-context note on the assumed Delegate-Access workflow.
+- **Masked secret entry.** Tokens and secret keys are masked as you type, in both
+  the DNS provider forms and the first-run **API-token onboarding** screen.
+
+### Notes
+- The DNS module is **entirely read-only** — it lists hosts and verifies access;
+  it does not change any DNS records (editing is a later phase). Provider
+  credentials are optional: without them you still get the full host inventory,
+  just without the editable/account columns.
+
 ## [0.5.0] - 2026-06-19
 
 ### Added
@@ -164,7 +204,8 @@ Initial tagged release.
 ### Notes
 - Read-only release: works with a SpinupWP **Read Only** API token.
 
-[Unreleased]: https://github.com/mwender/spinupwp-tui/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/mwender/spinupwp-tui/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/mwender/spinupwp-tui/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/mwender/spinupwp-tui/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/mwender/spinupwp-tui/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/mwender/spinupwp-tui/compare/v0.2.0...v0.3.0

--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ Once you're in, the dashboard looks like this:
   SSH: CPU (aggregate + per-core + sparkline), load, memory/swap, disk mounts,
   and top processes. Polls every few seconds. (See "Server health" below.)
 - **Open in browser** — press `o` on any site to open it in your default browser.
+- **Link local working copies** — press `L` on a site to link its local checkout
+  (a path plus the local URL where you serve it), then open it with `t` (a
+  terminal there) or `v` (its local URL). The Stacks tab can **auto-discover**
+  copies (`S`) by git remote / Bedrock `WP_HOME` / folder name, and **report**
+  managed sites that still need one (`f`). Linked sites show a `◆` marker, and a
+  linked checkout shows its local git drift (`⇡N unpushed` / `● uncommitted`).
+  (See "Local working copies" below.)
+- **SSH into a site** — press `s` on a site to open a new terminal already running
+  `ssh` into it (`{site_user}@{server_ip}`).
+- **DNS hosts & access** — press `n` on a site (or `N` on a server) to see where
+  each domain's DNS is hosted, and — if you connect a provider (AWS Route 53 /
+  Cloudflare / GoDaddy) — whether you can edit it and through which account. The
+  whole module is **read-only**: it inventories and verifies, it doesn't change
+  records. (See "DNS hosts & access" below.)
 - **Upgrade a site's PHP version** — press `u` on a site to pick a new PHP
   version and apply it (`PUT /sites/{id}/php`), then watch the upgrade event run
   to completion. (See "Upgrading PHP" below.)
@@ -154,14 +168,22 @@ Both can be set in `config.json` or via an environment variable:
 | `Tab` | Switch focus between columns |
 | `g` / `G` | Jump to top / bottom |
 | `o` | Open the selected site in your browser |
+| `s` | Open a terminal and SSH into the selected site |
+| `L` | Link / edit a site's local working copy |
+| `t` / `v` | Open the linked copy in a terminal / its local URL in your browser |
+| `n` | Look up where a site's domains host DNS |
+| `N` | DNS host + access inventory for the selected server |
 | `h` | Live server health (CPU/mem/disk over SSH) |
 | `d` | Detect a site's stack via SSH (Servers / Stacks tabs) |
 | `D` | Detect every site in the selected stack (Stacks tab) |
+| `S` | Auto-discover & batch-link local copies (Stacks tab) |
+| `f` | Report sites with no usable local copy (Stacks tab) |
 | `u` | Upgrade a site's PHP version (Servers / Stacks / Search; needs a Read/Write token) |
 | `a` | Server actions: reboot / restart a service (Servers / Search; needs a Read/Write token) |
 | `w` | Open the selected server/site in the SpinupWP web app |
 | `/` | Jump to global search |
 | `r` | Refresh data from the API |
+| `i` | Explain the current screen (what each pane and key does) |
 | `?` | Toggle the help overlay |
 | `q` / `Ctrl+C` | Quit |
 
@@ -257,6 +279,62 @@ server's row keeps a spinner).
   file 1:1).
 - **Reboot is the big one** — its confirmation calls out that it takes the whole
   server down briefly (every site on it); a service restart is a brief blip.
+
+## Local working copies
+
+Bridge your SpinupWP sites to the local checkouts you actually edit. Press `L` on
+a site (Servers / Stacks / Search) to link a path and the local URL where you
+serve it; the site's details gain a "Local" field, and you can open the copy with
+`t` (a terminal at the path) or `v` (its local URL). All of this is **local-only**
+— no SpinupWP writes.
+
+- **Auto-discover (`S`, Stacks tab).** Scan one or more folders and match their
+  subdirectories to sites — by git remote, Bedrock `WP_HOME`, or folder name —
+  then batch-link the matches.
+- **"Needs a local copy" report (`f`, Stacks tab).** Lists the managed sites you
+  have no usable local copy for (never linked, or a missing path), filterable by
+  stack.
+- **Markers & drift.** Linked sites show `◆` in the lists; a linked, on-disk copy
+  shows its local git drift (`⇡N unpushed` / `● uncommitted`), read from the repo
+  with no network.
+
+Config keys: `localRoots` (folders to scan) and `localSites` (per-site path +
+local URL — tool-agnostic: Valet, Cove, LocalWP, Herd, DDEV, …).
+
+## DNS hosts & access
+
+A **read-only** DNS module: see where each domain's DNS is hosted, and whether
+you can edit it. No DNS records are ever changed.
+
+- **Inventory.** Press `n` on a site to look up its domains' hosts, or `N` on a
+  server for a zone-keyed inventory of every domain on it. The unit is the
+  **zone** — `www` and the apex collapse together, and a separate-TLD redirect
+  surfaces as its own zone with its own host (so a full portfolio move misses
+  nothing). Hosts come from a live nameserver lookup (no `dig` needed) and are
+  labeled (Cloudflare, AWS Route 53, GoDaddy, …), falling back to the nameserver
+  domain for anything unrecognized. Lookups are cached with a visible age; `r`
+  refreshes.
+- **Access (`✓ ↗ ○ ·`).** Each zone shows whether you can edit it: `✓` editable,
+  `↗` web-only handoff, `○` the provider has an API but you haven't connected an
+  account that holds the zone, `·` unknown. A zone is `✓` only when a connected
+  account of the provider that actually serves it (its live nameservers) holds it
+  — so a stale or duplicate zone elsewhere never shows a false green. With two or
+  more accounts connected, an **ACCOUNT** column names the owning one.
+- **Connect a provider (`c`).** Manage credentials for the selected zone's
+  provider — **AWS Route 53** (an IAM access key scoped to Route 53 reads),
+  **Cloudflare** (a `Zone:Read` token), or **GoDaddy** (a Production API key).
+  Multiple accounts per provider are supported, with a drill-down into each
+  account's zones. Credentials are verified before they're stored, kept in
+  `config.json` (chmod 600), and the matching environment variables are honored
+  (`CLOUDFLARE_API_TOKEN`, `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`,
+  `GODADDY_API_KEY` / `GODADDY_API_SECRET`). Secrets are masked as you type.
+- **GoDaddy fallback.** GoDaddy's API is limited to larger accounts, so a GoDaddy
+  zone shows `↗`; press `w` (in the inventory or the connect overlay) to open your
+  GoDaddy Clients hub with the domain copied to your clipboard. The flow assumes
+  you manage client domains via Delegate Access from one main account.
+
+Provider credentials are entirely optional — without them you still get the full
+host inventory, just without the editable/account columns.
 
 ## Development
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,6 +26,22 @@ land, add bullets under `## [Unreleased]` in the right group: **Added / Changed 
 Fixed / Removed** (plus **Notes** for caveats). Write user-facing impact, not
 implementation detail.
 
+## Keep the README current (part of shipping a feature)
+
+`README.md` is user-facing docs, not just a landing page — a new feature isn't
+"done" until it's there. Whenever a change adds or changes user-facing behavior,
+update, in the same breath:
+
+- the **Features** list (a bullet, with the key and a "see … below" pointer),
+- the **Keybindings** table (every new key, with where it applies),
+- the relevant **feature section** (a short how-it-works block; add one for a
+  whole new area like the DNS module or local working copies).
+
+When cutting a release, **re-read those three against the new `## [Unreleased]`
+changelog entries** and backfill anything that slipped — a prior release's
+features missing from the README is the exact failure mode this step exists to
+catch.
+
 ## Versioning (SemVer, while in `0.x`)
 
 - New user-facing feature → **minor** bump (`0.2.0` → `0.3.0`).
@@ -37,7 +53,8 @@ implementation detail.
 Run these in order. Replace `X.Y.Z` with the new version.
 
 1. **Land the work.** Feature branch merged to `main` (or docs committed directly).
-   `bun run typecheck` is green.
+   `bun run typecheck` is green, and `README.md` reflects the new features (see
+   "Keep the README current").
 2. **Bump the version** in `package.json`.
 3. **Roll the changelog:** rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD`,
    add a fresh empty `## [Unreleased]` above it, and update the compare links at
@@ -81,6 +98,7 @@ Run these in order. Replace `X.Y.Z` with the new version.
 ## Quick checklist
 
 - [ ] Work merged to `main`, `bun run typecheck` green
+- [ ] `README.md` Features / Keybindings / feature sections updated for new user-facing changes
 - [ ] `package.json` version bumped (SemVer)
 - [ ] `CHANGELOG.md`: `[Unreleased]` → `[X.Y.Z]` + date, fresh `[Unreleased]`, compare links updated
 - [ ] Release commit on `main`

--- a/docs/dns-access-phase2-spec.md
+++ b/docs/dns-access-phase2-spec.md
@@ -1,0 +1,179 @@
+# DNS Module Phase 2 — Access Detection (read-only)
+
+Adds an **ACCESS** column to the DNS inventory: for each zone, can you edit its
+DNS, and by what means? **Still no writes.** Phase 2 only *verifies read access*
+(lists the zones each connected account can see) and surfaces a glyph. Editing +
+the migrate-a-site TTL workflow are Phase 3.
+
+Builds on Phase 1 (`docs/dns-zone-host-spec.md`). The zone-host detection from
+Phase 1 tells us the provider; Phase 2 answers whether we hold credentials that
+can reach that zone.
+
+## The ACCESS states (glyph + footer legend)
+
+A narrow, glyph-only column between HOST and NOTE:
+
+| Glyph | State | Meaning |
+| ----- | ----- | ------- |
+| `✓` | editable | Verified: the zone apex is in a **connected** account's zone set |
+| `○` | needs key | Provider is API-capable (Route 53 / Cloudflare) but the zone isn't in any connected account |
+| `↗` | web only | No API path — but we can deep-link to the provider's web console |
+| `·` | unknown | Unmanaged / unrecognized host (the fallback labels) |
+
+Footer legend: `✓ editable   ↗ web only   ○ needs key`. Header `ACCESS`.
+
+`✓` is **verified, never assumed** (user decision): we only show it when a real
+`ListHostedZones` / Cloudflare list-zones response contained the zone. Creds
+present but the zone not in that account → `○`, never a false green.
+
+## Connections model — N credentials per provider
+
+A site/dev has many accounts per provider, so a provider holds a **list of
+connections**, each = one stored credential:
+
+- **AWS connection** = one access key-set = exactly one account (no cross-account
+  key; multiple accounts → multiple connections, mirroring `~/.aws` profiles).
+- **Cloudflare connection** = one token, which may surface **one or several
+  accounts** (a CF token can be scoped to multiple accounts / "all zones").
+
+A provider's **effective zone set = the union across its connections.** The
+ACCESS glyph asks "is this apex in that union?". Connecting another account
+re-greens every zone it owns. We also record each zone's **owning account** so
+Phase 3 editing can route to the right credential.
+
+## Credentials & storage
+
+- Stored in `config.json` (chmod 0600), a new `providers` block:
+  ```jsonc
+  providers: {
+    cloudflare: [ { id, label, token } ],
+    aws:        [ { id, label, accessKeyId, secretAccessKey, region } ]
+  }
+  ```
+- **Env overrides** appear as read-only connections (consistent with the SpinupWP
+  token): `CLOUDFLARE_API_TOKEN` → a cloudflare connection labeled "env";
+  `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` (+ `AWS_REGION`) → an aws "env"
+  connection. Env connections can't be removed from the UI (unset the var).
+- **Never** echo a secret in a flash/log; **never** in a public artifact.
+- **Least privilege is the guardrail for stored AWS keys:** the connect flow
+  steers the user to a dedicated IAM user scoped to `route53:ListHostedZones` +
+  `route53:ListResourceRecordSets` (Phase 2), and a Cloudflare `Zone:Read` token.
+
+## Verification = the column's data (one mechanism)
+
+Verifying a connection IS the fetch that powers the column:
+
+- **Cloudflare** — `GET https://api.cloudflare.com/client/v4/zones?per_page=50`
+  (paginate via `result_info.total_pages`), `Authorization: Bearer <token>`.
+  Each `result[]` → `{ apex: name, accountId: account.id, accountName: account.name }`.
+  Auto-label = the account name (or "N accounts" when several).
+- **AWS Route 53** — hand-rolled **SigV4** GET (no `aws` CLI, no SDK):
+  - `sts:GetCallerIdentity` (`https://sts.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15`,
+    service `sts`) → the 12-digit account id (always permitted; auto-label default).
+  - `route53 ListHostedZones` (`https://route53.amazonaws.com/2013-04-01/hostedzone`,
+    service `route53`, region `us-east-1`, paginate via `IsTruncated`/`NextMarker`)
+    → XML, extract each `<HostedZone>`'s `<Name>` (strip trailing dot, lowercase).
+  - Both responses are XML; minimal regex extraction (no XML lib).
+
+Results are cached on disk per connection (`providers-cache.json`, model on
+`dnsCache.ts`): `{ connectionId, ok, zones: VerifiedZone[], accountLabel, error?, verifiedAt }`.
+Hydrated at startup so the column populates without re-hitting providers; an age
+is shown and a re-verify is one key.
+
+## Capability registry
+
+The Phase-1 `PROVIDERS` label table is joined by a capability map:
+
+```ts
+API_PROVIDERS = { route53, cloudflare }           // can verify via API
+PROVIDER_CONSOLE: Record<providerKey, url>          // web-console deep links
+  route53    → AWS Route 53 console (hosted zones)
+  cloudflare → dash.cloudflare.com
+  godaddy    → GoDaddy DNS manager
+  namecheap, dnsme, digitalocean, google, …         // best-effort console roots
+```
+
+`accessForZone(apex, providerKey)`:
+- providerKey ∈ API_PROVIDERS → apex in union(connected zones)? `editable` : `needs-key`
+- else providerKey has a console → `web`
+- else → `unknown`
+
+## UI
+
+### ACCESS column (DnsInventory)
+
+Insert between HOST and NOTE. Glyph-only (width ~2) + the footer legend.
+Empty-state teaches: with no connections, the legend reads
+"connect a provider (c) to see what you can edit".
+
+### Connect overlay (`src/ui/views/ProviderConnect.tsx`)
+
+Opened with **`c`** on the selected zone — context-sensitive on the zone's host:
+- API provider (route53/cloudflare) → the provider's connect/manage overlay
+- web-only host → open its console URL (the `↗` handoff)
+- unknown host → flash "no known DNS console for <host>"
+
+The overlay is **also the per-provider manager** (honors "many accounts" without
+a settings tab): it lists existing connections for that provider and an "add
+another" affordance.
+
+```
+ Connect Cloudflare
+   personal token        2 accounts · 18 zones · ok · 4m ago
+   + add another token
+
+ [add form]  Paste a scoped API token (Zone:Read is enough for now):
+             > ********************************
+             Create one at dash.cloudflare.com → My Profile → API Tokens
+```
+
+```
+ Connect AWS (Route 53)
+   main account (1234…6789)   12 zones · ok
+   + add another account
+
+ [add form]  Access Key ID     > AKIA…
+             Secret Access Key > ****************
+             Region (optional) > us-east-1
+             Use an IAM user scoped to route53:ListHostedZones + ListResourceRecordSets
+```
+
+Flow: fill form → **verify immediately** → on success store the connection +
+cache its zones + flash "Connected — N zones"; on failure show the error, keep
+the form. Existing connection rows support **re-verify** and **remove**
+(stored connections only; env connections are read-only).
+
+### Keys
+
+- DnsInventory: `c` = manage access for the selected zone (connect / console),
+  `r` already re-runs DNS lookups — extend `r` to also re-verify connections
+  (or a separate key; TBD in build).
+- Connect overlay: `a` add, `↑↓` select connection, `v` re-verify, `x` remove
+  (stored only), `Esc` close. Secret inputs masked.
+
+## Store additions
+
+- `providerConnections: { aws: Connection[]; cloudflare: Connection[] }` (config +
+  env, hydrated).
+- `providerZones: Map<connectionId, VerifiedConn>` (cache snapshot).
+- `addConnection(provider, draft)` → verify → persist + cache; `removeConnection`;
+  `verifyConnection(id)`; `verifyAllConnections()`.
+- `accessForZone(apex, providerKey)` selector → `editable | needs-key | web | unknown`.
+- `connectZoneTarget: { apex, providerKey } | null` (drives the overlay; set by `c`).
+
+## Out of scope (Phase 3)
+
+DNS record writes, TTL drop/restore migrate workflow, scope-upgrade prompts when a
+read token is insufficient to edit, same per-zone credential routing for edits.
+
+## File map
+
+- `src/lib/awsSigV4.ts` — pure `signGetV4()` + `awsGet()` (node:crypto, fetch).
+- `src/lib/providers.ts` — types, capability registry, `verifyCloudflare`,
+  `verifyAws`, `accessForZone` helper, console map.
+- `src/lib/providersCache.ts` — disk cache of verified zone sets.
+- `src/config.ts` — `providers` block + env-derived connections.
+- `src/ui/store.tsx` — connections state + actions + `accessForZone`.
+- `src/ui/views/ProviderConnect.tsx` — connect/manage overlay.
+- `src/ui/views/DnsInventory.tsx` — ACCESS column + `c`.
+- `src/ui/App.tsx`, `src/ui/Help.tsx` — wiring + docs.

--- a/docs/dns-zone-host-spec.md
+++ b/docs/dns-zone-host-spec.md
@@ -1,0 +1,171 @@
+# DNS Zone-Host Inventory — Spec (v1, read-only)
+
+The first slice of the DNS module (backlog item 6). **Read-only.** No AWS/Cloudflare
+credentials, no scoped tokens, no writes. It answers one question a developer needs
+exactly when migrating or cloning a site: **"where is each domain's DNS zone hosted?"**
+
+It also proves the provider-detection layer the later editing phases will reuse, while
+deliberately not touching anything dangerous.
+
+## The job it does
+
+When moving or cloning a site you must inventory the DNS host of every domain in the
+site's portfolio — not just the apex, but separate-TLD redirects/aliases too, since a
+full move has to carry the whole portfolio (and those can live on a different host).
+Today that's a hand-built spreadsheet. This view replaces it.
+
+## Core concept: the unit is the **zone**, not the site
+
+- A site owns one or more **zones** (distinct registrable domains).
+- `www.example.com` and `example.com` collapse into one zone (`example.com`).
+- A separate-TLD additional domain (`example.net`) is its **own zone** with its **own
+  host**, surfaced as its own row.
+- DNS host is a property of the **zone apex's NS records**, so we resolve once per zone.
+
+Per-FQDN delegation (a subdomain delegated to a different host than its apex) is a known,
+bounded gap — **out of scope for v1** (no zones in the target fleet use it).
+
+## Resolution (`src/lib/dns.ts`)
+
+Use **`node:dns/promises`** — no `dig` dependency. Point a `new dns.Resolver()` at public
+resolvers (`1.1.1.1`, `8.8.8.8`) with a timeout (~5s) to avoid local-resolver/VPN caching.
+
+**Walk-up to find the zone apex** (no Public Suffix List needed):
+
+```
+resolveZone(domain):
+  name = domain without a leading "www."
+  loop:
+    try ns = resolver.resolveNs(name)
+    if ns non-empty -> apex = name; return { apex, nameservers: ns, ...label(ns) }
+    on ENODATA/ENOTFOUND -> strip leftmost label; if <2 labels left -> return null
+```
+
+Resolvers answer NS from the closest enclosing zone, so the first label that yields NS
+records *is* the apex. This is robust to multi-label TLDs (`.co.uk`) for free.
+
+### Provider label — curated table + smart fallback
+
+`labelForNameservers(ns: string[]) -> { key, label }`. Match any nameserver hostname
+against a curated substring table; **fall back to the registrable domain of the
+nameserver itself** so unknown hosts still produce the exact signal you'd write down.
+
+Starter table (extend freely):
+
+| NS contains            | key          | label             |
+| ---------------------- | ------------ | ----------------- |
+| `awsdns`               | `route53`    | AWS Route 53      |
+| `cloudflare.com`       | `cloudflare` | Cloudflare        |
+| `domaincontrol.com`    | `godaddy`    | GoDaddy           |
+| `registrar-servers.com`| `namecheap`  | Namecheap         |
+| `nsone.net`            | `ns1`        | NS1               |
+| `dnsmadeeasy.com`      | `dnsme`      | DNS Made Easy     |
+| `digitalocean.com`     | `do`         | DigitalOcean      |
+| `ns-cloud-` / `googledomains` | `google` | Google           |
+| `worldnic.com`         | `netsol`     | Network Solutions |
+| `dreamhost.com`        | `dreamhost`  | DreamHost         |
+| `name-services.com`    | `enom`       | eNom              |
+
+Fallback: `ns1.somehost.net` -> `{ key: "somehost.net", label: "somehost.net" }`.
+
+`route53` / `cloudflare` keys are the editable providers later — the inventory just
+shows labels; nothing keys off editability in v1.
+
+## Caching (`src/lib/dnsCache.ts`)
+
+Mirror `stackCache.ts`: disk file `~/.config/spinupwp-tui/dns-cache.json`, hydrate on
+startup, serialized write-through. **Keyed by zone apex** (so `www` + apex share one
+entry). Value: `{ apex, nameservers, providerKey, providerLabel, checkedAt }`.
+
+DNS host rarely changes — *except during the migration you're using this for*. So:
+default staleness **24h**, but **always show age** ("checked 3m ago") and offer a
+**one-key refresh** for fresh reads while watching a cutover.
+
+## Store (`src/ui/store.tsx`)
+
+Parallels the probe plumbing:
+
+- `dnsZones: Map<string, ZoneHost>` — keyed by zone apex.
+- `domainZone: Map<string, string | null>` — domain -> apex (or null = unresolvable).
+- `dnsResolving: Set<string>` — domains in flight.
+- `dnsErrors: Map<string, string>` — domain -> message.
+- `lookupDomain(domain)` — resolve one (cache first), lazy.
+- `lookupSiteDns(siteId)` — resolve all of a site's domains (`domain` + `additional_domains[]`).
+- `lookupServerDns(serverId)` — resolve every domain of every site on the server,
+  bounded concurrency 5 (like `runProbeMany`); dedupe by `www`-stripped name then by apex.
+- `refreshDns(scope)` — bypass cache.
+
+**Lazy always** — never auto-fire on selection (network cost), like `d` probe / `ensureDrift`.
+
+## UI
+
+### Site Detail — on-demand per-zone lines
+
+Key **`n`** on a selected site (Browser / Servers) runs `lookupSiteDns` and adds a DNS
+section to the detail pane: domains grouped by zone -> host, with a redirect note where
+present.
+
+```
+DNS
+  example.com    -> AWS Route 53
+  example.net    -> GoDaddy           → redirects to example.com
+```
+
+### Server DNS inventory overlay (`src/ui/views/DnsInventory.tsx`)
+
+Key **`N`** (shift) opens a full-screen overlay for the **selected site's server**
+(mirrors the `d`/`D` "this site / this group" pairing; follows the Forgotten/Discover
+overlay pattern). Phases: resolving (progress) -> table.
+
+Zone-keyed table across all sites on the server:
+
+```
+SERVER  srv-name (1.2.3.4)              7 zones · 4 Route 53 · 2 Cloudflare · 1 GoDaddy
+
+SITE              ZONE              HOST            NOTE
+example.com       example.com       AWS Route 53
+                  example.net       GoDaddy         → redirects to example.com
+shop.example.com  shop-example.com  Cloudflare
+```
+
+- One row per distinct **zone**; `www` collapsed in.
+- Separate-TLD additional domains get their own row with their own host.
+- NOTE column from `AdditionalDomain.redirect` (`enabled` -> `→ redirects to {destination}`);
+  a non-redirecting alias shows no note (itself meaningful).
+- Summary line counts **zones** by host.
+- Keys: `r` refresh (bypass cache), `Esc` close. (Sort toggle zone/host — optional.)
+
+**No CSV export in v1.** The view replaces the spreadsheet. The data model is identical
+to an export, so it's a ~half-hour add if a durable/shareable artifact need appears
+(multi-day TTL migration log, client handoff).
+
+### Discoverability
+
+`?` Help "DNS" section + an explain/subtitle entry, per
+[[feedback-name-by-outcome-teach-in-context]]. Name by outcome ("where each domain's DNS
+is hosted"), not mechanism.
+
+## Out of scope for v1 (later phases)
+
+- Any DNS **writes** / the migrate-a-site TTL workflow (the high-risk core of item 6).
+- Per-FQDN subdomain-delegation resolution.
+- CSV/spreadsheet export.
+- Cloudflare/Route 53 API credentials.
+- A dedicated DNS/Advanced tab (overlay-first; graduate only if it accretes surfaces).
+
+## Open implementation-level choices (recommended defaults)
+
+- **Keys:** `n` = look up selected site; `N` = server inventory overlay (mirrors `d`/`D`).
+- **Cache TTL:** 24h default staleness; age always shown; `r` forces refresh.
+- **Resolver:** `node:dns` Resolver -> `1.1.1.1`,`8.8.8.8`, ~5s timeout.
+- **Concurrency:** 5 (matches `runProbeMany`).
+
+## File map
+
+- `src/lib/dns.ts` — `resolveZone`, `labelForNameservers`, provider table, `ZoneHost`.
+- `src/lib/dnsCache.ts` — disk cache (model on `stackCache.ts`).
+- `src/ui/store.tsx` — maps + lazy lookup actions.
+- `src/ui/views/DnsInventory.tsx` — server overlay.
+- `src/ui/Details.tsx` (or the SiteDetail component) — on-demand DNS section.
+- `src/ui/App.tsx` — overlay wiring + `n`/`N` keys + guards.
+- `src/ui/Help.tsx` — DNS section.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spinupwp-tui",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A cool terminal UI for browsing and monitoring your SpinupWP servers and sites.",
   "type": "module",
   "bin": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ import { join } from "node:path"
 import { mkdir, chmod } from "node:fs/promises"
 import { existsSync, readFileSync } from "node:fs"
 import type { LocalLink } from "./lib/local.ts"
+import { ALL_PROVIDERS, type Connection, type ConnProvider } from "./lib/providers.ts"
 
 export const DEFAULT_BASE_URL = "https://api.spinupwp.app/v1"
 
@@ -35,6 +36,35 @@ export interface AppConfig {
   // Local working-copy links, keyed by SpinupWP site id (as a string, since
   // JSON object keys are strings). See lib/local.ts for the link shape.
   localSites: Record<string, LocalLink>
+  // DNS provider connections (Phase 2 access detection), keyed by provider, merged
+  // from the stored config and the environment. Env-sourced connections carry
+  // `env: true` and are read-only in the UI. Secrets live here (file is chmod 600).
+  providerConnections: Record<ConnProvider, Connection[]>
+}
+
+// Stored connection (no `provider`/`env` discriminators — added on load).
+export interface StoredConnection {
+  id: string
+  label: string
+  creds: Record<string, string>
+}
+export type StoredProviders = Partial<Record<ConnProvider, StoredConnection[]>>
+
+// Read a connection's creds, migrating the pre-registry shape (credentials stored
+// as inline fields) to the `creds` bag. The migrated bag is rewritten to disk on
+// the next saveConfig (add/remove a connection).
+function migrateCreds(provider: ConnProvider, c: Record<string, unknown>): Record<string, string> {
+  if (c.creds && typeof c.creds === "object") return c.creds as Record<string, string>
+  if (provider === "aws") {
+    return {
+      accessKeyId: String(c.accessKeyId ?? ""),
+      secretAccessKey: String(c.secretAccessKey ?? ""),
+      region: String(c.region ?? ""),
+    }
+  }
+  if (provider === "cloudflare") return { token: String(c.token ?? "") }
+  if (provider === "godaddy") return { apiKey: String(c.apiKey ?? ""), apiSecret: String(c.apiSecret ?? "") }
+  return {}
 }
 
 export interface StoredConfig {
@@ -45,6 +75,7 @@ export interface StoredConfig {
   terminalApp?: string
   localRoots?: string[]
   localSites?: Record<string, LocalLink>
+  providers?: StoredProviders
 }
 
 export function configDir(): string {
@@ -75,6 +106,37 @@ export function loadConfig(): AppConfig {
   const token = envToken || fileToken || ""
   const tokenSource: AppConfig["tokenSource"] = envToken ? "env" : fileToken ? "file" : "none"
 
+  // Provider connections: stored ones first (per provider), with env-derived ones
+  // prepended as read-only "env" connections (consistent with the env token above).
+  const sp = stored.providers ?? {}
+  const providerConnections = {} as Record<ConnProvider, Connection[]>
+  for (const provider of ALL_PROVIDERS) {
+    providerConnections[provider] = (sp[provider] ?? []).map((c) => ({
+      id: c.id,
+      provider,
+      label: c.label,
+      creds: migrateCreds(provider, c as unknown as Record<string, unknown>),
+    }))
+  }
+  const cfEnv = process.env.CLOUDFLARE_API_TOKEN?.trim()
+  if (cfEnv) providerConnections.cloudflare.unshift({ id: "cloudflare-env", provider: "cloudflare", label: "env", creds: { token: cfEnv }, env: true })
+  const awsKey = process.env.AWS_ACCESS_KEY_ID?.trim()
+  const awsSecret = process.env.AWS_SECRET_ACCESS_KEY?.trim()
+  if (awsKey && awsSecret) {
+    providerConnections.aws.unshift({
+      id: "aws-env",
+      provider: "aws",
+      label: "env",
+      creds: { accessKeyId: awsKey, secretAccessKey: awsSecret, region: process.env.AWS_REGION?.trim() || "" },
+      env: true,
+    })
+  }
+  const gdKey = process.env.GODADDY_API_KEY?.trim()
+  const gdSecret = process.env.GODADDY_API_SECRET?.trim()
+  if (gdKey && gdSecret) {
+    providerConnections.godaddy.unshift({ id: "godaddy-env", provider: "godaddy", label: "env", creds: { apiKey: gdKey, apiSecret: gdSecret }, env: true })
+  }
+
   return {
     token,
     baseUrl: (stored.baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, ""),
@@ -84,6 +146,7 @@ export function loadConfig(): AppConfig {
     terminalApp: process.env.SPINUPWP_TERMINAL_APP?.trim() || stored.terminalApp?.trim() || null,
     localRoots: stored.localRoots ?? [],
     localSites: stored.localSites ?? {},
+    providerConnections,
   }
 }
 

--- a/src/lib/awsSigV4.ts
+++ b/src/lib/awsSigV4.ts
@@ -1,0 +1,95 @@
+// Hand-rolled AWS Signature Version 4 for GET requests — no `aws` CLI, no SDK.
+// We only ever issue a handful of read-only GETs (STS GetCallerIdentity, Route 53
+// ListHostedZones / ListResourceRecordSets), so the full SigV4 algorithm for an
+// unsigned-body GET is all we need. Keeps the app dependency-light (node:crypto +
+// fetch only) and the compiled binary small.
+//
+// Reference: docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+// Verified against AWS's published "get-vanilla" test vector (see awsSigV4.test).
+
+import { createHash, createHmac } from "node:crypto"
+
+export interface AwsCreds {
+  accessKeyId: string
+  secretAccessKey: string
+  region?: string // defaults to us-east-1 (Route 53 + STS are global, signed in us-east-1)
+  sessionToken?: string
+}
+
+function sha256hex(data: string): string {
+  return createHash("sha256").update(data, "utf8").digest("hex")
+}
+function hmac(key: string | Buffer, data: string): Buffer {
+  return createHmac("sha256", key).update(data, "utf8").digest()
+}
+
+// AWS URI-encoding (RFC 3986): encodeURIComponent plus the four chars it leaves.
+function enc(s: string): string {
+  return encodeURIComponent(s).replace(/[!*'()]/g, (c) => "%" + c.charCodeAt(0).toString(16).toUpperCase())
+}
+
+export interface SignGetOptions {
+  creds: AwsCreds
+  service: string
+  host: string
+  path: string // already in canonical form (we only use simple ASCII paths)
+  query?: Record<string, string>
+  amzDate?: string // override for testing; defaults to now in ISO8601 basic (YYYYMMDDTHHMMSSZ)
+}
+
+// Produce the headers + URL for a signed GET. Pure (no I/O) so it can be unit
+// tested against AWS's reference vectors.
+export function signGetV4(opts: SignGetOptions): { url: string; headers: Record<string, string> } {
+  const { creds, service, host, path } = opts
+  const region = creds.region || "us-east-1"
+  const query = opts.query ?? {}
+  const amzDate = opts.amzDate ?? new Date().toISOString().replace(/[:-]|\.\d{3}/g, "")
+  const dateStamp = amzDate.slice(0, 8)
+
+  const canonicalQuery = Object.keys(query)
+    .sort()
+    .map((k) => `${enc(k)}=${enc(query[k])}`)
+    .join("&")
+
+  // Signed headers (lowercase names, sorted). host + x-amz-date, plus the session
+  // token header when present.
+  const hdrs: Record<string, string> = { host, "x-amz-date": amzDate }
+  if (creds.sessionToken) hdrs["x-amz-security-token"] = creds.sessionToken
+  const names = Object.keys(hdrs).sort()
+  const canonicalHeaders = names.map((n) => `${n}:${hdrs[n].trim()}\n`).join("")
+  const signedHeaders = names.join(";")
+
+  const payloadHash = sha256hex("") // empty body for a GET
+  const canonicalRequest = ["GET", path, canonicalQuery, canonicalHeaders, signedHeaders, payloadHash].join("\n")
+
+  const scope = `${dateStamp}/${region}/${service}/aws4_request`
+  const stringToSign = ["AWS4-HMAC-SHA256", amzDate, scope, sha256hex(canonicalRequest)].join("\n")
+
+  const kDate = hmac("AWS4" + creds.secretAccessKey, dateStamp)
+  const kRegion = hmac(kDate, region)
+  const kService = hmac(kRegion, service)
+  const kSigning = hmac(kService, "aws4_request")
+  const signature = createHmac("sha256", kSigning).update(stringToSign, "utf8").digest("hex")
+
+  const authorization = `AWS4-HMAC-SHA256 Credential=${creds.accessKeyId}/${scope}, SignedHeaders=${signedHeaders}, Signature=${signature}`
+
+  // host is implied by the URL (fetch sets it); send the rest.
+  const headers: Record<string, string> = { "x-amz-date": amzDate, Authorization: authorization }
+  if (creds.sessionToken) headers["x-amz-security-token"] = creds.sessionToken
+
+  const url = `https://${host}${path}${canonicalQuery ? "?" + canonicalQuery : ""}`
+  return { url, headers }
+}
+
+// Sign and perform a GET. Returns the HTTP status + raw body text.
+export async function awsGet(
+  creds: AwsCreds,
+  service: string,
+  host: string,
+  path: string,
+  query: Record<string, string> = {},
+): Promise<{ status: number; body: string }> {
+  const { url, headers } = signGetV4({ creds, service, host, path, query })
+  const res = await fetch(url, { method: "GET", headers })
+  return { status: res.status, body: await res.text() }
+}

--- a/src/lib/dns.ts
+++ b/src/lib/dns.ts
@@ -1,0 +1,128 @@
+// DNS zone-host detection (read-only). Answers "where is this domain's DNS zone
+// hosted?" — the signal a developer needs when migrating or cloning a site and
+// has to inventory every domain's DNS host.
+//
+// No `dig` dependency: uses Node's built-in resolver (node:dns) pointed at public
+// resolvers, so it works the same regardless of the machine's local DNS setup.
+//
+// The unit is the ZONE, not the hostname. DNS host is a property of the zone
+// apex's NS records, so we WALK UP: query NS on the name; on ENODATA/NXDOMAIN
+// (e.g. `www` is just a CNAME in the parent zone) strip the leftmost label and
+// retry. The first label that returns NS records IS the zone apex — no Public
+// Suffix List needed, and it's robust to multi-label TLDs (.co.uk).
+
+import { Resolver } from "node:dns/promises"
+
+export interface ZoneHost {
+  apex: string // the zone apex the NS records live at (e.g. "example.com")
+  nameservers: string[] // authoritative NS hostnames, lowercased + sorted
+  providerKey: string // stable key for the host (e.g. "route53"); editable later: route53 | cloudflare
+  providerLabel: string // human label (e.g. "AWS Route 53")
+}
+
+// Query public resolvers so results don't depend on the local resolver / VPN.
+const PUBLIC_RESOLVERS = ["1.1.1.1", "8.8.8.8"]
+
+function makeResolver(): Resolver {
+  const r = new Resolver({ timeout: 5000, tries: 2 })
+  try {
+    r.setServers(PUBLIC_RESOLVERS)
+  } catch {
+    // Fall back to the system resolver if the servers can't be set.
+  }
+  return r
+}
+
+// Lowercase, drop a trailing dot and a leading "www." — `www` is never its own
+// zone, so collapsing it here means www + apex share one lookup and one cache key.
+export function normalizeDomain(domain: string): string {
+  return domain.trim().toLowerCase().replace(/\.$/, "").replace(/^www\./, "")
+}
+
+// The next zone candidate up. Returns null once only a single-label TLD remains
+// (so a dead/unregistered domain can't walk all the way up to the TLD's servers).
+function parentDomain(name: string): string | null {
+  const i = name.indexOf(".")
+  if (i === -1) return null
+  const parent = name.slice(i + 1)
+  return parent.includes(".") ? parent : null
+}
+
+// Resolve the authoritative DNS host for a domain's zone. Returns null when no NS
+// records can be found at or above the domain (unregistered, lookup failed, etc.).
+export async function resolveZone(input: string): Promise<ZoneHost | null> {
+  const start = normalizeDomain(input)
+  if (!start || !start.includes(".")) return null
+  const resolver = makeResolver()
+  let name: string | null = start
+  while (name && name.includes(".")) {
+    try {
+      const ns = await resolver.resolveNs(name)
+      if (ns && ns.length > 0) {
+        const nameservers = ns.map((n) => n.toLowerCase().replace(/\.$/, "")).sort()
+        const { key, label } = labelForNameservers(nameservers)
+        return { apex: name, nameservers, providerKey: key, providerLabel: label }
+      }
+    } catch {
+      // ENODATA / ENOTFOUND / timeout → the zone is higher up; try the parent.
+    }
+    name = parentDomain(name)
+  }
+  return null
+}
+
+interface ProviderEntry {
+  match: string // lowercase substring tested against each nameserver hostname
+  key: string
+  label: string
+}
+
+// Curated nameserver → host map for the common providers. `route53` and
+// `cloudflare` are the ones a later editing phase can write to; the rest are
+// label-only.
+//
+// PRINCIPLE: only curate a host when the NS pattern maps to ONE broadly-recognized
+// brand (Cloudflare, Route 53, GoDaddy…). For white-label / reseller platforms
+// where a single NS domain is resold under many brands (e.g. orderbox-dns.com →
+// ResellerClub / BigRock / …), DON'T curate — the fallback's nameserver-domain
+// label ("orderbox-dns.com") is the most honest, universal, and actionable signal.
+// A wrong brand label is worse than the raw domain. Extend with single-brand hosts.
+const PROVIDERS: ProviderEntry[] = [
+  { match: "awsdns", key: "route53", label: "AWS Route 53" },
+  { match: "cloudflare.com", key: "cloudflare", label: "Cloudflare" },
+  { match: "domaincontrol.com", key: "godaddy", label: "GoDaddy" },
+  { match: "registrar-servers.com", key: "namecheap", label: "Namecheap" },
+  { match: "nsone.net", key: "ns1", label: "NS1" },
+  { match: "dnsmadeeasy.com", key: "dnsme", label: "DNS Made Easy" },
+  { match: "digitalocean.com", key: "digitalocean", label: "DigitalOcean" },
+  { match: "ns-cloud-", key: "google", label: "Google Cloud DNS" },
+  { match: "googledomains.com", key: "google", label: "Google Domains" },
+  { match: "worldnic.com", key: "netsol", label: "Network Solutions" },
+  { match: "dreamhost.com", key: "dreamhost", label: "DreamHost" },
+  { match: "name-services.com", key: "enom", label: "eNom" },
+  { match: "azure-dns", key: "azure", label: "Azure DNS" },
+  { match: "wpengine.com", key: "wpengine", label: "WP Engine" },
+  { match: "linode.com", key: "linode", label: "Linode" },
+  { match: "vultr.com", key: "vultr", label: "Vultr" },
+]
+
+// Map a set of nameservers to a host label. Falls back to the registrable domain
+// of the nameserver itself (e.g. ns1.somehost.net → "somehost.net"), so even an
+// uncurated provider yields exactly the signal you'd write in an inventory.
+export function labelForNameservers(ns: string[]): { key: string; label: string } {
+  for (const host of ns) {
+    for (const p of PROVIDERS) {
+      if (host.includes(p.match)) return { key: p.key, label: p.label }
+    }
+  }
+  const reg = registrableOf(ns[0] ?? "")
+  return reg ? { key: reg, label: reg } : { key: "unknown", label: "Unknown" }
+}
+
+// Naive registrable domain (last two labels) — good enough for the fallback label
+// since nameserver hostnames are almost always provider.tld style.
+function registrableOf(host: string): string {
+  const parts = host.replace(/\.$/, "").split(".").filter(Boolean)
+  if (parts.length <= 2) return parts.join(".")
+  return parts.slice(-2).join(".")
+}

--- a/src/lib/dnsCache.ts
+++ b/src/lib/dnsCache.ts
@@ -1,0 +1,94 @@
+// Disk-backed cache for DNS zone-host lookups, keyed by normalized domain.
+//
+// Modeled on stackCache.ts (same hydrate-on-startup / write-through lifecycle).
+// DNS host rarely changes — except during the very migration you're using this
+// for — so entries are time-stamped: the UI shows the age and offers a refresh,
+// and a 24h staleness window keeps long-lived caches honest across launches.
+//
+// Keyed by the NORMALIZED domain (www-stripped, lowercased) rather than the zone
+// apex, so a lookup can hit the cache WITHOUT a network round-trip (we can't know
+// a domain's apex until we resolve it). www + apex share one key; a separate
+// subdomain that happens to share a zone just stores a duplicate entry — cheap.
+
+import { join } from "node:path"
+import { existsSync, readFileSync } from "node:fs"
+import { chmod, mkdir } from "node:fs/promises"
+import { configDir } from "../config.ts"
+import type { ZoneHost } from "./dns.ts"
+
+const CACHE_VERSION = 1
+const STALE_MS = 24 * 60 * 60 * 1000 // 24h
+
+export interface CachedDns {
+  zone: ZoneHost | null // null = looked up, no host found (unregistered / unresolvable)
+  checkedAt: number // epoch ms
+}
+
+interface CacheFile {
+  version: number
+  entries: Record<string, CachedDns> // key: normalized domain
+}
+
+export function dnsCachePath(): string {
+  return join(configDir(), "dns-cache.json")
+}
+
+export class DnsCache {
+  private entries = new Map<string, CachedDns>()
+  // Serializes writes so concurrent batch lookups can't tear the file.
+  private writeChain: Promise<void> = Promise.resolve()
+
+  // Read the cache file into memory. Never throws — a missing/corrupt file yields
+  // an empty cache.
+  load(): void {
+    try {
+      const path = dnsCachePath()
+      if (!existsSync(path)) return
+      const parsed = JSON.parse(readFileSync(path, "utf8")) as CacheFile
+      if (parsed?.version !== CACHE_VERSION || !parsed.entries) return
+      for (const [k, v] of Object.entries(parsed.entries)) {
+        if (k && v && typeof v.checkedAt === "number") this.entries.set(k, v)
+      }
+    } catch {
+      /* ignore corrupt/unreadable cache — start empty */
+    }
+  }
+
+  get(key: string): CachedDns | undefined {
+    return this.entries.get(key)
+  }
+
+  isStale(key: string): boolean {
+    const e = this.entries.get(key)
+    return e == null || Date.now() - e.checkedAt > STALE_MS
+  }
+
+  // Upsert a lookup result and persist immediately (write-through).
+  async set(key: string, zone: ZoneHost | null): Promise<void> {
+    this.entries.set(key, { zone, checkedAt: Date.now() })
+    await this.persist()
+  }
+
+  // A copy of all entries (for rendering without exposing the map).
+  snapshot(): Map<string, CachedDns> {
+    return new Map(this.entries)
+  }
+
+  private persist(): Promise<void> {
+    this.writeChain = this.writeChain.then(() => this.writeFile()).catch(() => {})
+    return this.writeChain
+  }
+
+  private async writeFile(): Promise<void> {
+    await mkdir(configDir(), { recursive: true })
+    const file: CacheFile = { version: CACHE_VERSION, entries: {} }
+    for (const [k, entry] of this.entries) file.entries[k] = entry
+    const path = dnsCachePath()
+    await Bun.write(path, JSON.stringify(file, null, 2) + "\n")
+    try {
+      await chmod(path, 0o600)
+    } catch {
+      /* best-effort on filesystems without POSIX perms */
+    }
+  }
+}

--- a/src/lib/open.ts
+++ b/src/lib/open.ts
@@ -11,6 +11,21 @@ export function openUrl(url: string): void {
   }
 }
 
+// Copy text to the system clipboard, cross-platform. Best-effort; never throws.
+// Used by the GoDaddy handoff so the domain is ready to paste after switching
+// into a delegated client account.
+export function copyToClipboard(text: string): void {
+  try {
+    const platform = process.platform
+    const cmd = platform === "darwin" ? ["pbcopy"] : platform === "win32" ? ["clip"] : ["xclip", "-selection", "clipboard"]
+    const proc = Bun.spawn(cmd, { stdin: "pipe", stdout: "ignore", stderr: "ignore" })
+    proc.stdin.write(text)
+    void proc.stdin.end()
+  } catch {
+    // ignore — clipboard is a convenience, not critical
+  }
+}
+
 // macOS has no registered "default terminal" role (unlike the default browser),
 // so we can't ask LaunchServices which terminal to use. The best proxy is
 // $TERM_PROGRAM — the terminal that launched this process sets it — which works

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -1,0 +1,275 @@
+// DNS provider access layer (Phase 2, read-only verification) — a small registry
+// so adding a provider is one entry, not edits across the app.
+//
+// Two namespaces meet here:
+//   - host providerKey (from dns.ts): who answers DNS live — route53 | cloudflare
+//     | godaddy | <fallback domain> …  (what the HOST column shows)
+//   - connection provider: who we can hold credentials for — see ConnProvider
+// apiProviderFor() bridges them via each descriptor's `hostKeys`.
+//
+// "Verify" = list the zones a credential can actually see (and, where the API
+// returns them for free, each zone's assigned nameservers). That data drives the
+// ACCESS column: a zone is editable only when a connected account of the SAME
+// provider that hosts it contains it — and, when nameservers are known, only when
+// they match the live authoritative NS (so a stale/duplicate zone doesn't count).
+
+import { awsGet } from "./awsSigV4.ts"
+
+export type ConnProvider = "aws" | "cloudflare" | "godaddy"
+
+// A stored credential for a provider. `creds` is a provider-specific bag (the
+// descriptor's `fields` define its keys); secrets live in config.json (0600).
+export interface Connection {
+  id: string
+  provider: ConnProvider
+  label: string
+  creds: Record<string, string>
+  env?: boolean // sourced from environment (read-only in the UI)
+}
+
+export interface VerifiedZone {
+  apex: string
+  account: string // account identifier/name as the provider reports it
+  nameservers: string[] // assigned NS (lowercased, sorted); [] when the API didn't return them
+}
+
+export interface VerifyResult {
+  ok: boolean
+  zones: VerifiedZone[]
+  accountLabel: string // a default connection label derived from the account(s) seen
+  error?: string
+}
+
+// A credential field rendered in the connect form (besides the always-present label).
+export interface ProviderField {
+  name: string // key in Connection.creds
+  label: string
+  secret?: boolean // render masked (SecretInput)
+  optional?: boolean
+  placeholder?: string
+}
+
+export interface ProviderDescriptor {
+  key: ConnProvider
+  name: string // e.g. "AWS (Route 53)"
+  hostKeys: string[] // dns.ts providerKeys that map to this connection provider
+  fields: ProviderField[]
+  guidance: string // help line under the form
+  // Optional web handoff for the "no API access" fallback (e.g. GoDaddy, whose API
+  // is gated to large accounts). When set, an unconnected zone shows `↗ web` instead
+  // of `○ needs key`, and the connect overlay offers `w` to open `console`.
+  console?: string
+  consoleLabel?: string // button/hint text for the handoff (default "web console")
+  // Longer in-overlay note shown when `console` is set — explains the assumed
+  // access model + the handoff flow.
+  accessNote?: string
+  verify: (creds: Record<string, string>) => Promise<VerifyResult>
+}
+
+function normApex(name: string): string {
+  return name.trim().toLowerCase().replace(/\.$/, "")
+}
+
+// Normalize a nameserver set for comparison: lowercase, drop trailing dots, sort.
+export function normNameservers(ns: string[] | undefined): string[] {
+  return (ns ?? []).map((s) => s.trim().toLowerCase().replace(/\.$/, "")).filter(Boolean).sort()
+}
+
+export function nameserversMatch(a: string[], b: string[]): boolean {
+  if (a.length === 0 || b.length === 0) return false
+  if (a.length !== b.length) return false
+  return a.every((v, i) => v === b[i])
+}
+
+// ---- Cloudflare ------------------------------------------------------------
+
+async function verifyCloudflare(creds: Record<string, string>): Promise<VerifyResult> {
+  const token = creds.token ?? ""
+  try {
+    const zones: VerifiedZone[] = []
+    const accounts = new Set<string>()
+    let page = 1
+    let totalPages = 1
+    do {
+      const res = await fetch(`https://api.cloudflare.com/client/v4/zones?per_page=50&page=${page}`, {
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      })
+      const json = (await res.json()) as {
+        success?: boolean
+        errors?: { message?: string }[]
+        result?: { name: string; name_servers?: string[]; account?: { name?: string } }[]
+        result_info?: { total_pages?: number }
+      }
+      if (!res.ok || !json.success) {
+        return { ok: false, zones: [], accountLabel: "", error: json?.errors?.[0]?.message || `HTTP ${res.status}` }
+      }
+      for (const z of json.result ?? []) {
+        zones.push({ apex: normApex(z.name), account: z.account?.name ?? "", nameservers: normNameservers(z.name_servers) })
+        if (z.account?.name) accounts.add(z.account.name)
+      }
+      totalPages = json.result_info?.total_pages ?? 1
+      page++
+    } while (page <= totalPages)
+    const accountLabel = accounts.size === 1 ? [...accounts][0] : accounts.size > 1 ? `${accounts.size} accounts` : "Cloudflare"
+    return { ok: true, zones, accountLabel }
+  } catch (err) {
+    return { ok: false, zones: [], accountLabel: "", error: (err as Error).message }
+  }
+}
+
+// ---- AWS Route 53 (hand-rolled SigV4) --------------------------------------
+
+function awsErrorMessage(xml: string): string | null {
+  return xml.match(/<Message>([^<]+)<\/Message>/)?.[1] ?? null
+}
+
+async function verifyAws(creds: Record<string, string>): Promise<VerifyResult> {
+  const aws = { accessKeyId: creds.accessKeyId ?? "", secretAccessKey: creds.secretAccessKey ?? "", region: creds.region || undefined }
+  try {
+    const sts = await awsGet(aws, "sts", "sts.amazonaws.com", "/", { Action: "GetCallerIdentity", Version: "2011-06-15" })
+    if (sts.status !== 200) {
+      return { ok: false, zones: [], accountLabel: "", error: awsErrorMessage(sts.body) || `STS HTTP ${sts.status}` }
+    }
+    const accountId = sts.body.match(/<Account>([^<]+)<\/Account>/)?.[1] ?? ""
+
+    // Route 53 ListHostedZones (paginate). We deliberately do NOT fetch each
+    // zone's nameservers (GetHostedZone is one call per zone and Route 53 caps at
+    // ~5 req/s — 27s+ for a large account). AWS zones therefore use membership-
+    // based access (provider-scoped); nameservers stay [] → NS-match falls back.
+    const zones: VerifiedZone[] = []
+    let marker: string | undefined
+    do {
+      const query: Record<string, string> = { maxitems: "100" }
+      if (marker) query.marker = marker
+      const r = await awsGet(aws, "route53", "route53.amazonaws.com", "/2013-04-01/hostedzone", query)
+      if (r.status !== 200) {
+        return { ok: false, zones: [], accountLabel: "", error: awsErrorMessage(r.body) || `Route 53 HTTP ${r.status}` }
+      }
+      for (const block of r.body.split(/<HostedZone>/).slice(1)) {
+        const name = block.match(/<Name>([^<]+)<\/Name>/)?.[1]
+        if (name) zones.push({ apex: normApex(name), account: accountId, nameservers: [] })
+      }
+      marker = /<IsTruncated>true<\/IsTruncated>/.test(r.body)
+        ? r.body.match(/<NextMarker>([^<]+)<\/NextMarker>/)?.[1]
+        : undefined
+    } while (marker)
+
+    return { ok: true, zones, accountLabel: accountId || "AWS" }
+  } catch (err) {
+    return { ok: false, zones: [], accountLabel: "", error: (err as Error).message }
+  }
+}
+
+// ---- GoDaddy (header auth, no signing) -------------------------------------
+
+async function verifyGodaddy(creds: Record<string, string>): Promise<VerifyResult> {
+  const key = creds.apiKey ?? ""
+  const secret = creds.apiSecret ?? ""
+  try {
+    const res = await fetch("https://api.godaddy.com/v1/domains?statuses=ACTIVE&limit=1000", {
+      headers: { Authorization: `sso-key ${key}:${secret}`, Accept: "application/json" },
+    })
+    if (!res.ok) {
+      // GoDaddy gates API access (≈20+ domains / reseller tiers); 403 means this
+      // account can't use the API — the zone stays a web-only (↗) handoff.
+      const body = (await res.json().catch(() => ({}))) as { message?: string }
+      const msg = res.status === 403 ? "This GoDaddy account has no API access (needs 20+ domains / reseller)." : body.message || `HTTP ${res.status}`
+      return { ok: false, zones: [], accountLabel: "", error: msg }
+    }
+    const list = (await res.json()) as { domain: string; nameServers?: string[] }[]
+    const zones: VerifiedZone[] = list.map((d) => ({
+      apex: normApex(d.domain),
+      account: "godaddy",
+      nameservers: normNameservers(d.nameServers),
+    }))
+    return { ok: true, zones, accountLabel: "GoDaddy" }
+  } catch (err) {
+    return { ok: false, zones: [], accountLabel: "", error: (err as Error).message }
+  }
+}
+
+// ---- Registry --------------------------------------------------------------
+
+export const PROVIDER_REGISTRY: Record<ConnProvider, ProviderDescriptor> = {
+  aws: {
+    key: "aws",
+    name: "AWS (Route 53)",
+    hostKeys: ["route53"],
+    fields: [
+      { name: "accessKeyId", label: "Access Key ID", placeholder: "AKIA…" },
+      { name: "secretAccessKey", label: "Secret Access Key", secret: true, placeholder: "secret" },
+      { name: "region", label: "Region (optional, default us-east-1)", optional: true, placeholder: "us-east-1" },
+    ],
+    guidance: "Use an IAM user scoped to route53:ListHostedZones + ListResourceRecordSets.",
+    verify: verifyAws,
+  },
+  cloudflare: {
+    key: "cloudflare",
+    name: "Cloudflare",
+    hostKeys: ["cloudflare"],
+    fields: [{ name: "token", label: "API token — Zone:Read is enough", secret: true, placeholder: "Cloudflare API token" }],
+    guidance: "Create one at dash.cloudflare.com → My Profile → API Tokens.",
+    verify: verifyCloudflare,
+  },
+  godaddy: {
+    key: "godaddy",
+    name: "GoDaddy",
+    hostKeys: ["godaddy"],
+    fields: [
+      { name: "apiKey", label: "API Key", placeholder: "key" },
+      { name: "apiSecret", label: "API Secret", secret: true, placeholder: "secret" },
+    ],
+    guidance:
+      "At developer.godaddy.com → Create New API Key, choose Environment = Production (NOT OTE/test). GoDaddy's API is only available to larger accounts (≈20+ domains / reseller); without it, use w for the Clients hub.",
+    console: "https://hub.godaddy.com/clients?view=table",
+    consoleLabel: "Clients hub",
+    accessNote:
+      "Spinup assumes you manage GoDaddy domains via Delegate Access from one main account. Press w to open your Clients hub (the domain is copied to your clipboard) → Login as the client → paste the domain → Exit access before checking the next.",
+    verify: verifyGodaddy,
+  },
+}
+
+export const ALL_PROVIDERS: ConnProvider[] = Object.keys(PROVIDER_REGISTRY) as ConnProvider[]
+
+// Map a live host providerKey to the connection provider we can authenticate as.
+export function apiProviderFor(hostKey: string): ConnProvider | null {
+  for (const d of Object.values(PROVIDER_REGISTRY)) if (d.hostKeys.includes(hostKey)) return d.key
+  return null
+}
+
+export function verifyConnection(conn: Connection): Promise<VerifyResult> {
+  return PROVIDER_REGISTRY[conn.provider].verify(conn.creds)
+}
+
+// Best-effort web-console deep links for hosts we can't (or don't yet) drive via
+// API — the `↗ web only` handoff. API providers normally resolve to editable/
+// needs-key before reaching here.
+export const PROVIDER_CONSOLE: Record<string, string> = {
+  namecheap: "https://ap.www.namecheap.com/domains/list",
+  dnsme: "https://dnsmadeeasy.com",
+  digitalocean: "https://cloud.digitalocean.com/networking/domains",
+  google: "https://domains.google.com/registrar",
+  netsol: "https://www.networksolutions.com/my-account",
+  dreamhost: "https://panel.dreamhost.com",
+  azure: "https://portal.azure.com",
+  linode: "https://cloud.linode.com/domains",
+  vultr: "https://my.vultr.com/dns/",
+}
+
+// The web handoff (URL + label) for a host, if any: an API provider's console
+// (e.g. GoDaddy's Clients hub), else a web-only host's console. null for hosts
+// managed purely via API (Route 53 / Cloudflare) or unrecognized fallbacks.
+export function consoleForHost(hostKey: string): { url: string; label: string } | null {
+  const prov = apiProviderFor(hostKey)
+  if (prov) {
+    const d = PROVIDER_REGISTRY[prov]
+    return d.console ? { url: d.console, label: d.consoleLabel ?? "web console" } : null
+  }
+  const url = PROVIDER_CONSOLE[hostKey]
+  return url ? { url, label: "web console" } : null
+}
+
+export type AccessState = "editable" | "needs-key" | "web" | "unknown"
+
+// NOTE: the access decision is computed in the store (accessForZone) — it has the
+// connection data — and is PROVIDER-SCOPED + NS-aware. See store.tsx.

--- a/src/lib/providersCache.ts
+++ b/src/lib/providersCache.ts
@@ -1,0 +1,88 @@
+// Disk cache of verified provider zone sets, keyed by connection id.
+//
+// Holds only the RESULT of verification (zone names + account labels + an age) —
+// NOT the credentials themselves (those live in config.json). Lets the ACCESS
+// column populate at startup without re-hitting every provider; a visible age +
+// a re-verify key keep it honest. Modeled on dnsCache.ts.
+
+import { join } from "node:path"
+import { existsSync, readFileSync } from "node:fs"
+import { chmod, mkdir } from "node:fs/promises"
+import { configDir } from "../config.ts"
+import type { VerifiedZone } from "./providers.ts"
+
+// v2: VerifiedZone gained `nameservers` + `account` (was accountId/accountName).
+// Old entries are dropped on load so connections re-verify with the new shape.
+const CACHE_VERSION = 2
+
+export interface VerifiedConn {
+  ok: boolean
+  zones: VerifiedZone[]
+  accountLabel: string
+  error?: string
+  verifiedAt: number // epoch ms
+}
+
+interface CacheFile {
+  version: number
+  entries: Record<string, VerifiedConn> // key: connection id
+}
+
+export function providersCachePath(): string {
+  return join(configDir(), "providers-cache.json")
+}
+
+export class ProvidersCache {
+  private entries = new Map<string, VerifiedConn>()
+  private writeChain: Promise<void> = Promise.resolve()
+
+  load(): void {
+    try {
+      const path = providersCachePath()
+      if (!existsSync(path)) return
+      const parsed = JSON.parse(readFileSync(path, "utf8")) as CacheFile
+      if (parsed?.version !== CACHE_VERSION || !parsed.entries) return
+      for (const [k, v] of Object.entries(parsed.entries)) {
+        if (k && v && typeof v.verifiedAt === "number") this.entries.set(k, v)
+      }
+    } catch {
+      /* ignore corrupt/unreadable cache — start empty */
+    }
+  }
+
+  get(id: string): VerifiedConn | undefined {
+    return this.entries.get(id)
+  }
+
+  snapshot(): Map<string, VerifiedConn> {
+    return new Map(this.entries)
+  }
+
+  async set(id: string, conn: VerifiedConn): Promise<void> {
+    this.entries.set(id, conn)
+    await this.persist()
+  }
+
+  async delete(id: string): Promise<void> {
+    if (!this.entries.delete(id)) return
+    await this.persist()
+  }
+
+  private persist(): Promise<void> {
+    this.writeChain = this.writeChain.then(() => this.writeFile()).catch(() => {})
+    return this.writeChain
+  }
+
+  private async writeFile(): Promise<void> {
+    await mkdir(configDir(), { recursive: true })
+    const file: CacheFile = { version: CACHE_VERSION, entries: {} }
+    for (const [k, entry] of this.entries) file.entries[k] = entry
+    const path = providersCachePath()
+    await Bun.write(path, JSON.stringify(file, null, 2) + "\n")
+    try {
+      await chmod(path, 0o600)
+    } catch {
+      /* best-effort */
+    }
+  }
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -20,6 +20,7 @@ import { LocalLinkOverlay } from "./views/LocalLink.tsx"
 import { Discover } from "./views/Discover.tsx"
 import { Forgotten } from "./views/Forgotten.tsx"
 import { DnsInventory } from "./views/DnsInventory.tsx"
+import { ProviderConnect } from "./views/ProviderConnect.tsx"
 
 const MIN_SPLASH_MS = 1200
 
@@ -47,7 +48,8 @@ export function App() {
     store.localLinkSite !== null ||
     store.discoverOpen ||
     store.forgottenOpen ||
-    store.dnsInventoryServer !== null
+    store.dnsInventoryServer !== null ||
+    store.connectZoneTarget !== null
   useEffect(() => {
     store.setOverlayOpen(overlayActive)
   }, [overlayActive, store])
@@ -88,6 +90,9 @@ export function App() {
 
     // The DNS inventory overlay owns the keyboard while open.
     if (store.dnsInventoryServer) return
+
+    // The provider-connect overlay owns the keyboard while open.
+    if (store.connectZoneTarget) return
 
     if (showHelp) {
       if (key.name === "escape" || key.name === "q" || key.name === "?") setShowHelp(false)
@@ -161,6 +166,7 @@ export function App() {
       {store.discoverOpen && <Discover />}
       {store.forgottenOpen && <Forgotten />}
       {store.dnsInventoryServer && <DnsInventory />}
+      {store.connectZoneTarget && <ProviderConnect />}
     </box>
   )
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -19,6 +19,7 @@ import { ServerActions } from "./views/ServerActions.tsx"
 import { LocalLinkOverlay } from "./views/LocalLink.tsx"
 import { Discover } from "./views/Discover.tsx"
 import { Forgotten } from "./views/Forgotten.tsx"
+import { DnsInventory } from "./views/DnsInventory.tsx"
 
 const MIN_SPLASH_MS = 1200
 
@@ -45,7 +46,8 @@ export function App() {
     store.serverActionsServer !== null ||
     store.localLinkSite !== null ||
     store.discoverOpen ||
-    store.forgottenOpen
+    store.forgottenOpen ||
+    store.dnsInventoryServer !== null
   useEffect(() => {
     store.setOverlayOpen(overlayActive)
   }, [overlayActive, store])
@@ -83,6 +85,9 @@ export function App() {
 
     // The "needs a local copy" report owns the keyboard while open.
     if (store.forgottenOpen) return
+
+    // The DNS inventory overlay owns the keyboard while open.
+    if (store.dnsInventoryServer) return
 
     if (showHelp) {
       if (key.name === "escape" || key.name === "q" || key.name === "?") setShowHelp(false)
@@ -155,6 +160,7 @@ export function App() {
       {store.localLinkSite && <LocalLinkOverlay />}
       {store.discoverOpen && <Discover />}
       {store.forgottenOpen && <Forgotten />}
+      {store.dnsInventoryServer && <DnsInventory />}
     </box>
   )
 }

--- a/src/ui/Details.tsx
+++ b/src/ui/Details.tsx
@@ -7,6 +7,7 @@ import { Field, StatusBadge } from "./components.tsx"
 import { classifyStack, stackColor } from "../lib/stack.ts"
 import { probeKindColor } from "../lib/probe.ts"
 import { resolveLocalLink } from "../lib/local.ts"
+import { normalizeDomain } from "../lib/dns.ts"
 import type { Drift } from "../lib/gitStatus.ts"
 import { useStore, isUpgradeInFlight, isServerOpInFlight } from "./store.tsx"
 import type { Server, Site } from "../api/types.ts"
@@ -121,6 +122,7 @@ export function SiteDetail({ site, serverName }: { site: Site; serverName: strin
       <Field label="User" value={site.site_user ?? "—"} />
       <Field label="Public dir" value={site.public_folder ?? "/"} />
       <Field label="Local" value={linkValue} valueColor={linkColor} />
+      <SiteDnsSection site={site} />
       <Field
         label="HTTPS"
         value={site.https?.enabled ? "enabled" : "disabled"}
@@ -157,6 +159,42 @@ export function SiteDetail({ site, serverName }: { site: Site; serverName: strin
       {site.git?.repo && <Field label="Git" value={`${truncate(site.git.repo, 26)} (${site.git.branch ?? "?"})`} />}
       {site.basic_auth?.enabled && <Field label="Basic auth" value="enabled" valueColor={theme.warn} />}
       <Field label="Created" value={formatDate(site.created_at)} />
+    </box>
+  )
+}
+
+// DNS zone-host lines for a site's domains, populated on demand (key `n`). Each
+// distinct zone (www + apex collapsed) shows its resolved host; a separate-TLD
+// additional domain surfaces as its own line with its own host. Read-only.
+function SiteDnsSection({ site }: { site: Site }) {
+  const { zoneForDomain, isDnsResolving } = useStore()
+  const seen = new Set<string>()
+  const domains = [site.domain, ...(site.additional_domains?.map((a) => a.domain) ?? [])].filter((d) => {
+    const k = normalizeDomain(d)
+    if (!k || seen.has(k)) return false
+    seen.add(k)
+    return true
+  })
+  const anyResolved = domains.some((d) => zoneForDomain(d))
+  const anyResolving = domains.some((d) => isDnsResolving(d))
+  if (!anyResolved && !anyResolving) {
+    return <Field label="DNS" value="not checked · n" valueColor={theme.textFaint} />
+  }
+  return (
+    <box style={{ flexDirection: "column" }}>
+      <text content="DNS" fg={theme.textDim} />
+      {domains.map((d) => {
+        const c = zoneForDomain(d)
+        const resolving = isDnsResolving(d) && !c
+        const host = resolving ? "looking up…" : !c ? "—" : c.zone === null ? "no host found" : c.zone.providerLabel
+        const color = resolving ? theme.textDim : !c ? theme.textFaint : c.zone === null ? theme.warn : theme.accent
+        return (
+          <box key={d} style={{ flexDirection: "row" }}>
+            <text content={"  " + truncate(d, 22)} fg={theme.text} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
+            <text content={host} fg={color} wrapMode="none" style={{ flexShrink: 0 }} />
+          </box>
+        )
+      })}
     </box>
   )
 }

--- a/src/ui/Help.tsx
+++ b/src/ui/Help.tsx
@@ -43,6 +43,13 @@ const SECTIONS: { title: string; keys: [string, string][] }[] = [
     ],
   },
   {
+    title: "DNS hosts",
+    keys: [
+      ["n", "Look up where the selected site's domains host DNS"],
+      ["N", "DNS zone-host inventory for the selected server"],
+    ],
+  },
+  {
     title: "Row markers",
     keys: [
       ["◆", "A local working copy is linked for this site"],

--- a/src/ui/Help.tsx
+++ b/src/ui/Help.tsx
@@ -47,6 +47,9 @@ const SECTIONS: { title: string; keys: [string, string][] }[] = [
     keys: [
       ["n", "Look up where the selected site's domains host DNS"],
       ["N", "DNS zone-host inventory for the selected server"],
+      ["c", "In the inventory: connect a provider / open its console for the zone"],
+      ["✓ ↗ ○ ·", "Access: editable · web only · needs key · unknown"],
+      ["GoDaddy", "Assumes Delegate Access from one main account: c → w opens your Clients hub (domain copied) → Login as client → paste → Exit access"],
     ],
   },
   {

--- a/src/ui/Onboarding.tsx
+++ b/src/ui/Onboarding.tsx
@@ -6,7 +6,7 @@
 
 import { useState } from "react"
 import { theme } from "../lib/theme.ts"
-import { Spinner } from "./components.tsx"
+import { Spinner, SecretInput } from "./components.tsx"
 import { SpinupWPClient } from "../api/client.ts"
 import { DEFAULT_BASE_URL, saveConfig, configPath } from "../config.ts"
 
@@ -61,17 +61,12 @@ export function Onboarding({ onComplete }: { onComplete: () => void }) {
         <box style={{ height: 1 }} />
 
         <text content="API Access Token" fg={theme.accent} />
-        <input
+        <SecretInput
           focused={phase !== "validating"}
           value={value}
           placeholder="paste your token here…"
-          onInput={setValue}
+          onChange={setValue}
           onSubmit={() => submit(value)}
-          style={{
-            backgroundColor: theme.bgAlt,
-            focusedBackgroundColor: theme.bgAlt,
-            textColor: theme.text,
-          }}
         />
         <box style={{ height: 1 }} />
 

--- a/src/ui/components.tsx
+++ b/src/ui/components.tsx
@@ -1,6 +1,7 @@
 // Small shared presentational components used across views.
 
-import { useEffect, useState, type ReactNode } from "react"
+import { useEffect, useRef, useState, type ReactNode } from "react"
+import { useKeyboard, usePaste } from "@opentui/react"
 import { theme, statusColor, statusDot } from "../lib/theme.ts"
 import { isUpgradeInFlight, type PhpUpgradeProgress } from "./store.tsx"
 
@@ -136,6 +137,67 @@ export function SiteMetaCell({ linked, updates, selected = false }: { linked: bo
     <box style={{ flexDirection: "row", flexShrink: 0 }}>
       <text content={linked ? "◆ " : "  "} fg={selected ? theme.text : theme.good} wrapMode="none" />
       {updates > 0 ? <text content={`↑${updates} `} fg={selected ? theme.text : theme.warn} wrapMode="none" /> : null}
+    </box>
+  )
+}
+
+// A masked text field for secrets/tokens. OpenTUI's <input> keeps its own editor
+// buffer and has no masking/password mode, so a controlled "show dots" value
+// fights that buffer (the secret flashes, then the field clears). Instead this
+// owns the value itself: it captures keypresses + paste while focused and renders
+// only dots — the secret is never drawn in cleartext. We deliberately do NOT use
+// <input> here. Editing is append/backspace at the end (paste-and-go for tokens).
+const MASK = "•"
+export function SecretInput({
+  value,
+  onChange,
+  focused,
+  placeholder,
+  onSubmit,
+}: {
+  value: string
+  onChange: (v: string) => void
+  focused?: boolean
+  placeholder?: string
+  onSubmit?: () => void
+}) {
+  // Mirror the value in a ref so a rapid burst of key events (or a paste split
+  // into per-char events) accumulates instead of each handler closing over a
+  // stale `value` and overwriting the last — we update the ref synchronously.
+  const valueRef = useRef(value)
+  valueRef.current = value
+  const setValue = (next: string) => {
+    valueRef.current = next
+    onChange(next)
+  }
+
+  useKeyboard((key) => {
+    if (!focused) return
+    const name = key.name ?? ""
+    if (name === "return" || name === "enter") return onSubmit?.()
+    if (name === "backspace" || name === "delete") return setValue(valueRef.current.slice(0, -1))
+    // Let the host overlay handle navigation/dismiss keys.
+    if (["up", "down", "left", "right", "tab", "escape"].includes(name)) return
+    if (key.ctrl || key.meta) return
+    // A single printable character — append it.
+    const seq: string = (key as { sequence?: string; raw?: string }).sequence ?? (key as { raw?: string }).raw ?? ""
+    if (seq.length === 1 && seq >= " ") setValue(valueRef.current + seq)
+  })
+
+  usePaste((event: { bytes?: Uint8Array }) => {
+    if (!focused) return
+    const text = event?.bytes ? new TextDecoder().decode(event.bytes) : ""
+    const cleaned = text.replace(/[\r\n]+/g, "") // tokens are one line; drop any newlines
+    if (cleaned) setValue(valueRef.current + cleaned)
+  })
+
+  const hasValue = value.length > 0
+  const content = hasValue
+    ? MASK.repeat(value.length) + (focused ? "▏" : "")
+    : (focused ? "▏ " : "") + (placeholder ?? "")
+  return (
+    <box style={{ height: 1, flexDirection: "row", backgroundColor: theme.bgAlt, paddingLeft: 1, paddingRight: 1 }}>
+      <text content={content} fg={hasValue ? theme.text : theme.textFaint} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
     </box>
   )
 }

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -5,7 +5,7 @@
 // truth keeps the splash screen, header, and views in sync, and lets any view
 // trigger a refresh.
 
-import { createContext, useContext, useCallback, useEffect, useRef, useState, type ReactNode } from "react"
+import { createContext, useContext, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
 import { SpinupWPClient, ApiError, type ServerService } from "../api/client.ts"
 import type { Server, Site, Event } from "../api/types.ts"
 import { loadConfig, saveConfig } from "../config.ts"
@@ -16,6 +16,20 @@ import { gitDrift, type Drift } from "../lib/gitStatus.ts"
 import { probeSite } from "../lib/probe.ts"
 import { resolveZone, normalizeDomain } from "../lib/dns.ts"
 import { DnsCache, type CachedDns } from "../lib/dnsCache.ts"
+import {
+  verifyConnection as verifyProviderConnection,
+  apiProviderFor,
+  nameserversMatch,
+  PROVIDER_CONSOLE,
+  PROVIDER_REGISTRY,
+  ALL_PROVIDERS,
+  type Connection,
+  type ConnProvider,
+  type VerifyResult,
+  type AccessState,
+} from "../lib/providers.ts"
+import { ProvidersCache, type VerifiedConn } from "../lib/providersCache.ts"
+import type { StoredProviders } from "../config.ts"
 import { fetchRebootInfo, type RebootInfo } from "../lib/ssh.ts"
 import { StackCache, siteSignature, type CachedProbe } from "../lib/stackCache.ts"
 import { resolvePhpEolDates, refreshPhpEolDates, isPhpEol as isPhpEolWith, offeredPhpVersions as offeredPhpVersionsWith, type PhpEolDates } from "../lib/phpEol.ts"
@@ -172,6 +186,27 @@ interface StoreValue extends DataState {
   // The server whose DNS-inventory overlay is open, or null. Set by site views.
   dnsInventoryServer: Server | null
   setDnsInventoryServer: (s: Server | null) => void
+  // DNS provider connections (Phase 2), keyed by provider — each is a credential
+  // ("account"). The overlay lists + manages them. `providerZones` holds each
+  // connection's last verified zone set (hydrated from disk). Secrets persist to
+  // config (chmod 600).
+  connections: Record<ConnProvider, Connection[]>
+  connectionsFor: (provider: ConnProvider) => Connection[]
+  connectionCount: number // total across all providers
+  providerZones: Map<string, VerifiedConn> // by connection id
+  // Add a connection: verify FIRST, persist + cache only on success; returns the
+  // verify result so the overlay can show zones or the error.
+  addConnection: (provider: ConnProvider, label: string, creds: Record<string, string>) => Promise<VerifyResult>
+  removeConnection: (id: string) => void // stored connections only (not env)
+  verifyConnectionById: (id: string) => void // re-verify + refresh cache
+  // Access state for a zone, from its live host, the live authoritative NS, and
+  // the verified zones we can reach. Provider-scoped + NS-aware (see store impl).
+  accessForZone: (apex: string, hostKey: string, liveNs: string[]) => AccessState
+  // The connection (account) label that owns/serves a zone, or "" if none.
+  accountForZone: (apex: string, hostKey: string, liveNs: string[]) => string
+  // The zone whose provider-connect overlay is open (apex + its host key), or null.
+  connectZoneTarget: { apex: string; hostKey: string } | null
+  setConnectZoneTarget: (t: { apex: string; hostKey: string } | null) => void
   // Whether a PHP version is past end-of-life (real dates vs today, refreshed).
   isPhpEol: (version: string | null | undefined) => boolean
   // PHP versions to offer in the upgrade picker (dynamic; current always included).
@@ -250,6 +285,17 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const [dnsZones, setDnsZones] = useState<Map<string, CachedDns>>(() => dnsCacheRef.current!.snapshot())
   const [dnsResolving, setDnsResolving] = useState<Set<string>>(new Set())
   const [dnsInventoryServer, setDnsInventoryServer] = useState<Server | null>(null)
+
+  // DNS provider connections (Phase 2). Connections hydrate from config (stored +
+  // env); their verified zone sets hydrate from disk and re-verify on demand.
+  const providersCacheRef = useRef<ProvidersCache | null>(null)
+  if (!providersCacheRef.current) {
+    providersCacheRef.current = new ProvidersCache()
+    providersCacheRef.current.load()
+  }
+  const [connections, setConnections] = useState<Record<ConnProvider, Connection[]>>(() => cfgRef.current.providerConnections)
+  const [providerZones, setProviderZones] = useState<Map<string, VerifiedConn>>(() => providersCacheRef.current!.snapshot())
+  const [connectZoneTarget, setConnectZoneTarget] = useState<{ apex: string; hostKey: string } | null>(null)
 
   // PHP EOL dates: embedded defaults overlaid with the last cached fetch; a
   // background refresh (endoflife.date) updates them when the cache is stale.
@@ -662,6 +708,152 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const zoneForDomain = useCallback((domain: string) => dnsZones.get(normalizeDomain(domain)), [dnsZones])
   const isDnsResolving = useCallback((domain: string) => dnsResolving.has(normalizeDomain(domain)), [dnsResolving])
 
+  // ---- DNS provider connections (Phase 2 access detection) -------------------
+
+  const genConnId = (provider: ConnProvider) =>
+    `${provider}-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`
+
+  const allConnections = useMemo(() => ALL_PROVIDERS.flatMap((p) => connections[p]), [connections])
+  const connectionsFor = useCallback((provider: ConnProvider) => connections[provider], [connections])
+
+  // Zones we can reach, keyed by `${provider}:${apex}` → list of candidate
+  // accounts (label + the account-zone's assigned nameservers). Provider-scoped:
+  // a Cloudflare-hosted zone is only reachable via a connected CLOUDFLARE account.
+  const reachable = useMemo(() => {
+    const m = new Map<string, { label: string; ns: string[] }[]>()
+    for (const conn of allConnections) {
+      const v = providerZones.get(conn.id)
+      if (v?.ok)
+        for (const z of v.zones) {
+          const key = `${conn.provider}:${z.apex}`
+          const list = m.get(key) ?? []
+          list.push({ label: conn.label || conn.id, ns: z.nameservers ?? [] })
+          m.set(key, list)
+        }
+    }
+    return m
+  }, [allConnections, providerZones])
+
+  // Pick the candidate account that actually SERVES a zone, using the live
+  // authoritative nameservers when the account's NS are known (catches stale /
+  // duplicate zones across accounts). When no NS are known (e.g. AWS), fall back
+  // to membership — provider-scoping already guarantees the right provider.
+  const matchedAccount = useCallback(
+    (apex: string, hostKey: string, liveNs: string[]): { editable: boolean; label: string } => {
+      const prov = apiProviderFor(hostKey)
+      if (!prov) return { editable: false, label: "" }
+      const candidates = reachable.get(`${prov}:${apex}`) ?? []
+      if (candidates.length === 0) return { editable: false, label: "" }
+      const withNs = candidates.filter((c) => c.ns.length > 0)
+      // If we know any candidate's NS, require a live match to count as editable.
+      if (withNs.length > 0 && liveNs.length > 0) {
+        const live = withNs.find((c) => nameserversMatch(c.ns, liveNs))
+        if (live) return { editable: true, label: live.label }
+        // Some candidates have NS but none serve the live zone → only editable if
+        // another candidate's NS are unknown (can't disprove it).
+        const unknown = candidates.find((c) => c.ns.length === 0)
+        return unknown ? { editable: true, label: unknown.label } : { editable: false, label: "" }
+      }
+      // No NS info to match on → membership (provider-scoped) is the best we have.
+      return { editable: true, label: candidates[0].label }
+    },
+    [reachable],
+  )
+
+  const accessForZone = useCallback(
+    (apex: string, hostKey: string, liveNs: string[]): AccessState => {
+      const prov = apiProviderFor(hostKey)
+      if (prov) {
+        if (matchedAccount(apex, hostKey, liveNs).editable) return "editable"
+        // Not reachable via API: providers with a console fallback (GoDaddy, whose
+        // API is gated) show `web`; others show `needs-key`.
+        return PROVIDER_REGISTRY[prov].console ? "web" : "needs-key"
+      }
+      if (PROVIDER_CONSOLE[hostKey]) return "web"
+      return "unknown"
+    },
+    [matchedAccount],
+  )
+
+  const accountForZone = useCallback(
+    (apex: string, hostKey: string, liveNs: string[]) => matchedAccount(apex, hostKey, liveNs).label,
+    [matchedAccount],
+  )
+
+  // Persist the stored (non-env) connections to config, keeping cfgRef in sync.
+  const persistConnections = useCallback((next: Record<ConnProvider, Connection[]>) => {
+    cfgRef.current.providerConnections = next
+    const providers: StoredProviders = {}
+    for (const p of ALL_PROVIDERS) {
+      providers[p] = next[p].filter((c) => !c.env).map((c) => ({ id: c.id, label: c.label, creds: c.creds }))
+    }
+    void saveConfig({ providers })
+  }, [])
+
+  // Verify a connection and write the result through to the cache.
+  const verifyAndCache = useCallback(async (conn: Connection): Promise<VerifyResult> => {
+    const res = await verifyProviderConnection(conn)
+    await providersCacheRef.current!.set(conn.id, {
+      ok: res.ok,
+      zones: res.zones,
+      accountLabel: res.accountLabel,
+      error: res.error,
+      verifiedAt: Date.now(),
+    })
+    setProviderZones(providersCacheRef.current!.snapshot())
+    return res
+  }, [])
+
+  const addConnection = useCallback(
+    async (provider: ConnProvider, label: string, creds: Record<string, string>): Promise<VerifyResult> => {
+      const trimmed: Record<string, string> = {}
+      for (const [k, v] of Object.entries(creds)) trimmed[k] = v.trim()
+      const conn: Connection = { id: genConnId(provider), provider, label: label.trim(), creds: trimmed }
+      const res = await verifyAndCache(conn)
+      if (!res.ok) {
+        // Don't keep a credential we couldn't verify; drop its cache entry.
+        await providersCacheRef.current!.delete(conn.id)
+        setProviderZones(providersCacheRef.current!.snapshot())
+        return res
+      }
+      conn.label = conn.label || res.accountLabel || provider
+      setConnections((prev) => {
+        const next = { ...prev, [provider]: [...prev[provider], conn] }
+        persistConnections(next)
+        return next
+      })
+      return res
+    },
+    [verifyAndCache, persistConnections],
+  )
+
+  const removeConnection = useCallback(
+    (id: string) => {
+      setConnections((prev) => {
+        let changed = false
+        const next = {} as Record<ConnProvider, Connection[]>
+        for (const p of ALL_PROVIDERS) {
+          const filtered = prev[p].filter((c) => c.id !== id || c.env) // env can't be removed
+          if (filtered.length !== prev[p].length) changed = true
+          next[p] = filtered
+        }
+        if (!changed) return prev
+        persistConnections(next)
+        void providersCacheRef.current!.delete(id).then(() => setProviderZones(providersCacheRef.current!.snapshot()))
+        return next
+      })
+    },
+    [persistConnections],
+  )
+
+  const verifyConnectionById = useCallback(
+    (id: string) => {
+      const conn = allConnections.find((c) => c.id === id)
+      if (conn) void verifyAndCache(conn)
+    },
+    [allConnections, verifyAndCache],
+  )
+
   const value: StoreValue = {
     servers,
     sites,
@@ -732,6 +924,17 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     isDnsResolving,
     dnsInventoryServer,
     setDnsInventoryServer,
+    connections,
+    connectionsFor,
+    connectionCount: allConnections.length,
+    providerZones,
+    addConnection,
+    removeConnection,
+    verifyConnectionById,
+    accessForZone,
+    accountForZone,
+    connectZoneTarget,
+    setConnectZoneTarget,
     isPhpEol,
     offeredPhpVersions,
   }

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -14,6 +14,8 @@ import type { Stack } from "../lib/stack.ts"
 import { openTerminalAt, openUrl, openSshSession } from "../lib/open.ts"
 import { gitDrift, type Drift } from "../lib/gitStatus.ts"
 import { probeSite } from "../lib/probe.ts"
+import { resolveZone, normalizeDomain } from "../lib/dns.ts"
+import { DnsCache, type CachedDns } from "../lib/dnsCache.ts"
 import { fetchRebootInfo, type RebootInfo } from "../lib/ssh.ts"
 import { StackCache, siteSignature, type CachedProbe } from "../lib/stackCache.ts"
 import { resolvePhpEolDates, refreshPhpEolDates, isPhpEol as isPhpEolWith, offeredPhpVersions as offeredPhpVersionsWith, type PhpEolDates } from "../lib/phpEol.ts"
@@ -157,6 +159,19 @@ interface StoreValue extends DataState {
   runProbeMany: (sites: Site[]) => void
   // Whether a cached probe for this site is stale (site shape changed since).
   isProbeStale: (site: Site) => boolean
+  // DNS zone-host lookups (read-only). Hydrated from disk at startup; resolved
+  // lazily on demand (never auto-fired on selection — network cost).
+  dnsZones: Map<string, CachedDns> // by normalized domain (www-stripped, lowercased)
+  dnsResolving: Set<string> // normalized domains with an in-flight lookup
+  // Resolve every domain of a site / of all sites on a server (bounded conc).
+  lookupSiteDns: (site: Site, force?: boolean) => void
+  lookupServerDns: (serverId: number, force?: boolean) => void
+  // The cached zone-host for a domain (undefined = never looked up).
+  zoneForDomain: (domain: string) => CachedDns | undefined
+  isDnsResolving: (domain: string) => boolean
+  // The server whose DNS-inventory overlay is open, or null. Set by site views.
+  dnsInventoryServer: Server | null
+  setDnsInventoryServer: (s: Server | null) => void
   // Whether a PHP version is past end-of-life (real dates vs today, refreshed).
   isPhpEol: (version: string | null | undefined) => boolean
   // PHP versions to offer in the upgrade picker (dynamic; current always included).
@@ -222,6 +237,19 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const [probes, setProbes] = useState<Map<number, CachedProbe>>(() => cacheRef.current!.snapshot())
   const [probingIds, setProbingIds] = useState<Set<number>>(new Set())
   const [probeErrors, setProbeErrors] = useState<Map<number, string>>(new Map())
+
+  // DNS zone-host cache: hydrate from disk once (no network at startup); lookups
+  // run lazily on demand and write through to disk. `dnsInFlight` is a ref so the
+  // lookup actions can dedupe concurrent requests without re-rendering.
+  const dnsCacheRef = useRef<DnsCache | null>(null)
+  if (!dnsCacheRef.current) {
+    dnsCacheRef.current = new DnsCache()
+    dnsCacheRef.current.load()
+  }
+  const dnsInFlight = useRef<Set<string>>(new Set())
+  const [dnsZones, setDnsZones] = useState<Map<string, CachedDns>>(() => dnsCacheRef.current!.snapshot())
+  const [dnsResolving, setDnsResolving] = useState<Set<string>>(new Set())
+  const [dnsInventoryServer, setDnsInventoryServer] = useState<Server | null>(null)
 
   // PHP EOL dates: embedded defaults overlaid with the last cached fetch; a
   // background refresh (endoflife.date) updates them when the cache is stale.
@@ -570,6 +598,70 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     void gitDrift(linkPath).then((d) => setDrift((prev) => new Map(prev).set(siteId, d)))
   }, [])
 
+  // ---- DNS zone-host lookups -------------------------------------------------
+
+  // Resolve one domain's zone host (cache first). Concurrency-safe — the ref-based
+  // in-flight set dedupes, and a fresh cache entry short-circuits unless forced.
+  const dnsResolveOne = useCallback(async (domain: string, force: boolean) => {
+    const cache = dnsCacheRef.current!
+    const key = normalizeDomain(domain)
+    if (!key || dnsInFlight.current.has(key)) return
+    if (!force && !cache.isStale(key)) return
+    dnsInFlight.current.add(key)
+    setDnsResolving((prev) => new Set(prev).add(key))
+    try {
+      const zone = await resolveZone(key)
+      await cache.set(key, zone)
+      setDnsZones(cache.snapshot())
+    } finally {
+      dnsInFlight.current.delete(key)
+      setDnsResolving((prev) => {
+        const next = new Set(prev)
+        next.delete(key)
+        return next
+      })
+    }
+  }, [])
+
+  // Resolve many domains with a bounded pool (skips fresh/in-flight unless forced).
+  const dnsLookupMany = useCallback(
+    (domains: string[], force = false) => {
+      const cache = dnsCacheRef.current!
+      const keys = Array.from(new Set(domains.map(normalizeDomain).filter(Boolean)))
+      const queue = keys.filter((k) => !dnsInFlight.current.has(k) && (force || cache.isStale(k)))
+      if (queue.length === 0) return
+      const CONCURRENCY = 5
+      let cursor = 0
+      const worker = async () => {
+        while (cursor < queue.length) await dnsResolveOne(queue[cursor++], force)
+      }
+      for (let i = 0; i < Math.min(CONCURRENCY, queue.length); i++) void worker()
+    },
+    [dnsResolveOne],
+  )
+
+  const domainsForSite = (site: Site): string[] => [
+    site.domain,
+    ...(site.additional_domains?.map((a) => a.domain) ?? []),
+  ]
+
+  const lookupSiteDns = useCallback(
+    (site: Site, force = false) => dnsLookupMany(domainsForSite(site), force),
+    [dnsLookupMany],
+  )
+
+  const lookupServerDns = useCallback(
+    (serverId: number, force = false) => {
+      const domains: string[] = []
+      for (const s of sites) if (s.server_id === serverId) domains.push(...domainsForSite(s))
+      dnsLookupMany(domains, force)
+    },
+    [dnsLookupMany, sites],
+  )
+
+  const zoneForDomain = useCallback((domain: string) => dnsZones.get(normalizeDomain(domain)), [dnsZones])
+  const isDnsResolving = useCallback((domain: string) => dnsResolving.has(normalizeDomain(domain)), [dnsResolving])
+
   const value: StoreValue = {
     servers,
     sites,
@@ -632,6 +724,14 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     runProbe,
     runProbeMany,
     isProbeStale,
+    dnsZones,
+    dnsResolving,
+    lookupSiteDns,
+    lookupServerDns,
+    zoneForDomain,
+    isDnsResolving,
+    dnsInventoryServer,
+    setDnsInventoryServer,
     isPhpEol,
     offeredPhpVersions,
   }

--- a/src/ui/views/Browser.tsx
+++ b/src/ui/views/Browser.tsx
@@ -22,7 +22,7 @@ type Focus = "servers" | "sites"
 
 export function Browser({ rows }: { rows: number }) {
   const store = useStore()
-  const { servers, sitesForServer, route, inputMode, overlayOpen, setHealthServer, runProbe, accountSlug, setPhpUpgradeSite, phpUpgrades, setServerActionsServer, serverOps, setLocalLinkSite, openLocalTerminal, openLocalUrl, localLinks, sshSite } = store
+  const { servers, sitesForServer, route, inputMode, overlayOpen, setHealthServer, runProbe, accountSlug, setPhpUpgradeSite, phpUpgrades, setServerActionsServer, serverOps, setLocalLinkSite, openLocalTerminal, openLocalUrl, localLinks, sshSite, lookupSiteDns, setDnsInventoryServer } = store
 
   const [serverIndex, setServerIndex] = useState(0)
   const [siteIndex, setSiteIndex] = useState(0)
@@ -126,6 +126,19 @@ export function Browser({ rows }: { rows: number }) {
           setTimeout(() => setFlash(null), 2000)
         }
         return
+      case "n":
+        // Look up where the selected site's domains host DNS (shows in Details).
+        if (focus === "sites" && sites[siteIndex]) {
+          const s = sites[siteIndex]
+          lookupSiteDns(s)
+          setFlash(`Looking up DNS hosts for ${s.domain}…`)
+          setTimeout(() => setFlash(null), 1500)
+        }
+        return
+      case "N":
+        // Server-wide DNS zone-host inventory (server-scoped, both panes).
+        if (server) setDnsInventoryServer(server)
+        return
       case "a":
         // Server actions (reboot / restart) are server-scoped, so only offered
         // when the Servers pane is focused — when you've drilled into a site,
@@ -160,6 +173,7 @@ export function Browser({ rows }: { rows: number }) {
           { key: "↑↓/jk", label: "select" },
           { key: "→/⏎", label: "view sites" },
           { key: "a", label: "server actions" },
+          { key: "N", label: "DNS hosts" },
           { key: "h", label: "health" },
           { key: "w", label: "SpinupWP" },
         ]
@@ -167,9 +181,9 @@ export function Browser({ rows }: { rows: number }) {
           { key: "↑↓/jk", label: "select site" },
           { key: "←/esc", label: "back" },
           { key: "d", label: "identify app" },
+          { key: "n", label: "DNS host" },
           { key: "u", label: "change PHP" },
           { key: "o", label: "open" },
-          { key: "w", label: "SpinupWP" },
           { key: "s", label: "ssh" },
           { key: "h", label: "health" },
         ]

--- a/src/ui/views/DnsInventory.tsx
+++ b/src/ui/views/DnsInventory.tsx
@@ -12,40 +12,78 @@ import { useKeyboard, useTerminalDimensions } from "@opentui/react"
 import { theme, statusColor, statusDot } from "../../lib/theme.ts"
 import { truncate, timeAgo } from "../../lib/format.ts"
 import { normalizeDomain } from "../../lib/dns.ts"
+import { apiProviderFor, consoleForHost, type AccessState } from "../../lib/providers.ts"
+import { openUrl, copyToClipboard } from "../../lib/open.ts"
 import { List, moveSelection } from "../List.tsx"
 import { StatusBar } from "../StatusBar.tsx"
 import { Spinner } from "../components.tsx"
 import { useStore } from "../store.tsx"
 import type { Site } from "../../api/types.ts"
 
-// Fixed column widths (chars) so SITE/ZONE/HOST align on every row; NOTE flexes
-// to fill the remainder. Each cell truncates to width-1 for a 1-space gutter.
+// Fixed column widths (chars) so SITE/ZONE/HOST/ACCESS align on every row; NOTE
+// flexes to fill the remainder. Each cell truncates to width-1 for a 1-space gutter.
 const SITE_W = 38
 const ZONE_W = 44
 const HOST_W = 18
+const ACCESS_W = 8
+const ACCOUNT_W = 18
+
+// Glyph + color for an access state (Phase 2). `·` is the resting/unknown state.
+function accessGlyph(state: AccessState, selected: boolean): { glyph: string; color: string } {
+  switch (state) {
+    case "editable":
+      return { glyph: "✓", color: selected ? theme.text : theme.good }
+    case "web":
+      return { glyph: "↗", color: selected ? theme.text : theme.accent }
+    case "needs-key":
+      return { glyph: "○", color: selected ? theme.text : theme.warn }
+    default:
+      return { glyph: "·", color: selected ? theme.text : theme.textFaint }
+  }
+}
 
 interface ZoneRow {
   siteDomain: string // owning site (primary domain)
   showSite: boolean // first zone row for this site (others blank the column)
   status: string // owning site status (for the leading dot)
   zone: string // zone apex (or normalized domain when unresolved)
+  hostKey: string // provider key from DNS detection (drives access + the `c` action)
   host: string // provider label, or a lookup-state string
   hostColor: string
+  access: AccessState // editable | needs-key | web | unknown
+  account: string // owning connection/account label (editable zones only)
   note: string // e.g. "→ redirects to example.com"
   checkedAt: number | null // age of the cached lookup, null when not yet known
 }
 
 export function DnsInventory() {
-  const { dnsInventoryServer, setDnsInventoryServer, sitesForServer, zoneForDomain, lookupServerDns, dnsZones, dnsResolving } =
+  const { dnsInventoryServer, setDnsInventoryServer, sitesForServer, zoneForDomain, lookupServerDns, dnsZones, dnsResolving, accessForZone, accountForZone, setConnectZoneTarget, connectZoneTarget, connections, connectionCount, providerZones, verifyConnectionById } =
     useStore()
+  const allConnections = useMemo(() => Object.values(connections).flat(), [connections])
+  // Show the ACCOUNT column only when more than one account is connected (else
+  // it's the same label on every editable row — just noise).
+  const showAccount = connectionCount >= 2
   const { height } = useTerminalDimensions()
   const [index, setIndex] = useState(0)
+  const [flash, setFlash] = useState<string | null>(null)
   const server = dnsInventoryServer
 
   // Kick off resolution for any un-cached domains when the overlay opens.
   useEffect(() => {
     if (server) lookupServerDns(server.id)
   }, [server, lookupServerDns])
+
+  // Verify any configured-but-not-yet-verified connections so `✓` access appears
+  // without a manual re-verify (e.g. connections from a prior session or env).
+  // Cached ones are left alone; re-verify is on demand (connect overlay `v`).
+  useEffect(() => {
+    for (const c of allConnections) {
+      if (!providerZones.has(c.id)) verifyConnectionById(c.id)
+    }
+    // providerZones intentionally omitted: verify once per connection, not on each
+    // cache update (which would re-fire mid-flight).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [allConnections, verifyConnectionById])
 
   const sites = useMemo<Site[]>(
     () => (server ? [...sitesForServer(server.id)].sort((a, b) => a.domain.localeCompare(b.domain)) : []),
@@ -86,6 +124,8 @@ export function DnsInventory() {
         const resolving = g.entries.some((e) => dnsResolving.has(normalizeDomain(e.domain)))
         let host: string
         let hostColor: string
+        const hostKey = cached?.zone?.providerKey ?? ""
+        const liveNs = cached?.zone?.nameservers ?? []
         if (cached === undefined) {
           host = resolving ? "looking up…" : "—"
           hostColor = resolving ? theme.textDim : theme.textFaint
@@ -108,8 +148,11 @@ export function DnsInventory() {
           showSite: idx === 0,
           status: site.status,
           zone: g.apex,
+          hostKey,
           host,
           hostColor,
+          access: accessForZone(g.apex, hostKey, liveNs),
+          account: accountForZone(g.apex, hostKey, liveNs),
           note,
           checkedAt: cached?.checkedAt ?? null,
         })
@@ -121,12 +164,13 @@ export function DnsInventory() {
     if (pending > 0) parts.push(`${pending} resolving`)
     const summary = `${total} zone${total === 1 ? "" : "s"}${parts.length ? " · " + parts.join(" · ") : ""}`
     return { rows: out, summary, resolvedZones: resolved, totalZones: total }
-  }, [sites, dnsZones, dnsResolving, zoneForDomain])
+  }, [sites, dnsZones, dnsResolving, zoneForDomain, accessForZone, accountForZone])
 
   const safeIndex = Math.min(index, Math.max(0, rows.length - 1))
   const close = () => setDnsInventoryServer(null)
 
   useKeyboard((key) => {
+    if (connectZoneTarget) return // the connect overlay (on top) owns the keyboard
     const raw = key.name ?? ""
     const name = key.shift && raw.length === 1 ? raw.toUpperCase() : raw
     switch (name) {
@@ -142,11 +186,44 @@ export function DnsInventory() {
       case "r":
         if (server) lookupServerDns(server.id, true)
         return
+      case "c": {
+        // Manage access for the selected zone: connect an API provider, or open
+        // the web console for a host we can't drive via API.
+        const r = rows[safeIndex]
+        if (!r) return
+        if (apiProviderFor(r.hostKey)) setConnectZoneTarget({ apex: r.zone, hostKey: r.hostKey })
+        else openWeb(r)
+        return
+      }
+      case "w": {
+        // Quick web handoff for the selected zone (e.g. GoDaddy Clients hub),
+        // copying the domain so it's ready to paste — no overlay round-trip.
+        const r = rows[safeIndex]
+        if (r) openWeb(r)
+        return
+      }
     }
   })
 
+  function openWeb(r: ZoneRow) {
+    const con = consoleForHost(r.hostKey)
+    if (con) {
+      copyToClipboard(r.zone)
+      openUrl(con.url)
+      showFlash(`${con.label} opened · ${r.zone} copied`)
+    } else {
+      showFlash("No web console for this host — c to manage access")
+    }
+  }
+
+  function showFlash(msg: string) {
+    if (!msg) return
+    setFlash(msg)
+    setTimeout(() => setFlash(null), 2000)
+  }
+
   if (!server) return null
-  const listRows = Math.max(3, height - 6)
+  const listRows = Math.max(3, height - 7)
   const oldest = rows.reduce<number | null>((min, r) => (r.checkedAt && (min === null || r.checkedAt < min) ? r.checkedAt : min), null)
 
   return (
@@ -158,13 +235,25 @@ export function DnsInventory() {
         {resolvedZones < totalZones ? <Spinner color={theme.brand} interval={120} /> : null}
       </box>
 
-      {/* Column header — fixed widths so SITE/ZONE/HOST line up on every row; the
-          leading "  " matches the status-dot cell. NOTE (last) flexes to fill. */}
+      {/* Column header — fixed widths so SITE/ZONE/HOST/ACCESS line up on every row;
+          the leading "  " matches the status-dot cell. NOTE (last) flexes to fill. */}
       <box style={{ flexDirection: "row", paddingLeft: 1, paddingRight: 1, height: 1 }}>
         <text content={"  " + "SITE".padEnd(SITE_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
         <text content={"ZONE".padEnd(ZONE_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
         <text content={"HOST".padEnd(HOST_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content={"ACCESS".padEnd(ACCESS_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
+        {showAccount ? <text content={"ACCOUNT".padEnd(ACCOUNT_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} /> : null}
         <text content="NOTE" fg={theme.textFaint} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
+      </box>
+
+      {/* Access legend — teaches the glyphs + the c action in-context. */}
+      <box style={{ flexDirection: "row", paddingLeft: 1, paddingRight: 1, height: 1 }}>
+        <text content="ACCESS  " fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content="✓ editable" fg={theme.good} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content="   ↗ web only" fg={theme.accent} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content="   ○ needs key" fg={theme.warn} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content="   · unknown" fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content="    c manage access" fg={theme.textDim} wrapMode="none" style={{ flexShrink: 1 }} />
       </box>
 
       <box style={{ flexGrow: 1, flexDirection: "column", paddingLeft: 1, paddingRight: 1 }}>
@@ -178,15 +267,20 @@ export function DnsInventory() {
             focused
             keyFor={(_r, i) => i}
             emptyText="—"
-            renderRow={(r, selected) => (
-              <>
-                <text content={r.showSite ? statusDot(r.status) + " " : "  "} fg={statusColor(r.status)} style={{ flexShrink: 0 }} />
-                <text content={(r.showSite ? truncate(r.siteDomain, SITE_W - 1) : "").padEnd(SITE_W)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} />
-                <text content={truncate(r.zone, ZONE_W - 1).padEnd(ZONE_W)} fg={theme.text} wrapMode="none" style={{ flexShrink: 0 }} />
-                <text content={truncate(r.host, HOST_W - 1).padEnd(HOST_W)} fg={selected ? theme.text : r.hostColor} wrapMode="none" style={{ flexShrink: 0 }} />
-                <text content={r.note} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
-              </>
-            )}
+            renderRow={(r, selected) => {
+              const acc = accessGlyph(r.access, selected)
+              return (
+                <>
+                  <text content={r.showSite ? statusDot(r.status) + " " : "  "} fg={statusColor(r.status)} style={{ flexShrink: 0 }} />
+                  <text content={(r.showSite ? truncate(r.siteDomain, SITE_W - 1) : "").padEnd(SITE_W)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} />
+                  <text content={truncate(r.zone, ZONE_W - 1).padEnd(ZONE_W)} fg={theme.text} wrapMode="none" style={{ flexShrink: 0 }} />
+                  <text content={truncate(r.host, HOST_W - 1).padEnd(HOST_W)} fg={selected ? theme.text : r.hostColor} wrapMode="none" style={{ flexShrink: 0 }} />
+                  <text content={(acc.glyph + " ").padEnd(ACCESS_W)} fg={acc.color} wrapMode="none" style={{ flexShrink: 0 }} />
+                  {showAccount ? <text content={truncate(r.account, ACCOUNT_W - 1).padEnd(ACCOUNT_W)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} /> : null}
+                  <text content={r.note} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
+                </>
+              )
+            }}
           />
         )}
       </box>
@@ -194,11 +288,13 @@ export function DnsInventory() {
       <StatusBar
         hints={[
           { key: "↑↓/jk", label: "scroll" },
+          { key: "c", label: "manage access" },
+          { key: "w", label: "web console" },
           { key: "r", label: "refresh lookups" },
           { key: "esc", label: "close" },
         ]}
-        message={oldest ? `checked ${timeAgo(new Date(oldest).toISOString())}` : undefined}
-        messageColor={theme.textFaint}
+        message={flash ?? (oldest ? `checked ${timeAgo(new Date(oldest).toISOString())}` : undefined)}
+        messageColor={flash ? theme.brand : theme.textFaint}
         showGlobal={false}
       />
     </box>

--- a/src/ui/views/DnsInventory.tsx
+++ b/src/ui/views/DnsInventory.tsx
@@ -1,0 +1,206 @@
+// DNS zone-host inventory for a server — the read-only first slice of the DNS
+// module. Answers "where is every domain on this server's DNS hosted?", the
+// inventory you build by hand when migrating or cloning a site.
+//
+// The unit is the ZONE, not the hostname: www + apex collapse into one row, and a
+// separate-TLD additional domain (e.g. example.net redirecting to example.com)
+// surfaces as its OWN zone with its OWN host — because a full move must carry the
+// whole portfolio, and those can live on a different provider. Opened with `N`.
+
+import { useEffect, useMemo, useState } from "react"
+import { useKeyboard, useTerminalDimensions } from "@opentui/react"
+import { theme, statusColor, statusDot } from "../../lib/theme.ts"
+import { truncate, timeAgo } from "../../lib/format.ts"
+import { normalizeDomain } from "../../lib/dns.ts"
+import { List, moveSelection } from "../List.tsx"
+import { StatusBar } from "../StatusBar.tsx"
+import { Spinner } from "../components.tsx"
+import { useStore } from "../store.tsx"
+import type { Site } from "../../api/types.ts"
+
+// Fixed column widths (chars) so SITE/ZONE/HOST align on every row; NOTE flexes
+// to fill the remainder. Each cell truncates to width-1 for a 1-space gutter.
+const SITE_W = 38
+const ZONE_W = 44
+const HOST_W = 18
+
+interface ZoneRow {
+  siteDomain: string // owning site (primary domain)
+  showSite: boolean // first zone row for this site (others blank the column)
+  status: string // owning site status (for the leading dot)
+  zone: string // zone apex (or normalized domain when unresolved)
+  host: string // provider label, or a lookup-state string
+  hostColor: string
+  note: string // e.g. "→ redirects to example.com"
+  checkedAt: number | null // age of the cached lookup, null when not yet known
+}
+
+export function DnsInventory() {
+  const { dnsInventoryServer, setDnsInventoryServer, sitesForServer, zoneForDomain, lookupServerDns, dnsZones, dnsResolving } =
+    useStore()
+  const { height } = useTerminalDimensions()
+  const [index, setIndex] = useState(0)
+  const server = dnsInventoryServer
+
+  // Kick off resolution for any un-cached domains when the overlay opens.
+  useEffect(() => {
+    if (server) lookupServerDns(server.id)
+  }, [server, lookupServerDns])
+
+  const sites = useMemo<Site[]>(
+    () => (server ? [...sitesForServer(server.id)].sort((a, b) => a.domain.localeCompare(b.domain)) : []),
+    [server, sitesForServer],
+  )
+
+  // Build the zone-keyed rows. Recomputes as lookups land (dnsZones changes).
+  const { rows, summary, resolvedZones, totalZones } = useMemo(() => {
+    const out: ZoneRow[] = []
+    const tally = new Map<string, number>() // host label → zone count
+    let total = 0
+    let resolved = 0
+
+    for (const site of sites) {
+      const entries = [
+        { domain: site.domain, redirect: undefined as { enabled: boolean; destination: string } | undefined },
+        ...(site.additional_domains?.map((a) => ({ domain: a.domain, redirect: a.redirect })) ?? []),
+      ]
+      const primaryApex = zoneForDomain(site.domain)?.zone?.apex ?? normalizeDomain(site.domain)
+
+      // Group the site's domains by zone apex.
+      const groups = new Map<string, { apex: string; entries: typeof entries }>()
+      for (const e of entries) {
+        const apex = zoneForDomain(e.domain)?.zone?.apex ?? normalizeDomain(e.domain)
+        const g = groups.get(apex) ?? { apex, entries: [] }
+        g.entries.push(e)
+        groups.set(apex, g)
+      }
+
+      // Primary zone first, then alphabetical.
+      const ordered = [...groups.values()].sort((a, b) =>
+        a.apex === primaryApex ? -1 : b.apex === primaryApex ? 1 : a.apex.localeCompare(b.apex),
+      )
+
+      ordered.forEach((g, idx) => {
+        total++
+        const cached = zoneForDomain(g.entries[0].domain)
+        const resolving = g.entries.some((e) => dnsResolving.has(normalizeDomain(e.domain)))
+        let host: string
+        let hostColor: string
+        if (cached === undefined) {
+          host = resolving ? "looking up…" : "—"
+          hostColor = resolving ? theme.textDim : theme.textFaint
+        } else if (cached.zone === null) {
+          host = "no host found"
+          hostColor = theme.warn
+          resolved++
+        } else {
+          host = cached.zone.providerLabel
+          hostColor = theme.accent
+          resolved++
+          tally.set(host, (tally.get(host) ?? 0) + 1)
+        }
+        // A note only when this zone is NOT the canonical one and redirects away.
+        const isPrimaryZone = g.apex === primaryApex
+        const redirect = g.entries.find((e) => e.redirect?.enabled)?.redirect
+        const note = !isPrimaryZone && redirect ? `→ redirects to ${redirect.destination}` : ""
+        out.push({
+          siteDomain: site.domain,
+          showSite: idx === 0,
+          status: site.status,
+          zone: g.apex,
+          host,
+          hostColor,
+          note,
+          checkedAt: cached?.checkedAt ?? null,
+        })
+      })
+    }
+
+    const parts = [...tally.entries()].sort((a, b) => b[1] - a[1]).map(([label, n]) => `${n} ${label}`)
+    const pending = total - resolved
+    if (pending > 0) parts.push(`${pending} resolving`)
+    const summary = `${total} zone${total === 1 ? "" : "s"}${parts.length ? " · " + parts.join(" · ") : ""}`
+    return { rows: out, summary, resolvedZones: resolved, totalZones: total }
+  }, [sites, dnsZones, dnsResolving, zoneForDomain])
+
+  const safeIndex = Math.min(index, Math.max(0, rows.length - 1))
+  const close = () => setDnsInventoryServer(null)
+
+  useKeyboard((key) => {
+    const raw = key.name ?? ""
+    const name = key.shift && raw.length === 1 ? raw.toUpperCase() : raw
+    switch (name) {
+      case "escape":
+      case "q":
+        return close()
+      case "up":
+      case "k":
+        return setIndex((i) => moveSelection(i, -1, rows.length))
+      case "down":
+      case "j":
+        return setIndex((i) => moveSelection(i, 1, rows.length))
+      case "r":
+        if (server) lookupServerDns(server.id, true)
+        return
+    }
+  })
+
+  if (!server) return null
+  const listRows = Math.max(3, height - 6)
+  const oldest = rows.reduce<number | null>((min, r) => (r.checkedAt && (min === null || r.checkedAt < min) ? r.checkedAt : min), null)
+
+  return (
+    <box style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", flexDirection: "column", backgroundColor: theme.bg, zIndex: 216 }}>
+      <box style={{ flexDirection: "row", height: 1, backgroundColor: theme.bgAlt, paddingLeft: 1, paddingRight: 1, alignItems: "center" }}>
+        <text content={`🌐 DNS hosts · ${truncate(server.name, 28)}  `} fg={theme.brand} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content={summary} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 1 }} />
+        <box style={{ flexGrow: 1 }} />
+        {resolvedZones < totalZones ? <Spinner color={theme.brand} interval={120} /> : null}
+      </box>
+
+      {/* Column header — fixed widths so SITE/ZONE/HOST line up on every row; the
+          leading "  " matches the status-dot cell. NOTE (last) flexes to fill. */}
+      <box style={{ flexDirection: "row", paddingLeft: 1, paddingRight: 1, height: 1 }}>
+        <text content={"  " + "SITE".padEnd(SITE_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content={"ZONE".padEnd(ZONE_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content={"HOST".padEnd(HOST_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content="NOTE" fg={theme.textFaint} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
+      </box>
+
+      <box style={{ flexGrow: 1, flexDirection: "column", paddingLeft: 1, paddingRight: 1 }}>
+        {rows.length === 0 ? (
+          <text content="No sites on this server." fg={theme.textFaint} wrapMode="none" />
+        ) : (
+          <List
+            items={rows}
+            selectedIndex={safeIndex}
+            viewportRows={listRows}
+            focused
+            keyFor={(_r, i) => i}
+            emptyText="—"
+            renderRow={(r, selected) => (
+              <>
+                <text content={r.showSite ? statusDot(r.status) + " " : "  "} fg={statusColor(r.status)} style={{ flexShrink: 0 }} />
+                <text content={(r.showSite ? truncate(r.siteDomain, SITE_W - 1) : "").padEnd(SITE_W)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} />
+                <text content={truncate(r.zone, ZONE_W - 1).padEnd(ZONE_W)} fg={theme.text} wrapMode="none" style={{ flexShrink: 0 }} />
+                <text content={truncate(r.host, HOST_W - 1).padEnd(HOST_W)} fg={selected ? theme.text : r.hostColor} wrapMode="none" style={{ flexShrink: 0 }} />
+                <text content={r.note} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
+              </>
+            )}
+          />
+        )}
+      </box>
+
+      <StatusBar
+        hints={[
+          { key: "↑↓/jk", label: "scroll" },
+          { key: "r", label: "refresh lookups" },
+          { key: "esc", label: "close" },
+        ]}
+        message={oldest ? `checked ${timeAgo(new Date(oldest).toISOString())}` : undefined}
+        messageColor={theme.textFaint}
+        showGlobal={false}
+      />
+    </box>
+  )
+}

--- a/src/ui/views/ProviderConnect.tsx
+++ b/src/ui/views/ProviderConnect.tsx
@@ -1,0 +1,340 @@
+// DNS provider connect / manage overlay — Phase 2 (access detection, read-only).
+//
+// Opened with `c` from the DNS inventory on a zone whose host is an API provider
+// (Route 53 → AWS, Cloudflare). It's BOTH the connect form and the per-provider
+// manager: it lists every credential ("connection") for that provider — because a
+// dev has many accounts — and lets you add another, re-verify, or remove one.
+//
+// Connecting = verify the credential by listing the account's zones; that same
+// data drives the inventory's ACCESS column. Verification runs before anything is
+// stored, so a bad credential never persists. Secrets live in config.json (0600).
+//
+// Secret fields (CF token, AWS secret key) use the masked SecretInput; once saved
+// a secret is never shown again (the list shows label + zone count + status only).
+
+import { useEffect, useMemo, useState } from "react"
+import { useKeyboard, useTerminalDimensions } from "@opentui/react"
+import { theme } from "../../lib/theme.ts"
+import { truncate, timeAgo } from "../../lib/format.ts"
+import { Panel, SecretInput } from "../components.tsx"
+import { List, moveSelection } from "../List.tsx"
+import { StatusBar } from "../StatusBar.tsx"
+import { useStore } from "../store.tsx"
+import { openUrl, copyToClipboard } from "../../lib/open.ts"
+import { apiProviderFor, PROVIDER_REGISTRY, type Connection } from "../../lib/providers.ts"
+
+type Mode = "list" | "add"
+type Pane = "connections" | "zones"
+
+export function ProviderConnect() {
+  const store = useStore()
+  const { connectZoneTarget, setConnectZoneTarget, connectionsFor, providerZones, addConnection, removeConnection, verifyConnectionById, setInputMode } = store
+
+  const target = connectZoneTarget
+  const provider = target ? apiProviderFor(target.hostKey) : null
+  const descriptor = provider ? PROVIDER_REGISTRY[provider] : null
+  const fields = descriptor?.fields ?? []
+  const connections: Connection[] = provider ? connectionsFor(provider) : []
+
+  // Jump straight to the add form when there are no connections — unless the
+  // provider has a console fallback (GoDaddy), where the list's `a`/`w` choice
+  // (add a key vs open the web console) should be visible first.
+  const [mode, setMode] = useState<Mode>(connections.length === 0 && !descriptor?.console ? "add" : "list")
+  const openConsole = () => {
+    if (!descriptor?.console) return
+    if (target) copyToClipboard(target.apex)
+    openUrl(descriptor.console)
+    const label = descriptor.consoleLabel ?? "web console"
+    note(target ? `${label} opened · ${target.apex} copied — Login as the client, then paste.` : `${label} opened.`)
+  }
+  const [sel, setSel] = useState(0)
+  const [pane, setPane] = useState<Pane>("connections")
+  const [zoneIndex, setZoneIndex] = useState(0)
+  const [field, setField] = useState(0) // 0 = label; 1..N = descriptor.fields
+  const [label, setLabel] = useState("")
+  const [creds, setCreds] = useState<Record<string, string>>({})
+  const setCred = (name: string, val: string) => setCreds((c) => ({ ...c, [name]: val }))
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [flash, setFlash] = useState<string | null>(null)
+
+  const { height } = useTerminalDimensions()
+  const safeSel = Math.min(sel, Math.max(0, connections.length - 1))
+  const selectedConn = connections[safeSel]
+  const selectedVerified = selectedConn ? providerZones.get(selectedConn.id) : undefined
+  // The selected connection's zones (idea B: the right-pane drill-down).
+  const zones = useMemo(
+    () => (selectedVerified?.ok ? [...selectedVerified.zones].sort((a, b) => a.apex.localeCompare(b.apex)) : []),
+    [selectedVerified],
+  )
+
+  // The form owns the keyboard while adding (so typing a token doesn't navigate).
+  useEffect(() => {
+    setInputMode(mode === "add")
+    return () => setInputMode(false)
+  }, [mode, setInputMode])
+
+  // Reset the zone scroll when the selected connection changes.
+  useEffect(() => {
+    setZoneIndex(0)
+  }, [safeSel])
+
+  const close = () => {
+    setInputMode(false)
+    setConnectZoneTarget(null)
+  }
+
+  const note = (msg: string) => {
+    setFlash(msg)
+    setTimeout(() => setFlash(null), 2500)
+  }
+
+  const resetForm = () => {
+    setLabel("")
+    setCreds({})
+    setField(0)
+    setError(null)
+  }
+
+  const submit = async () => {
+    if (busy || !provider) return
+    setError(null)
+    const missing = fields.find((f) => !f.optional && !(creds[f.name] ?? "").trim())
+    if (missing) return setError(`${missing.label.replace(/ \(.*\)$/, "")} is required.`)
+    setBusy(true)
+    const res = await addConnection(provider, label, creds)
+    setBusy(false)
+    if (res.ok) {
+      note(`Connected — ${res.zones.length} zone${res.zones.length === 1 ? "" : "s"}`)
+      resetForm()
+      setMode("list")
+    } else {
+      const base = res.error || "Verification failed."
+      setError(descriptor?.console ? `${base} — Esc, then w for the ${descriptor.consoleLabel ?? "console"}.` : base)
+    }
+  }
+
+  const fieldCount = fields.length + 1 // + the label field
+
+  useKeyboard((key) => {
+    const raw = key.name ?? ""
+    if (busy) return // ignore input while verifying
+
+    if (mode === "add") {
+      if (raw === "escape") return connections.length > 0 || descriptor?.console ? (resetForm(), setMode("list")) : close()
+      if (raw === "up") return setField((f) => (f - 1 + fieldCount) % fieldCount)
+      if (raw === "down") return setField((f) => (f + 1) % fieldCount)
+      return
+    }
+
+    // list mode — two panes: connections (left) and that account's zones (right)
+    switch (raw) {
+      case "escape":
+        return pane === "zones" ? setPane("connections") : close()
+      case "q":
+        return close()
+      case "up":
+      case "k":
+        return pane === "zones"
+          ? setZoneIndex((i) => moveSelection(i, -1, zones.length))
+          : setSel((i) => moveSelection(i, -1, connections.length))
+      case "down":
+      case "j":
+        return pane === "zones"
+          ? setZoneIndex((i) => moveSelection(i, 1, zones.length))
+          : setSel((i) => moveSelection(i, 1, connections.length))
+      case "right":
+      case "l":
+      case "tab":
+        if (pane === "connections" && zones.length > 0) {
+          setZoneIndex(0)
+          setPane("zones")
+        }
+        return
+      case "left":
+        return pane === "zones" ? setPane("connections") : undefined
+      case "a":
+        if (pane !== "connections") return
+        resetForm()
+        return setMode("add")
+      case "w":
+        // Web-console fallback (e.g. GoDaddy without API access).
+        if (descriptor?.console) openConsole()
+        return
+      case "v": {
+        if (pane !== "connections") return
+        if (selectedConn) {
+          verifyConnectionById(selectedConn.id)
+          note(`Re-verifying ${selectedConn.label || selectedConn.id}…`)
+        }
+        return
+      }
+      case "x": {
+        if (pane !== "connections") return
+        if (selectedConn && !selectedConn.env) {
+          removeConnection(selectedConn.id)
+          setSel(0)
+          setPane("connections")
+          note("Removed connection")
+        } else if (selectedConn?.env) {
+          note("Env connection — unset the variable to remove")
+        }
+        return
+      }
+    }
+  })
+
+  if (!target || !provider || !descriptor) return null
+  const providerName = descriptor.name
+
+  return (
+    <box style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", flexDirection: "column", backgroundColor: theme.bg, zIndex: 230 }}>
+      <box style={{ flexDirection: "row", height: 1, backgroundColor: theme.bgAlt, paddingLeft: 1, paddingRight: 1, alignItems: "center" }}>
+        <text content={`🔑 Connect ${providerName}  `} fg={theme.brand} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content={`for ${truncate(target.apex, 40)}`} fg={theme.textDim} wrapMode="none" style={{ flexShrink: 1 }} />
+      </box>
+
+      <box style={{ flexGrow: 1, flexDirection: "column", padding: 1 }}>
+        {mode === "list" ? renderList() : renderAdd()}
+      </box>
+
+      <StatusBar hints={hints()} message={busy ? "Verifying…" : (flash ?? error ?? undefined)} messageColor={error && !flash ? theme.bad : theme.brand} showGlobal={false} />
+    </box>
+  )
+
+  function renderList() {
+    const zoneTitle = selectedConn
+      ? ` Zones · ${truncate(selectedConn.label || selectedConn.id, 18)}${selectedVerified?.ok ? ` (${zones.length})` : ""} `
+      : " Zones "
+    return (
+      <box style={{ flexGrow: 1, flexDirection: "row", gap: 1 }}>
+        {/* Left: the provider's connections (accounts) */}
+        <Panel title={` ${providerName} connections `} active={pane === "connections"} width={48}>
+          <box style={{ flexDirection: "column", flexGrow: 1, paddingTop: 1 }}>
+            {descriptor!.accessNote ? (
+              <box style={{ flexDirection: "column", marginBottom: 1 }}>
+                <text content={descriptor!.accessNote} fg={theme.textDim} />
+                <box style={{ height: 1 }} />
+              </box>
+            ) : null}
+            {connections.length === 0 ? (
+              <text
+                content={descriptor!.console ? `No API key — press a to add one, or w for the ${descriptor!.consoleLabel ?? "web console"}.` : "No connections yet — press a to add one."}
+                fg={theme.textFaint}
+              />
+            ) : (
+              connections.map((c, i) => {
+                const v = providerZones.get(c.id)
+                const selected = i === safeSel
+                const status = !v
+                  ? "not verified · v"
+                  : v.ok
+                    ? `${v.zones.length} zone${v.zones.length === 1 ? "" : "s"} · ${timeAgo(new Date(v.verifiedAt).toISOString())}`
+                    : `error: ${truncate(v.error ?? "failed", 22)}`
+                const statusColor = !v ? theme.textFaint : v.ok ? theme.good : theme.bad
+                return (
+                  <box key={c.id} style={{ flexDirection: "row", backgroundColor: selected && pane === "connections" ? theme.selectedBg : undefined }}>
+                    <text content={selected ? "› " : "  "} fg={theme.brand} style={{ flexShrink: 0 }} />
+                    <text content={truncate(c.label || c.id, 16).padEnd(17)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} />
+                    {c.env ? <text content="env " fg={theme.purple} style={{ flexShrink: 0 }} /> : null}
+                    <text content={status} fg={selected ? theme.text : statusColor} wrapMode="none" style={{ flexShrink: 1 }} />
+                  </box>
+                )
+              })
+            )}
+            <box style={{ flexGrow: 1 }} />
+            <text content={`a add · v re-verify · x remove · → zones${descriptor!.console ? ` · w ${descriptor!.consoleLabel ?? "console"}` : ""}`} fg={theme.textFaint} wrapMode="none" />
+          </box>
+        </Panel>
+
+        {/* Right: the selected connection's zones (idea B drill-down) */}
+        <Panel title={zoneTitle} active={pane === "zones"} flexGrow={1}>
+          {renderZones()}
+        </Panel>
+      </box>
+    )
+  }
+
+  function renderZones() {
+    if (!selectedConn) return <text content="—" fg={theme.textFaint} />
+    if (!selectedVerified) return <text content="Not verified yet — press v on the connection." fg={theme.textFaint} wrapMode="none" />
+    if (!selectedVerified.ok) return <text content={`Verification failed: ${selectedVerified.error ?? "unknown error"}`} fg={theme.bad} wrapMode="none" />
+    if (zones.length === 0) return <text content="No DNS zones in this account." fg={theme.textFaint} wrapMode="none" />
+    return (
+      <List
+        items={zones}
+        selectedIndex={Math.min(zoneIndex, zones.length - 1)}
+        viewportRows={Math.max(3, height - 7)}
+        focused={pane === "zones"}
+        keyFor={(z) => z.apex}
+        renderRow={(z, selected) => {
+          const isTarget = z.apex === target!.apex
+          return (
+            <text
+              content={(isTarget ? "● " : "  ") + truncate(z.apex, 48)}
+              fg={selected ? theme.text : isTarget ? theme.brand : theme.textDim}
+              wrapMode="none"
+            />
+          )
+        }}
+      />
+    )
+  }
+
+  function renderAdd() {
+    const fieldFg = (i: number) => (field === i ? theme.accent : theme.textDim)
+    const inputStyle = { backgroundColor: theme.bgAlt, focusedBackgroundColor: theme.bgAlt, textColor: theme.text }
+    return (
+      <Panel title={` Add ${providerName} connection `} active>
+        <box style={{ flexDirection: "column", width: 72, paddingTop: 1, paddingBottom: 1 }}>
+          <text content="Label (optional — defaults to the account name)" fg={fieldFg(0)} />
+          <input focused={field === 0} value={label} placeholder="e.g. main account" onInput={setLabel} onSubmit={() => setField(1)} style={inputStyle} />
+          <box style={{ height: 1 }} />
+
+          {fields.map((f, j) => {
+            const idx = j + 1
+            const last = idx === fieldCount - 1
+            const onSubmit = last ? submit : () => setField(idx + 1)
+            const labelText = f.label + (f.secret ? " (masked)" : "")
+            return (
+              <box key={f.name} style={{ flexDirection: "column" }}>
+                <text content={labelText} fg={fieldFg(idx)} wrapMode="none" />
+                {f.secret ? (
+                  <SecretInput focused={field === idx} value={creds[f.name] ?? ""} placeholder={f.placeholder} onChange={(v) => setCred(f.name, v)} onSubmit={onSubmit} />
+                ) : (
+                  <input focused={field === idx} value={creds[f.name] ?? ""} placeholder={f.placeholder} onInput={(v) => setCred(f.name, v)} onSubmit={onSubmit} style={inputStyle} />
+                )}
+                <box style={{ height: 1 }} />
+              </box>
+            )
+          })}
+          <text content={descriptor!.guidance} fg={theme.textFaint} />
+        </box>
+      </Panel>
+    )
+  }
+
+  function hints() {
+    if (mode === "add")
+      return [
+        { key: "↑↓", label: "field" },
+        { key: "⏎", label: "next / connect" },
+        { key: "esc", label: connections.length > 0 ? "back" : "cancel" },
+      ]
+    if (pane === "zones")
+      return [
+        { key: "↑↓/jk", label: "scroll zones" },
+        { key: "←", label: "back to accounts" },
+        { key: "esc", label: "back" },
+      ]
+    return [
+      { key: "↑↓", label: "account" },
+      { key: "→", label: "its zones" },
+      { key: "a", label: "add" },
+      ...(descriptor?.console ? [{ key: "w", label: descriptor.consoleLabel ?? "console" }] : []),
+      { key: "v", label: "re-verify" },
+      { key: "x", label: "remove" },
+      { key: "esc", label: "close" },
+    ]
+  }
+}


### PR DESCRIPTION
The read-only first half of the DNS module — see where each domain's DNS is
hosted, and whether you can edit it. No DNS records are ever changed.

## What's in it

**Phase 1 — host inventory.** `n` on a site / `N` on a server gives a zone-keyed
map of where every domain's DNS is hosted. The unit is the zone (`www` + apex
collapse; a separate-TLD redirect surfaces as its own zone with its own host).
Hosts come from a live nameserver lookup (Node's resolver, no `dig` dependency)
mapped to a label (Cloudflare, AWS Route 53, GoDaddy, …) with a registrable-domain
fallback for anything uncurated. Cached with a visible age; `r` refreshes.

**Phase 2 — access detection.** An ACCESS column (`✓ editable · ↗ web · ○ needs
key · ·`) and, with 2+ accounts, an ACCOUNT column. A zone is `✓` only when a
connected account of the provider that **actually serves it** (live nameservers)
holds it — provider-scoped, with an NS-match for Cloudflare/GoDaddy so a stale or
duplicate zone never shows a false green. Connect providers with `c`:

- Provider registry (`lib/providers.ts`) — one descriptor per provider; adding a
  provider is a single entry.
- AWS Route 53 via **hand-rolled SigV4** (no SDK; verified against AWS's published
  reference vector), Cloudflare (scoped token), GoDaddy (header auth).
- Multiple accounts per provider; verify-before-store; secrets masked
  (`SecretInput`, also applied to onboarding) and kept in `config.json` (0600);
  env vars honored. Two-pane drill-down into each account's zones.
- GoDaddy's API is gated to large accounts, so a GoDaddy zone falls back to `↗`:
  `w` opens the GoDaddy Clients hub and copies the domain to the clipboard, with
  an in-context Delegate-Access note.

## Testing

- `bun run typecheck` green.
- SigV4 checked against AWS's `get-vanilla` reference vector.
- Verified live over a PTY against real AWS + Cloudflare accounts (read-only):
  host detection, the provider-scoped + NS-match access logic (incl. a real zone
  moved between providers correctly attributed), the multi-account ACCOUNT column,
  and the GoDaddy hub/clipboard fallback. AWS connections confirmed; Cloudflare
  and the masked fields confirmed by the maintainer.

## Notes

- Entirely read-only — editing DNS records is a later phase. The AWS NS-match for
  the duplicate/stale edge is deferred to that edit-time pre-flight (Route 53's
  ~5 req/s limit makes a blanket per-zone fetch impractical).
- Bundles the `chore: release v0.6.0` commit (version bump, changelog, README —
  the README also backfills the 0.5.0 local-working-copy features that had slipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)