### PR TITLE
DNS Phase 3 — migration record manager (TTL editing + site lens)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,39 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+### Added
+- **Edit DNS record TTLs — the first DNS write.** From the DNS view, press `⏎` on a
+  site's hosting record to open a focused editor and change its TTL (a preset or a
+  custom value). This is the prep step for a low-risk server migration: lower the TTL
+  before you cut over, then restore it after. Writes go to **AWS Route 53** or
+  **Cloudflare** through your connected account, behind a confirm step. An edit-time
+  safety check re-reads the live nameservers and **blocks the write** if the account's
+  zone isn't the one actually serving the domain — so you can't edit a stale or
+  duplicate copy. Route 53 changes are followed to completion; the record shows an
+  "updating" status that keeps ticking even if you leave the view.
+- **Open the DNS view scoped to one site.** Press `n` on a site (Servers or Search)
+  to open the inventory for just that site's domains and records — the view you want
+  when migrating a single site. Press `a` inside to expand to the whole server.
+
+### Changed
+- **The DNS view is now a migration lens, organized by site.** It shows only the
+  records that "count" when you move a site — each **site** on its own line (labeled
+  by the site's own domain, even when it's a subdomain), its hosting record's
+  type / TTL / value, a `◀ here` flag when the record points at this server, and a
+  `+www` tag when `www` simply follows the apex. A site's additional domains nest
+  beneath it, so a domain portfolio reads as one site, not many. TTLs are shown in
+  **seconds** (e.g. `3600`), and editing happens in place — there's no full-zone
+  record list to get lost in.
+
+### Notes
+- Only the **TTL** is editable so far (repointing a record's target is a later step).
+  Cloudflare **proxied** records are read-only (their TTL is managed by Cloudflare).
+  By design the view only ever touches a site's own hosting records — your MX, TXT,
+  and other zone records are never shown or modified, so moving a site can't take
+  down its email.
+- Editing a Cloudflare record needs a token scoped to `Zone.DNS:Edit` (the read-only
+  `Zone:Read` token from the host inventory isn't enough).
+
 ## [0.6.0] - 2026-06-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,11 +57,12 @@ Once you're in, the dashboard looks like this:
   (See "Local working copies" below.)
 - **SSH into a site** — press `s` on a site to open a new terminal already running
   `ssh` into it (`{site_user}@{server_ip}`).
-- **DNS hosts & access** — press `n` on a site (or `N` on a server) to see where
-  each domain's DNS is hosted, and — if you connect a provider (AWS Route 53 /
-  Cloudflare / GoDaddy) — whether you can edit it and through which account. The
-  whole module is **read-only**: it inventories and verifies, it doesn't change
-  records. (See "DNS hosts & access" below.)
+- **DNS migration lens** — press `n` on a site (or `N` on a server) to see the DNS
+  records that move a site to another server: each site's hostnames with their type,
+  TTL (in seconds), and a `◀ here` flag when they point at this server. Connect a
+  provider (AWS Route 53 / Cloudflare) and press `⏎` to **edit a record's TTL** — the
+  prep step for a low-risk cutover. It only ever touches a site's own hosting records,
+  never your MX/TXT/other records. (See "DNS hosts, access & editing" below.)
 - **Upgrade a site's PHP version** — press `u` on a site to pick a new PHP
   version and apply it (`PUT /sites/{id}/php`), then watch the upgrade event run
   to completion. (See "Upgrading PHP" below.)
@@ -171,8 +172,8 @@ Both can be set in `config.json` or via an environment variable:
 | `s` | Open a terminal and SSH into the selected site |
 | `L` | Link / edit a site's local working copy |
 | `t` / `v` | Open the linked copy in a terminal / its local URL in your browser |
-| `n` | Look up where a site's domains host DNS |
-| `N` | DNS host + access inventory for the selected server |
+| `n` | DNS migration view for a site — its records + TTLs (`⏎` edits a TTL; `a` shows the whole server) |
+| `N` | DNS migration view for the whole server |
 | `h` | Live server health (CPU/mem/disk over SSH) |
 | `d` | Detect a site's stack via SSH (Servers / Stacks tabs) |
 | `D` | Detect every site in the selected stack (Stacks tab) |
@@ -301,40 +302,55 @@ serve it; the site's details gain a "Local" field, and you can open the copy wit
 Config keys: `localRoots` (folders to scan) and `localSites` (per-site path +
 local URL — tool-agnostic: Valet, Cove, LocalWP, Herd, DDEV, …).
 
-## DNS hosts & access
+## DNS hosts, access & editing
 
-A **read-only** DNS module: see where each domain's DNS is hosted, and whether
-you can edit it. No DNS records are ever changed.
+A **server-migration lens** for DNS: see the records that move a site to another
+server, and edit them in place. It is deliberately **not** a full zone editor — it
+only ever shows and touches a site's own hosting records (its apex / `www` /
+subdomains and additional domains), so your MX, TXT, DKIM, and other zone records are
+never shown or changed. Moving a site can't take down its email.
 
-- **Inventory.** Press `n` on a site to look up its domains' hosts, or `N` on a
-  server for a zone-keyed inventory of every domain on it. The unit is the
-  **zone** — `www` and the apex collapse together, and a separate-TLD redirect
-  surfaces as its own zone with its own host (so a full portfolio move misses
-  nothing). Hosts come from a live nameserver lookup (no `dig` needed) and are
-  labeled (Cloudflare, AWS Route 53, GoDaddy, …), falling back to the nameserver
-  domain for anything unrecognized. Lookups are cached with a visible age; `r`
-  refreshes.
-- **Access (`✓ ↗ ○ ·`).** Each zone shows whether you can edit it: `✓` editable,
-  `↗` web-only handoff, `○` the provider has an API but you haven't connected an
-  account that holds the zone, `·` unknown. A zone is `✓` only when a connected
-  account of the provider that actually serves it (its live nameservers) holds it
-  — so a stale or duplicate zone elsewhere never shows a false green. With two or
-  more accounts connected, an **ACCOUNT** column names the owning one.
+- **The view.** Press `n` on a site for just that site's records, or `N` on a server
+  for every site on it; inside a site-scoped view, `a` expands to the whole server.
+  Each **site** is a line, labeled by its own domain (even when it's a subdomain),
+  with its hosting record's type, **TTL in seconds**, value, a `◀ here` flag when the
+  record points at this server, and a `+www` tag when `www` simply follows the apex.
+  A site's additional domains nest beneath it, so a domain portfolio reads as one
+  site, not many. TTLs come from the zone's authoritative nameserver (the configured
+  value, not a counted-down one), so they show even for hosts you haven't connected;
+  `r` refreshes.
+- **Access (`✓ ↗ ○ ·`).** Each record's zone shows whether you can edit it: `✓`
+  editable, `↗` web-only handoff, `○` the provider has an API but you haven't
+  connected an account that holds the zone, `·` unknown. A zone is `✓` only when a
+  connected account of the provider that actually serves it (its live nameservers)
+  holds it — so a stale or duplicate zone elsewhere never shows a false green. With
+  two or more accounts connected, an **ACCOUNT** column names the owning one.
+- **Edit a TTL (`⏎`).** On an editable record, `⏎` opens a focused editor — pick a
+  preset or a custom value, confirm, and it's written to **AWS Route 53** or
+  **Cloudflare** through your connected account. This is the prep step for a low-risk
+  migration: lower the TTL, cut over, then restore it. Before writing, an edit-time
+  check re-reads the live nameservers and **blocks** the change if the connected
+  account's zone isn't the one actually serving the domain. Route 53 changes are
+  followed to completion; the record shows an "updating" status that keeps ticking
+  even if you leave the view. Only the **TTL** is editable for now (repointing a
+  record's target comes later), and Cloudflare **proxied** records are read-only.
 - **Connect a provider (`c`).** Manage credentials for the selected zone's
-  provider — **AWS Route 53** (an IAM access key scoped to Route 53 reads),
-  **Cloudflare** (a `Zone:Read` token), or **GoDaddy** (a Production API key).
-  Multiple accounts per provider are supported, with a drill-down into each
-  account's zones. Credentials are verified before they're stored, kept in
-  `config.json` (chmod 600), and the matching environment variables are honored
-  (`CLOUDFLARE_API_TOKEN`, `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`,
-  `GODADDY_API_KEY` / `GODADDY_API_SECRET`). Secrets are masked as you type.
+  provider — **AWS Route 53** (an IAM access key), **Cloudflare** (a scoped token),
+  or **GoDaddy** (a Production API key). Multiple accounts per provider are
+  supported, with a drill-down into each account's zones. Credentials are verified
+  before they're stored, kept in `config.json` (chmod 600), and the matching
+  environment variables are honored (`CLOUDFLARE_API_TOKEN`, `AWS_ACCESS_KEY_ID` /
+  `AWS_SECRET_ACCESS_KEY`, `GODADDY_API_KEY` / `GODADDY_API_SECRET`). Secrets are
+  masked as you type. Listing hosts needs only read access (Cloudflare `Zone:Read`);
+  **editing a TTL** needs write access — Route 53 record writes, or a Cloudflare
+  `Zone.DNS:Edit` token.
 - **GoDaddy fallback.** GoDaddy's API is limited to larger accounts, so a GoDaddy
   zone shows `↗`; press `w` (in the inventory or the connect overlay) to open your
   GoDaddy Clients hub with the domain copied to your clipboard. The flow assumes
   you manage client domains via Delegate Access from one main account.
 
-Provider credentials are entirely optional — without them you still get the full
-host inventory, just without the editable/account columns.
+Provider credentials are optional — without them you still get the full host
+inventory and TTLs, just without the editable/account columns or in-place editing.
 
 ## Development
 

--- a/docs/dns-phase3-migration-spec.md
+++ b/docs/dns-phase3-migration-spec.md
@@ -1,0 +1,182 @@
+# DNS Module Phase 3 — Migration Record Manager (writes)
+
+The write phase of the DNS module (backlog item 6). **This is NOT a DNS zone
+editor.** It is a *migration record manager*: it edits only the handful of records
+that point a SpinupWP site at a server, so you can move that site to another server
+safely. Everything else in the zone — MX, TXT, DKIM, service CNAMEs — is invisible
+to this module and is **never touched**. That untouchability is a designed-in
+feature, not a limitation (see "Safety is the product" below).
+
+Builds on Phase 1 (`docs/dns-zone-host-spec.md`, zone-host detection) and Phase 2
+(`docs/dns-access-phase2-spec.md`, access detection + the connections model).
+
+## Why "Phase 3, re-scoped"
+
+The first implementation (commit `bdda820`, branch `dns-phase3-ttl`) shipped TTL
+editing **plus** a full-zone record list: pressing `⏎` on a record in the `N` view
+opened `DnsRecords.tsx`, which listed *every* RRset in the zone and let you edit
+from there. That made it a general zone editor — wider than this product needs, and
+worse, it reintroduces the classic footgun the module exists to prevent: a novice
+moving a site and **knocking out email** because the MX record was one keystroke
+from an edit. This spec re-scopes Phase 3 around the migration job and removes the
+zone-editor surface entirely.
+
+## The job it does
+
+When you migrate a SpinupWP site to a new server you must update the DNS records
+that point the site's hostnames at the old server so they point at the new one. The
+records that "count" are exactly:
+
+- The **apex A** record (`example.com → IP`).
+- **Subdomain A** records SpinupWP serves (`app.example.com → IP`).
+- The **`www`** record — *only if it's its own A record*. A `www` that is a
+  `CNAME → apex` follows the apex automatically and needs no edit (we mark it
+  "follows apex" and de-emphasize it).
+- The same set for each **additional domain** (separate-TLD aliases/redirects),
+  which may live in their own zone on their own host.
+
+Nothing else. The safe migration loop these records support:
+
+1. **Lower TTL** on the hosting records (so propagation is fast at cutover).
+2. Wait for the old TTL to expire.
+3. **Repoint the target** (A value → new server IP).
+4. **Verify propagation** (live authoritative values, read cred-free).
+5. **Restore TTL**.
+
+TTL editing (step 1) shipped first. Target repointing (step 3) is the next write
+and reuses the same single-record edit surface — TTL and target are two fields of
+one record edit, so the editor is built to hold both.
+
+## Discovery source: SpinupWP only
+
+Hosting records are derived **strictly** from SpinupWP's knowledge of the site —
+`site.domain` + `additional_domains[]`, expanded to apex/www/subdomain candidate
+hostnames (`candidateHostnames()` in `dns.ts`). We do **not** scan the zone for
+stray A records that happen to point at the server IP; those are almost always
+forgotten legacy records, and scanning for them would re-widen us back toward a
+zone editor. SpinupWP is authoritative for what a site serves; that's our set.
+
+## Safety is the product: "we only touch the records that move the site"
+
+This is the differentiator, so it's enforced structurally, not by discipline:
+
+- **No UI path shows non-hosting records.** There is no screen listing MX/TXT/etc.
+  You cannot edit what you cannot reach.
+- **Reads are scoped to the hosting records too** — not just writes. We never list
+  the whole zone. This is achievable on every supported API (see below), so the
+  guarantee holds host-agnostically and is faster besides.
+- The UI states the promise in-context (per `name-by-outcome, teach-in-context`):
+  the module's job is "move the site without touching anything else."
+
+## Host-agnostic by design — same operations, per-provider implementations
+
+We must support any DNS host that exposes an editing API, not assume Route 53. The
+provider-agnostic record layer (`src/lib/dnsRecords.ts`) is the seam; its surface is
+**operations on one named record**, which each provider implements its own way:
+
+- `readHostingRecord(host, type)` → `{ value, ttl, ... }` for that one record.
+- `writeHostingRecord(host, type, { ttl, value })` → upsert that one record.
+
+The single-record scoping is supported by every major API — it is not a Route 53
+convenience:
+
+| Host | Read one record | Write one record |
+| ---- | --------------- | ---------------- |
+| **Route 53** | `ListResourceRecordSets` with `StartRecordName`/`MaxItems` | `ChangeResourceRecordSets` UPSERT (SigV4 POST) |
+| **Cloudflare** | `GET /zones/{id}/dns_records?name=&type=` | `PATCH /zones/{id}/dns_records/{record_id}` |
+| **GoDaddy / unknown** | — (no usable API for most users) | web-console handoff (`↗`) |
+
+Cloudflare editing needs a token scoped to `Zone.DNS:Edit` (Phase 2 only required
+`Zone:Read`); prompt to upgrade scope at edit time.
+
+## Cloudflare's proxied records change the migration *semantics*, not just the API
+
+This is the part host-agnosticism can't paper over. A Cloudflare record can be
+**proxied (orange cloud)** or **DNS-only (grey cloud)**, and they migrate
+differently:
+
+- **`pointsHere` detection breaks for proxied records.** Our cred-free authoritative
+  lookup (`dnsQuery.ts`) returns *Cloudflare's anycast IPs*, not your origin — so
+  `◀ here` can't be computed from public DNS. For Cloudflare we may need the API
+  (`DNS:Read`) just to learn where a record truly points. That reframes "access" for
+  CF: web-only/no-key isn't only "can't edit," it can be "can't even show the true
+  migration state."
+- **The cutover move differs.** DNS-only records use the classic TTL loop
+  (lower → wait → repoint → restore). **Proxied** records force TTL to "Auto"
+  (TTL=1) — it's largely moot, and you cut over by changing the **origin IP**, which
+  is near-instant at the edge. "Lower the TTL first" is the wrong advice there;
+  there's also nothing to "restore" (Auto *is* the resting state — this is why the
+  earlier note "CF automatic can't be restored yet" was a non-problem).
+
+**Implication:** the record row must express *how this particular record cuts over*
+— a TTL knob for Route 53 / DNS-only Cloudflare, an origin-swap for proxied
+Cloudflare — rather than presenting one uniform TTL control.
+
+## Editing happens in place, on one record
+
+There is no zone drill-down. In the `N` view you select a hosting record and act on
+it directly:
+
+- The action is a **focused single-record edit** (TTL now; target/origin next),
+  not a list of the zone.
+- `DnsRecords.tsx` is **repurposed** from "zone browser + editor" down to "edit
+  *this one record*" (it already accepts a focused target via
+  `dnsRecordsTarget.focus`). Its NS-match pre-flight, confirm overlay, and
+  event-tracking guts are good and reused. (If, with the zone-list gone, it still
+  feels bloated, retire it for a smaller edit overlay — but start by repurposing.)
+
+### Edit-time NS-match pre-flight (kept)
+
+Before any write, re-dig **fresh live NS** for the zone and compare to the connected
+account's hosted-zone NS (the apex NS record, free from the scoped read — no extra
+`GetHostedZone` call). **Hard-stop** the edit if the account's zone isn't the one
+actually serving the domain live (a red banner), and resolve which account when an
+apex appears in 2+ connections. This prevents editing a stale/parked copy of a zone.
+
+### Write plumbing (reused)
+
+Writes go through the existing `mutate()` + async-event polling + confirm-before-
+firing pattern (per CLAUDE.md), mirroring `startPhpUpgrade`: `startTtlChange` /
+`ttlWrites` in the store, per-zone credential routing via `connForZone`.
+
+## The `N` view, re-scoped
+
+The view's spine is the two questions that matter at a server's DNS:
+
+1. **What access do we have?** (API `✓` / web `↗` / needs-key `○`) — the Phase 2
+   ACCESS column.
+2. **Can we adjust TTL and (eventually) the target?** — per hosting record.
+
+So `N` is: **per site, the handful of records that point it at a server**, each
+annotated with access, current TTL, current target/value, and the `◀ here` flag
+(does it point at this server?). The zone/host is lightweight *context* on those
+rows — not a selectable header you drill into (there's nothing to drill into). Note
+the absence of `◀ here` is also signal: a hosting record that doesn't point here
+mid-migration is a discrepancy worth seeing.
+
+This re-scoping also dissolves the "it's a bit busy" problem from a different angle
+than the previous plan: the density came from carrying zone-editor scaffolding
+(zone-header rows, the apex duplicated as its own record row, full column load) that
+this scope no longer needs.
+
+## Out of scope
+
+- Any record that isn't a SpinupWP site-hosting record (MX/TXT/DKIM/service records,
+  stray legacy A records).
+- A general zone editor / full per-zone record list.
+- Per-FQDN subdomain delegation (carried over from Phase 1).
+
+## File map (deltas from the shipped `dns-phase3-ttl` branch)
+
+- `src/lib/dnsRecords.ts` — keep the provider-agnostic seam; ensure reads are
+  scoped to a single hostname (no whole-zone list); add Cloudflare proxied/origin
+  awareness; target-write to follow.
+- `src/ui/views/DnsRecords.tsx` — strip the zone record list; repurpose to a
+  focused single-record editor (TTL + future target/origin).
+- `src/ui/views/DnsInventory.tsx` — `N` as the whole module: hosting records with
+  access + TTL + target + `◀ here`; `www`-CNAME-follows-apex distinction; per-record
+  cutover hint (TTL vs origin-swap); declutter.
+- `src/lib/dnsQuery.ts` — note the proxied-Cloudflare blind spot; prefer API origin
+  for CF when available.
+- `src/ui/store.tsx` — `startTtlChange`/`ttlWrites` (shipped); target-repoint action
+  to follow; keep `connForZone` credential routing.

--- a/src/lib/awsSigV4.ts
+++ b/src/lib/awsSigV4.ts
@@ -1,11 +1,12 @@
-// Hand-rolled AWS Signature Version 4 for GET requests — no `aws` CLI, no SDK.
-// We only ever issue a handful of read-only GETs (STS GetCallerIdentity, Route 53
-// ListHostedZones / ListResourceRecordSets), so the full SigV4 algorithm for an
-// unsigned-body GET is all we need. Keeps the app dependency-light (node:crypto +
-// fetch only) and the compiled binary small.
+// Hand-rolled AWS Signature Version 4 — no `aws` CLI, no SDK. We only issue a
+// handful of calls: read-only GETs (STS GetCallerIdentity, Route 53
+// ListHostedZonesByName / ListResourceRecordSets) and one write POST (Route 53
+// ChangeResourceRecordSets, for editing a record's TTL). The full SigV4 algorithm
+// for a signed request — empty body for GETs, hashed XML body for the POST — is
+// all we need, which keeps the app dependency-light (node:crypto + fetch only).
 //
 // Reference: docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
-// Verified against AWS's published "get-vanilla" test vector (see awsSigV4.test).
+// signGetV4 is verified against AWS's published "get-vanilla" test vector.
 
 import { createHash, createHmac } from "node:crypto"
 
@@ -28,19 +29,27 @@ function enc(s: string): string {
   return encodeURIComponent(s).replace(/[!*'()]/g, (c) => "%" + c.charCodeAt(0).toString(16).toUpperCase())
 }
 
-export interface SignGetOptions {
+export interface SignOptions {
   creds: AwsCreds
   service: string
   host: string
+  method?: string // defaults to GET
   path: string // already in canonical form (we only use simple ASCII paths)
   query?: Record<string, string>
+  body?: string // request body (empty string for GET)
+  contentType?: string // sent (unsigned) when a body is present
   amzDate?: string // override for testing; defaults to now in ISO8601 basic (YYYYMMDDTHHMMSSZ)
 }
 
-// Produce the headers + URL for a signed GET. Pure (no I/O) so it can be unit
-// tested against AWS's reference vectors.
-export function signGetV4(opts: SignGetOptions): { url: string; headers: Record<string, string> } {
+// Produce the headers + URL for a signed request. Pure (no I/O) so it can be unit
+// tested against AWS's reference vectors. Only host + x-amz-date (+ the session
+// token when present) are signed; Content-Type, when sent, rides along unsigned —
+// SigV4 permits unsigned headers, and this keeps the signed set (and thus the GET
+// path) identical to the verified reference implementation.
+export function signV4(opts: SignOptions): { url: string; headers: Record<string, string> } {
   const { creds, service, host, path } = opts
+  const method = opts.method ?? "GET"
+  const body = opts.body ?? ""
   const region = creds.region || "us-east-1"
   const query = opts.query ?? {}
   const amzDate = opts.amzDate ?? new Date().toISOString().replace(/[:-]|\.\d{3}/g, "")
@@ -59,8 +68,8 @@ export function signGetV4(opts: SignGetOptions): { url: string; headers: Record<
   const canonicalHeaders = names.map((n) => `${n}:${hdrs[n].trim()}\n`).join("")
   const signedHeaders = names.join(";")
 
-  const payloadHash = sha256hex("") // empty body for a GET
-  const canonicalRequest = ["GET", path, canonicalQuery, canonicalHeaders, signedHeaders, payloadHash].join("\n")
+  const payloadHash = sha256hex(body)
+  const canonicalRequest = [method, path, canonicalQuery, canonicalHeaders, signedHeaders, payloadHash].join("\n")
 
   const scope = `${dateStamp}/${region}/${service}/aws4_request`
   const stringToSign = ["AWS4-HMAC-SHA256", amzDate, scope, sha256hex(canonicalRequest)].join("\n")
@@ -76,9 +85,24 @@ export function signGetV4(opts: SignGetOptions): { url: string; headers: Record<
   // host is implied by the URL (fetch sets it); send the rest.
   const headers: Record<string, string> = { "x-amz-date": amzDate, Authorization: authorization }
   if (creds.sessionToken) headers["x-amz-security-token"] = creds.sessionToken
+  if (body && opts.contentType) headers["Content-Type"] = opts.contentType
 
   const url = `https://${host}${path}${canonicalQuery ? "?" + canonicalQuery : ""}`
   return { url, headers }
+}
+
+// Back-compat name for the GET-only signer (verified against AWS's reference
+// vector). Delegates to signV4 — the signed set is unchanged, so its output is
+// byte-identical to the original implementation.
+export function signGetV4(opts: {
+  creds: AwsCreds
+  service: string
+  host: string
+  path: string
+  query?: Record<string, string>
+  amzDate?: string
+}): { url: string; headers: Record<string, string> } {
+  return signV4({ ...opts, method: "GET" })
 }
 
 // Sign and perform a GET. Returns the HTTP status + raw body text.
@@ -89,7 +113,21 @@ export async function awsGet(
   path: string,
   query: Record<string, string> = {},
 ): Promise<{ status: number; body: string }> {
-  const { url, headers } = signGetV4({ creds, service, host, path, query })
+  const { url, headers } = signV4({ creds, service, host, path, query, method: "GET" })
   const res = await fetch(url, { method: "GET", headers })
+  return { status: res.status, body: await res.text() }
+}
+
+// Sign and perform a POST with a body. Returns the HTTP status + raw body text.
+export async function awsPost(
+  creds: AwsCreds,
+  service: string,
+  host: string,
+  path: string,
+  body: string,
+  contentType = "application/xml",
+): Promise<{ status: number; body: string }> {
+  const { url, headers } = signV4({ creds, service, host, path, body, contentType, method: "POST" })
+  const res = await fetch(url, { method: "POST", headers, body })
   return { status: res.status, body: await res.text() }
 }

--- a/src/lib/dns.ts
+++ b/src/lib/dns.ts
@@ -39,6 +39,22 @@ export function normalizeDomain(domain: string): string {
   return domain.trim().toLowerCase().replace(/\.$/, "").replace(/^www\./, "")
 }
 
+// The website-hosting hostnames for a set of configured site domains: each domain
+// plus its sibling apex/www variant — the records that "count" in a server
+// migration (apex A + www CNAME/A + each additional domain). Lowercased + deduped.
+// Unlike normalizeDomain this does NOT collapse www: www is its own record here.
+export function candidateHostnames(domains: string[]): string[] {
+  const set = new Set<string>()
+  for (const raw of domains) {
+    const d = raw.trim().toLowerCase().replace(/\.$/, "")
+    if (!d || !d.includes(".")) continue
+    set.add(d)
+    if (d.startsWith("www.")) set.add(d.slice(4))
+    else set.add("www." + d)
+  }
+  return [...set]
+}
+
 // The next zone candidate up. Returns null once only a single-label TLD remains
 // (so a dead/unregistered domain can't walk all the way up to the TLD's servers).
 function parentDomain(name: string): string | null {

--- a/src/lib/dnsQuery.ts
+++ b/src/lib/dnsQuery.ts
@@ -1,0 +1,180 @@
+// Minimal DNS query over UDP (node:dgram) — no `dig`, no deps. It exists to get
+// the one thing node's resolver can't: the TTL of ANY record type (notably CNAME)
+// as CONFIGURED. We query a zone's AUTHORITATIVE nameserver directly, so the answer
+// carries the full, non-decremented TTL (a recursive resolver hands back a
+// counted-down value, which is misleading for a migration). Same hand-rolled
+// spirit as awsSigV4.ts — we implement just enough of the protocol.
+//
+// Scope: A / AAAA / CNAME rdata are parsed for real (the website-hosting records
+// the DNS inventory shows); MX / TXT are parsed for display; anything else returns
+// its type + TTL with a placeholder value. Name compression pointers are handled.
+
+import { createSocket } from "node:dgram"
+import { isIP } from "node:net"
+import { Resolver } from "node:dns/promises"
+
+export interface DnsAnswer {
+  name: string
+  type: string // "A" | "AAAA" | "CNAME" | "MX" | "TXT" | numeric string
+  ttl: number
+  value: string
+}
+
+export type QueryType = "A" | "AAAA" | "CNAME" | "MX" | "TXT" | "NS"
+
+const TYPE_NUM: Record<QueryType, number> = { A: 1, NS: 2, CNAME: 5, MX: 15, TXT: 16, AAAA: 28 }
+const NUM_TYPE: Record<number, string> = { 1: "A", 2: "NS", 5: "CNAME", 6: "SOA", 15: "MX", 16: "TXT", 28: "AAAA" }
+const TIMEOUT_MS = 4000
+
+function encodeName(name: string): Buffer {
+  const parts = name.replace(/\.$/, "").split(".").filter(Boolean)
+  const bufs = parts.map((p) => {
+    const b = Buffer.from(p, "ascii")
+    return Buffer.concat([Buffer.from([b.length]), b])
+  })
+  return Buffer.concat([...bufs, Buffer.from([0])])
+}
+
+function buildQuery(name: string, type: number): { id: number; buf: Buffer } {
+  const id = Math.floor(Math.random() * 65536)
+  const header = Buffer.alloc(12)
+  header.writeUInt16BE(id, 0)
+  header.writeUInt16BE(0x0100, 2) // standard query, recursion desired
+  header.writeUInt16BE(1, 4) // QDCOUNT = 1
+  const tail = Buffer.alloc(4)
+  tail.writeUInt16BE(type, 0)
+  tail.writeUInt16BE(1, 2) // QCLASS = IN
+  return { id, buf: Buffer.concat([header, encodeName(name), tail]) }
+}
+
+// Read a (possibly compressed) name starting at `offset`. `next` is where reading
+// continues AFTER the name in the original stream (compression pointers don't
+// advance it past the 2-byte pointer).
+function readName(buf: Buffer, offset: number): { name: string; next: number } {
+  const labels: string[] = []
+  let i = offset
+  let jumped = false
+  let next = offset
+  let guard = 0
+  while (guard++ < 128) {
+    const len = buf[i]
+    if (len === 0) {
+      i++
+      if (!jumped) next = i
+      break
+    }
+    if ((len & 0xc0) === 0xc0) {
+      const ptr = ((len & 0x3f) << 8) | buf[i + 1]
+      if (!jumped) next = i + 2
+      i = ptr
+      jumped = true
+      continue
+    }
+    labels.push(buf.toString("ascii", i + 1, i + 1 + len))
+    i += 1 + len
+  }
+  return { name: labels.join("."), next }
+}
+
+function parseAnswers(buf: Buffer): DnsAnswer[] {
+  const qd = buf.readUInt16BE(4)
+  const an = buf.readUInt16BE(6)
+  let off = 12
+  for (let q = 0; q < qd; q++) {
+    const r = readName(buf, off)
+    off = r.next + 4 // skip QTYPE + QCLASS
+  }
+  const answers: DnsAnswer[] = []
+  for (let a = 0; a < an && off < buf.length; a++) {
+    const r = readName(buf, off)
+    off = r.next
+    const type = buf.readUInt16BE(off)
+    off += 2 // TYPE
+    off += 2 // CLASS
+    const ttl = buf.readUInt32BE(off)
+    off += 4
+    const rdlen = buf.readUInt16BE(off)
+    off += 2
+    const rdStart = off
+    let value = ""
+    if (type === 1 && rdlen === 4) {
+      value = `${buf[off]}.${buf[off + 1]}.${buf[off + 2]}.${buf[off + 3]}`
+    } else if (type === 28 && rdlen === 16) {
+      const segs: string[] = []
+      for (let k = 0; k < 16; k += 2) segs.push(buf.readUInt16BE(off + k).toString(16))
+      value = segs.join(":")
+    } else if (type === 5) {
+      value = readName(buf, off).name
+    } else if (type === 15) {
+      value = `${buf.readUInt16BE(off)} ${readName(buf, off + 2).name}`
+    } else if (type === 16) {
+      let p = off
+      const chunks: string[] = []
+      while (p < off + rdlen) {
+        const l = buf[p]
+        chunks.push(buf.toString("ascii", p + 1, p + 1 + l))
+        p += 1 + l
+      }
+      value = chunks.join("")
+    } else {
+      value = `(${rdlen}b)`
+    }
+    off = rdStart + rdlen
+    answers.push({ name: r.name, type: NUM_TYPE[type] ?? String(type), ttl, value })
+  }
+  return answers
+}
+
+// Resolve a nameserver hostname to an IP (via public resolvers), or pass an IP
+// through unchanged.
+async function nsIp(nsHost: string): Promise<string | null> {
+  if (isIP(nsHost)) return nsHost
+  try {
+    const r = new Resolver({ timeout: TIMEOUT_MS, tries: 1 })
+    r.setServers(["1.1.1.1", "8.8.8.8"])
+    const a = await r.resolve4(nsHost)
+    return a[0] ?? null
+  } catch {
+    return null
+  }
+}
+
+function queryOnce(serverIp: string, host: string, type: number): Promise<DnsAnswer[]> {
+  return new Promise((resolve, reject) => {
+    const { id, buf } = buildQuery(host, type)
+    const sock = createSocket(isIP(serverIp) === 6 ? "udp6" : "udp4")
+    const done = (err: Error | null, ans?: DnsAnswer[]) => {
+      clearTimeout(timer)
+      try {
+        sock.close()
+      } catch {
+        /* already closed */
+      }
+      err ? reject(err) : resolve(ans!)
+    }
+    const timer = setTimeout(() => done(new Error("DNS query timed out")), TIMEOUT_MS)
+    sock.on("message", (msg) => {
+      if (msg.length < 12 || msg.readUInt16BE(0) !== id) return done(new Error("DNS id mismatch"))
+      try {
+        done(null, parseAnswers(msg))
+      } catch (e) {
+        done(e as Error)
+      }
+    })
+    sock.on("error", (e) => done(e))
+    sock.send(buf, 53, serverIp)
+  })
+}
+
+// Query a record at the zone's authoritative nameservers (first that answers).
+// Returns the full answer section (a CNAME chain may include several records), or
+// null when none of the nameservers respond.
+export async function queryAuthoritative(host: string, type: QueryType, nameservers: string[]): Promise<DnsAnswer[] | null> {
+  for (const ns of nameservers) {
+    const ip = await nsIp(ns)
+    if (!ip) continue
+    const ans = await queryOnce(ip, host, TYPE_NUM[type]).catch(() => null)
+    if (ans) return ans
+  }
+  return null
+}

--- a/src/lib/dnsRecords.ts
+++ b/src/lib/dnsRecords.ts
@@ -1,0 +1,324 @@
+// DNS record access layer (Phase 3) — the read + first-write slice for editing a
+// record's TTL directly at the host, since SpinupWP's API doesn't manage DNS
+// records. Mirrors the providers.ts registry shape: one descriptor per editable
+// provider, so the overlay and store stay provider-agnostic.
+//
+// The unit here is the RECORD (within a zone), not the zone. We only ever touch
+// ONE field — the TTL — so a record is "editable" only when changing its TTL is
+// well-defined: not a Route 53 alias (no TTL), not a routing-policy set (TTL edit
+// would need the whole policy echoed back), and not a Cloudflare proxied record
+// (its TTL is forced to automatic). Everything else surfaces but is read-only.
+//
+// Two providers are wired: AWS Route 53 (hand-rolled SigV4; the write is an async
+// ChangeResourceRecordSets we poll to INSYNC) and Cloudflare (REST; the PATCH is
+// synchronous). GoDaddy stays a web handoff — its API is gated, like in Phase 2.
+
+import { awsGet, awsPost, type AwsCreds } from "./awsSigV4.ts"
+import type { ConnProvider } from "./providers.ts"
+
+export interface DnsRecord {
+  key: string // stable row key (Route 53: name|type; Cloudflare: record id)
+  recordId?: string // provider record id (Cloudflare PATCH target)
+  name: string // record name (trailing dot stripped)
+  type: string // A, AAAA, CNAME, MX, TXT, …
+  ttl: number | null // current TTL in seconds; null when the record carries no TTL
+  values: string[] // record value(s) — shown, and echoed back on a Route 53 upsert
+  editable: boolean // can we change THIS record's TTL?
+  reason?: string // when not editable, the short why (alias / proxied / policy)
+}
+
+export interface ListResult {
+  ok: boolean
+  zoneId: string // provider zone id (needed again for the write); "" on failure
+  records: DnsRecord[]
+  error?: string
+}
+
+export interface ChangeResult {
+  ok: boolean
+  // Route 53 applies the change asynchronously; pollId is its change id (poll to
+  // INSYNC). Absent (Cloudflare) means the change already took effect.
+  pollId?: string
+  error?: string
+}
+
+export type ChangeStatus = "pending" | "done" | "failed"
+
+export interface RecordProvider {
+  // List a zone's records (and return the provider zone id for the follow-up write).
+  listRecords(creds: Record<string, string>, apex: string): Promise<ListResult>
+  // Change one record's TTL. `zoneId` comes from listRecords; `record` carries the
+  // values to preserve (Route 53 needs the full set on an upsert).
+  setTtl(creds: Record<string, string>, zoneId: string, record: DnsRecord, ttl: number): Promise<ChangeResult>
+  // Poll an async change to completion. Only providers that return a pollId set this.
+  pollChange?(creds: Record<string, string>, pollId: string): Promise<ChangeStatus>
+}
+
+// ---- TTL presets + helpers -------------------------------------------------
+
+// Common TTLs offered in the picker. The record's current value is always shown
+// too, so any existing TTL is selectable even when it's not on this list.
+export const TTL_PRESETS: { ttl: number; label: string }[] = [
+  { ttl: 300, label: "5 minutes" },
+  { ttl: 1800, label: "30 minutes" },
+  { ttl: 3600, label: "1 hour" },
+  { ttl: 14400, label: "4 hours" },
+  { ttl: 43200, label: "12 hours" },
+  { ttl: 86400, label: "1 day" },
+]
+
+// Sane bounds for the TTL editor. Cloudflare rejects sub-60s TTLs (other than its
+// "automatic" sentinel, which the proxied/auto guard already excludes); Route 53
+// allows lower, but a 1-week ceiling keeps the custom input from fat-fingering a
+// value far outside what anyone wants here.
+const TTL_MAX = 604800 // 7 days
+const TTL_MIN: Record<ConnProvider, number> = { aws: 1, cloudflare: 60, godaddy: 60 }
+
+// Validate a custom TTL for a provider. Returns an error string, or null when ok.
+export function validateTtl(provider: ConnProvider, ttl: number): string | null {
+  if (!Number.isInteger(ttl)) return "TTL must be a whole number of seconds."
+  const min = TTL_MIN[provider]
+  if (ttl < min) return `TTL must be at least ${min}s for this provider.`
+  if (ttl > TTL_MAX) return `TTL can't exceed ${TTL_MAX}s (7 days).`
+  return null
+}
+
+// Humanize a TTL for display (e.g. 3600 → "1h", 5400 → "1h30m").
+export function formatTtl(ttl: number | null): string {
+  if (ttl == null) return "—"
+  if (ttl === 0) return "0"
+  const d = Math.floor(ttl / 86400)
+  const h = Math.floor((ttl % 86400) / 3600)
+  const m = Math.floor((ttl % 3600) / 60)
+  const s = ttl % 60
+  const parts: string[] = []
+  if (d) parts.push(`${d}d`)
+  if (h) parts.push(`${h}h`)
+  if (m) parts.push(`${m}m`)
+  if (s) parts.push(`${s}s`)
+  return parts.join("") || "0"
+}
+
+function stripDot(name: string): string {
+  return name.replace(/\.$/, "")
+}
+
+// Decode the small set of XML entities Route 53 emits in values/names.
+function xmlUnescape(s: string): string {
+  return s
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&")
+}
+
+function xmlEscape(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+}
+
+// ---- AWS Route 53 ----------------------------------------------------------
+
+const R53_HOST = "route53.amazonaws.com"
+const R53_BASE = "/2013-04-01"
+
+function awsCreds(creds: Record<string, string>): AwsCreds {
+  return { accessKeyId: creds.accessKeyId ?? "", secretAccessKey: creds.secretAccessKey ?? "", region: creds.region || undefined }
+}
+
+function awsErrorMessage(xml: string): string | null {
+  return xml.match(/<Message>([^<]+)<\/Message>/)?.[1] ?? null
+}
+
+// Find the PUBLIC hosted-zone id for an apex (there can be a private zone of the
+// same name; we only edit the public one). Returns the bare id, e.g. "Z123ABC".
+async function awsZoneId(creds: AwsCreds, apex: string): Promise<{ id: string; error?: string }> {
+  const r = await awsGet(creds, "route53", R53_HOST, `${R53_BASE}/hostedzonesbyname`, { dnsname: apex, maxitems: "10" })
+  if (r.status !== 200) return { id: "", error: awsErrorMessage(r.body) || `Route 53 HTTP ${r.status}` }
+  const want = stripDot(apex).toLowerCase()
+  for (const block of r.body.split(/<HostedZone>/).slice(1)) {
+    const name = block.match(/<Name>([^<]+)<\/Name>/)?.[1]
+    if (!name || stripDot(name).toLowerCase() !== want) continue
+    if (/<PrivateZone>true<\/PrivateZone>/.test(block)) continue // skip private zones
+    const id = block.match(/<Id>([^<]+)<\/Id>/)?.[1]
+    if (id) return { id: id.replace(/^\/hostedzone\//, "") }
+  }
+  return { id: "", error: `No public Route 53 hosted zone for ${want}.` }
+}
+
+function parseRoute53Records(xml: string): DnsRecord[] {
+  const out: DnsRecord[] = []
+  for (const block of xml.split(/<ResourceRecordSet>/).slice(1)) {
+    const body = block.split("</ResourceRecordSet>")[0]
+    const name = body.match(/<Name>([^<]*)<\/Name>/)?.[1]
+    const type = body.match(/<Type>([^<]*)<\/Type>/)?.[1]
+    if (!name || !type) continue
+    const ttlRaw = body.match(/<TTL>(\d+)<\/TTL>/)?.[1]
+    const isAlias = /<AliasTarget>/.test(body)
+    const setId = body.match(/<SetIdentifier>([^<]*)<\/SetIdentifier>/)?.[1]
+    const values = [...body.matchAll(/<Value>([\s\S]*?)<\/Value>/g)].map((m) => xmlUnescape(m[1]))
+    let editable = true
+    let reason: string | undefined
+    if (isAlias) {
+      editable = false
+      reason = "alias"
+    } else if (setId != null) {
+      editable = false
+      reason = "routing policy"
+    } else if (ttlRaw == null) {
+      editable = false
+      reason = "no TTL"
+    }
+    const display = stripDot(xmlUnescape(name))
+    out.push({
+      key: `${display}|${type}|${setId ?? ""}`,
+      name: display,
+      type,
+      ttl: ttlRaw != null ? Number(ttlRaw) : null,
+      values: isAlias ? ["(alias)"] : values,
+      editable,
+      reason,
+    })
+  }
+  return out
+}
+
+const route53: RecordProvider = {
+  async listRecords(rawCreds, apex) {
+    const creds = awsCreds(rawCreds)
+    const zone = await awsZoneId(creds, apex)
+    if (!zone.id) return { ok: false, zoneId: "", records: [], error: zone.error }
+    const records: DnsRecord[] = []
+    const query: Record<string, string> = { maxitems: "300" }
+    // Paginate via NextRecordName/Type (StartRecord* on the follow-up call).
+    for (;;) {
+      const r = await awsGet(creds, "route53", R53_HOST, `${R53_BASE}/hostedzone/${zone.id}/rrset`, query)
+      if (r.status !== 200) return { ok: false, zoneId: "", records: [], error: awsErrorMessage(r.body) || `Route 53 HTTP ${r.status}` }
+      records.push(...parseRoute53Records(r.body))
+      if (!/<IsTruncated>true<\/IsTruncated>/.test(r.body)) break
+      const nextName = r.body.match(/<NextRecordName>([^<]+)<\/NextRecordName>/)?.[1]
+      const nextType = r.body.match(/<NextRecordType>([^<]+)<\/NextRecordType>/)?.[1]
+      if (!nextName || !nextType) break
+      query.name = nextName
+      query.type = nextType
+    }
+    return { ok: true, zoneId: zone.id, records }
+  },
+
+  async setTtl(rawCreds, zoneId, record, ttl) {
+    const creds = awsCreds(rawCreds)
+    // UPSERT replaces the whole record set, so echo the existing values back with
+    // the new TTL — anything omitted would be dropped.
+    const valuesXml = record.values.map((v) => `<ResourceRecord><Value>${xmlEscape(v)}</Value></ResourceRecord>`).join("")
+    const body =
+      `<?xml version="1.0" encoding="UTF-8"?>` +
+      `<ChangeResourceRecordSetsRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">` +
+      `<ChangeBatch><Comment>spinup: set TTL to ${ttl}</Comment><Changes><Change>` +
+      `<Action>UPSERT</Action><ResourceRecordSet>` +
+      `<Name>${xmlEscape(record.name)}</Name><Type>${record.type}</Type><TTL>${ttl}</TTL>` +
+      `<ResourceRecords>${valuesXml}</ResourceRecords>` +
+      `</ResourceRecordSet></Change></Changes></ChangeBatch>` +
+      `</ChangeResourceRecordSetsRequest>`
+    const r = await awsPost(creds, "route53", R53_HOST, `${R53_BASE}/hostedzone/${zoneId}/rrset/`, body)
+    if (r.status !== 200) return { ok: false, error: awsErrorMessage(r.body) || `Route 53 HTTP ${r.status}` }
+    const changeId = r.body.match(/<Id>([^<]+)<\/Id>/)?.[1]?.replace(/^\/change\//, "")
+    return { ok: true, pollId: changeId }
+  },
+
+  async pollChange(rawCreds, pollId) {
+    const creds = awsCreds(rawCreds)
+    const r = await awsGet(creds, "route53", R53_HOST, `${R53_BASE}/change/${pollId}`)
+    if (r.status !== 200) return "failed"
+    return /<Status>INSYNC<\/Status>/.test(r.body) ? "done" : "pending"
+  },
+}
+
+// ---- Cloudflare ------------------------------------------------------------
+
+const CF_API = "https://api.cloudflare.com/client/v4"
+
+function cfHeaders(token: string): Record<string, string> {
+  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }
+}
+
+function cfError(json: { errors?: { message?: string }[] } | undefined, status: number): string {
+  return json?.errors?.[0]?.message || `HTTP ${status}`
+}
+
+async function cfZoneId(token: string, apex: string): Promise<{ id: string; error?: string }> {
+  const res = await fetch(`${CF_API}/zones?name=${encodeURIComponent(apex)}`, { headers: cfHeaders(token) })
+  const json = (await res.json().catch(() => undefined)) as { success?: boolean; result?: { id: string }[]; errors?: { message?: string }[] } | undefined
+  if (!res.ok || !json?.success) return { id: "", error: cfError(json, res.status) }
+  const id = json.result?.[0]?.id
+  return id ? { id } : { id: "", error: `No Cloudflare zone for ${apex}.` }
+}
+
+const cloudflare: RecordProvider = {
+  async listRecords(rawCreds, apex) {
+    const token = rawCreds.token ?? ""
+    const zone = await cfZoneId(token, apex)
+    if (!zone.id) return { ok: false, zoneId: "", records: [], error: zone.error }
+    const records: DnsRecord[] = []
+    let page = 1
+    let totalPages = 1
+    do {
+      const res = await fetch(`${CF_API}/zones/${zone.id}/dns_records?per_page=100&page=${page}`, { headers: cfHeaders(token) })
+      const json = (await res.json().catch(() => undefined)) as
+        | { success?: boolean; errors?: { message?: string }[]; result?: { id: string; type: string; name: string; content: string; ttl: number; proxied?: boolean }[]; result_info?: { total_pages?: number } }
+        | undefined
+      if (!res.ok || !json?.success) return { ok: false, zoneId: "", records: [], error: cfError(json, res.status) }
+      for (const r of json.result ?? []) {
+        const proxied = r.proxied === true
+        records.push({
+          key: r.id,
+          recordId: r.id,
+          name: stripDot(r.name),
+          type: r.type,
+          ttl: r.ttl === 1 ? null : r.ttl, // 1 = Cloudflare "automatic"
+          values: [r.content],
+          editable: !proxied,
+          reason: proxied ? "proxied" : undefined,
+        })
+      }
+      totalPages = json.result_info?.total_pages ?? 1
+      page++
+    } while (page <= totalPages)
+    return { ok: true, zoneId: zone.id, records }
+  },
+
+  async setTtl(rawCreds, zoneId, record, ttl) {
+    const token = rawCreds.token ?? ""
+    if (!record.recordId) return { ok: false, error: "Missing Cloudflare record id." }
+    const res = await fetch(`${CF_API}/zones/${zoneId}/dns_records/${record.recordId}`, {
+      method: "PATCH",
+      headers: cfHeaders(token),
+      body: JSON.stringify({ ttl }),
+    })
+    const json = (await res.json().catch(() => undefined)) as { success?: boolean; errors?: { message?: string }[] } | undefined
+    if (!res.ok || !json?.success) return { ok: false, error: cfError(json, res.status) }
+    return { ok: true } // Cloudflare applies synchronously
+  },
+}
+
+// ---- Registry --------------------------------------------------------------
+
+const RECORD_PROVIDERS: Partial<Record<ConnProvider, RecordProvider>> = {
+  aws: route53,
+  cloudflare,
+}
+
+// The record provider for a connection provider, or null when records aren't
+// API-editable for it (e.g. GoDaddy → web handoff).
+export function recordProviderFor(provider: ConnProvider): RecordProvider | null {
+  return RECORD_PROVIDERS[provider] ?? null
+}
+
+// The TTL the picker should show as "current" for a record whose live TTL is null
+// (Cloudflare auto): default the custom field to a sensible 1h starting point.
+export function defaultTtlFor(record: DnsRecord): number {
+  return record.ttl ?? 3600
+}

--- a/src/lib/dnsRecords.ts
+++ b/src/lib/dnsRecords.ts
@@ -1,13 +1,20 @@
 // DNS record access layer (Phase 3) — the read + first-write slice for editing a
-// record's TTL directly at the host, since SpinupWP's API doesn't manage DNS
-// records. Mirrors the providers.ts registry shape: one descriptor per editable
+// site's hosting records directly at the host, since SpinupWP's API doesn't manage
+// DNS records. Mirrors the providers.ts registry shape: one descriptor per editable
 // provider, so the overlay and store stay provider-agnostic.
 //
-// The unit here is the RECORD (within a zone), not the zone. We only ever touch
-// ONE field — the TTL — so a record is "editable" only when changing its TTL is
-// well-defined: not a Route 53 alias (no TTL), not a routing-policy set (TTL edit
-// would need the whole policy echoed back), and not a Cloudflare proxied record
-// (its TTL is forced to automatic). Everything else surfaces but is read-only.
+// This is a MIGRATION record manager, NOT a zone editor. We never enumerate a zone:
+// reads are scoped to ONE named record (`getRecord`), so by construction the module
+// can't see — let alone touch — MX/TXT/DKIM/other records. That untouchability is
+// the product's safety guarantee (move the site without knocking out email), and it
+// holds host-agnostically: Route 53 scopes via StartRecordName/Type, Cloudflare via
+// the `?name=&type=` filter.
+//
+// We only ever touch the TTL (target/IP repointing is the next write), so a record
+// is "editable" only when changing its TTL is well-defined: not a Route 53 alias (no
+// TTL), not a routing-policy set (TTL edit would need the whole policy echoed back),
+// and not a Cloudflare proxied record (its TTL is forced to automatic). A
+// non-editable record surfaces with a short reason.
 //
 // Two providers are wired: AWS Route 53 (hand-rolled SigV4; the write is an async
 // ChangeResourceRecordSets we poll to INSYNC) and Cloudflare (REST; the PATCH is
@@ -27,10 +34,14 @@ export interface DnsRecord {
   reason?: string // when not editable, the short why (alias / proxied / policy)
 }
 
-export interface ListResult {
+export interface RecordResult {
   ok: boolean
   zoneId: string // provider zone id (needed again for the write); "" on failure
-  records: DnsRecord[]
+  record?: DnsRecord // the single requested record
+  // The zone's declared apex NS records — fuel for the edit-time NS-match gate
+  // (compare to fresh live NS). Omitted by providers whose access is already
+  // NS-matched at connect time (Cloudflare), so the gate simply doesn't apply.
+  apexNs?: string[]
   error?: string
 }
 
@@ -45,9 +56,11 @@ export interface ChangeResult {
 export type ChangeStatus = "pending" | "done" | "failed"
 
 export interface RecordProvider {
-  // List a zone's records (and return the provider zone id for the follow-up write).
-  listRecords(creds: Record<string, string>, apex: string): Promise<ListResult>
-  // Change one record's TTL. `zoneId` comes from listRecords; `record` carries the
+  // Read ONE named record (and return the provider zone id for the follow-up write,
+  // plus the apex NS for the edit-time gate). Scoped on purpose — we never list the
+  // whole zone.
+  getRecord(creds: Record<string, string>, apex: string, name: string, type: string): Promise<RecordResult>
+  // Change one record's TTL. `zoneId` comes from getRecord; `record` carries the
   // values to preserve (Route 53 needs the full set on an upsert).
   setTtl(creds: Record<string, string>, zoneId: string, record: DnsRecord, ttl: number): Promise<ChangeResult>
   // Poll an async change to completion. Only providers that return a pollId set this.
@@ -187,26 +200,30 @@ function parseRoute53Records(xml: string): DnsRecord[] {
   return out
 }
 
+// Scoped read: ListResourceRecordSets starting at a name+type returns records AT or
+// AFTER that name, so we ask for a few and pick the exact match (never the zone).
+async function r53RecordAt(creds: AwsCreds, zoneId: string, name: string, type: string): Promise<{ ok: boolean; records: DnsRecord[]; error?: string }> {
+  const r = await awsGet(creds, "route53", R53_HOST, `${R53_BASE}/hostedzone/${zoneId}/rrset`, { name, type, maxitems: "5" })
+  if (r.status !== 200) return { ok: false, records: [], error: awsErrorMessage(r.body) || `Route 53 HTTP ${r.status}` }
+  return { ok: true, records: parseRoute53Records(r.body) }
+}
+
 const route53: RecordProvider = {
-  async listRecords(rawCreds, apex) {
+  async getRecord(rawCreds, apex, name, type) {
     const creds = awsCreds(rawCreds)
     const zone = await awsZoneId(creds, apex)
-    if (!zone.id) return { ok: false, zoneId: "", records: [], error: zone.error }
-    const records: DnsRecord[] = []
-    const query: Record<string, string> = { maxitems: "300" }
-    // Paginate via NextRecordName/Type (StartRecord* on the follow-up call).
-    for (;;) {
-      const r = await awsGet(creds, "route53", R53_HOST, `${R53_BASE}/hostedzone/${zone.id}/rrset`, query)
-      if (r.status !== 200) return { ok: false, zoneId: "", records: [], error: awsErrorMessage(r.body) || `Route 53 HTTP ${r.status}` }
-      records.push(...parseRoute53Records(r.body))
-      if (!/<IsTruncated>true<\/IsTruncated>/.test(r.body)) break
-      const nextName = r.body.match(/<NextRecordName>([^<]+)<\/NextRecordName>/)?.[1]
-      const nextType = r.body.match(/<NextRecordType>([^<]+)<\/NextRecordType>/)?.[1]
-      if (!nextName || !nextType) break
-      query.name = nextName
-      query.type = nextType
-    }
-    return { ok: true, zoneId: zone.id, records }
+    if (!zone.id) return { ok: false, zoneId: "", error: zone.error }
+    const want = stripDot(name).toLowerCase()
+    const got = await r53RecordAt(creds, zone.id, name, type)
+    if (!got.ok) return { ok: false, zoneId: "", error: got.error }
+    const record = got.records.find((r) => r.name.toLowerCase() === want && r.type === type)
+    if (!record) return { ok: false, zoneId: "", error: `No ${type} record for ${want} in this zone.` }
+    // A second scoped read for the apex NS (the edit-time NS-match gate compares it
+    // to the fresh live NS). Failure here just disables the gate, never the edit.
+    const apexLc = stripDot(apex).toLowerCase()
+    const nsGot = await r53RecordAt(creds, zone.id, apex, "NS")
+    const apexNs = nsGot.records.find((r) => r.type === "NS" && r.name.toLowerCase() === apexLc)?.values ?? []
+    return { ok: true, zoneId: zone.id, record, apexNs }
   },
 
   async setTtl(rawCreds, zoneId, record, ttl) {
@@ -258,36 +275,32 @@ async function cfZoneId(token: string, apex: string): Promise<{ id: string; erro
 }
 
 const cloudflare: RecordProvider = {
-  async listRecords(rawCreds, apex) {
+  async getRecord(rawCreds, apex, name, type) {
     const token = rawCreds.token ?? ""
     const zone = await cfZoneId(token, apex)
-    if (!zone.id) return { ok: false, zoneId: "", records: [], error: zone.error }
-    const records: DnsRecord[] = []
-    let page = 1
-    let totalPages = 1
-    do {
-      const res = await fetch(`${CF_API}/zones/${zone.id}/dns_records?per_page=100&page=${page}`, { headers: cfHeaders(token) })
-      const json = (await res.json().catch(() => undefined)) as
-        | { success?: boolean; errors?: { message?: string }[]; result?: { id: string; type: string; name: string; content: string; ttl: number; proxied?: boolean }[]; result_info?: { total_pages?: number } }
-        | undefined
-      if (!res.ok || !json?.success) return { ok: false, zoneId: "", records: [], error: cfError(json, res.status) }
-      for (const r of json.result ?? []) {
-        const proxied = r.proxied === true
-        records.push({
-          key: r.id,
-          recordId: r.id,
-          name: stripDot(r.name),
-          type: r.type,
-          ttl: r.ttl === 1 ? null : r.ttl, // 1 = Cloudflare "automatic"
-          values: [r.content],
-          editable: !proxied,
-          reason: proxied ? "proxied" : undefined,
-        })
-      }
-      totalPages = json.result_info?.total_pages ?? 1
-      page++
-    } while (page <= totalPages)
-    return { ok: true, zoneId: zone.id, records }
+    if (!zone.id) return { ok: false, zoneId: "", error: zone.error }
+    // Scoped read: filter to the one record by name+type (never the whole zone).
+    const url = `${CF_API}/zones/${zone.id}/dns_records?name=${encodeURIComponent(stripDot(name))}&type=${encodeURIComponent(type)}`
+    const res = await fetch(url, { headers: cfHeaders(token) })
+    const json = (await res.json().catch(() => undefined)) as
+      | { success?: boolean; errors?: { message?: string }[]; result?: { id: string; type: string; name: string; content: string; ttl: number; proxied?: boolean }[] }
+      | undefined
+    if (!res.ok || !json?.success) return { ok: false, zoneId: "", error: cfError(json, res.status) }
+    const r = json.result?.[0]
+    if (!r) return { ok: false, zoneId: "", error: `No ${type} record for ${stripDot(name)} in this zone.` }
+    const proxied = r.proxied === true
+    const record: DnsRecord = {
+      key: r.id,
+      recordId: r.id,
+      name: stripDot(r.name),
+      type: r.type,
+      ttl: r.ttl === 1 ? null : r.ttl, // 1 = Cloudflare "automatic"
+      values: [r.content],
+      editable: !proxied,
+      reason: proxied ? "proxied" : undefined,
+    }
+    // apexNs omitted — Cloudflare access is already NS-matched at connect time.
+    return { ok: true, zoneId: zone.id, record }
   },
 
   async setTtl(rawCreds, zoneId, record, ttl) {

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -200,15 +200,15 @@ export const PROVIDER_REGISTRY: Record<ConnProvider, ProviderDescriptor> = {
       { name: "secretAccessKey", label: "Secret Access Key", secret: true, placeholder: "secret" },
       { name: "region", label: "Region (optional, default us-east-1)", optional: true, placeholder: "us-east-1" },
     ],
-    guidance: "Use an IAM user scoped to route53:ListHostedZones + ListResourceRecordSets.",
+    guidance: "IAM perms: route53 ListHostedZonesByName + ListResourceRecordSets to view; add ChangeResourceRecordSets + GetChange to edit TTLs.",
     verify: verifyAws,
   },
   cloudflare: {
     key: "cloudflare",
     name: "Cloudflare",
     hostKeys: ["cloudflare"],
-    fields: [{ name: "token", label: "API token — Zone:Read is enough", secret: true, placeholder: "Cloudflare API token" }],
-    guidance: "Create one at dash.cloudflare.com → My Profile → API Tokens.",
+    fields: [{ name: "token", label: "API token — DNS:Read to view, DNS:Edit to change TTLs", secret: true, placeholder: "Cloudflare API token" }],
+    guidance: "Create one at dash.cloudflare.com → My Profile → API Tokens (Zone DNS:Edit to edit records).",
     verify: verifyCloudflare,
   },
   godaddy: {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -21,6 +21,7 @@ import { Discover } from "./views/Discover.tsx"
 import { Forgotten } from "./views/Forgotten.tsx"
 import { DnsInventory } from "./views/DnsInventory.tsx"
 import { ProviderConnect } from "./views/ProviderConnect.tsx"
+import { DnsRecords } from "./views/DnsRecords.tsx"
 
 const MIN_SPLASH_MS = 1200
 
@@ -49,7 +50,8 @@ export function App() {
     store.discoverOpen ||
     store.forgottenOpen ||
     store.dnsInventoryServer !== null ||
-    store.connectZoneTarget !== null
+    store.connectZoneTarget !== null ||
+    store.dnsRecordsTarget !== null
   useEffect(() => {
     store.setOverlayOpen(overlayActive)
   }, [overlayActive, store])
@@ -93,6 +95,9 @@ export function App() {
 
     // The provider-connect overlay owns the keyboard while open.
     if (store.connectZoneTarget) return
+
+    // The DNS-records overlay owns the keyboard while open.
+    if (store.dnsRecordsTarget) return
 
     if (showHelp) {
       if (key.name === "escape" || key.name === "q" || key.name === "?") setShowHelp(false)
@@ -167,6 +172,7 @@ export function App() {
       {store.forgottenOpen && <Forgotten />}
       {store.dnsInventoryServer && <DnsInventory />}
       {store.connectZoneTarget && <ProviderConnect />}
+      {store.dnsRecordsTarget && <DnsRecords />}
     </box>
   )
 }

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -14,7 +14,8 @@ import type { Stack } from "../lib/stack.ts"
 import { openTerminalAt, openUrl, openSshSession } from "../lib/open.ts"
 import { gitDrift, type Drift } from "../lib/gitStatus.ts"
 import { probeSite } from "../lib/probe.ts"
-import { resolveZone, normalizeDomain } from "../lib/dns.ts"
+import { resolveZone, normalizeDomain, candidateHostnames } from "../lib/dns.ts"
+import { queryAuthoritative } from "../lib/dnsQuery.ts"
 import { DnsCache, type CachedDns } from "../lib/dnsCache.ts"
 import {
   verifyConnection as verifyProviderConnection,
@@ -29,6 +30,7 @@ import {
   type AccessState,
 } from "../lib/providers.ts"
 import { ProvidersCache, type VerifiedConn } from "../lib/providersCache.ts"
+import { recordProviderFor, type DnsRecord, type ListResult } from "../lib/dnsRecords.ts"
 import type { StoredProviders } from "../config.ts"
 import { fetchRebootInfo, type RebootInfo } from "../lib/ssh.ts"
 import { StackCache, siteSignature, type CachedProbe } from "../lib/stackCache.ts"
@@ -67,6 +69,37 @@ export interface ServerOpProgress {
 
 export function isServerOpInFlight(p: ServerOpProgress | undefined): boolean {
   return p != null && p.status !== UPGRADE_DONE && p.status !== UPGRADE_FAIL
+}
+
+// A record TTL change (Phase 3), tracked in the store (same model as the other
+// writes) so it survives the records overlay being closed and a Route 53 change
+// can keep polling to INSYNC in the background. Keyed by the record's stable key.
+// `status`: queued → pending (Route 53 propagating) → done | failed. Cloudflare
+// applies synchronously, so it jumps straight to done.
+export interface TtlWriteProgress {
+  ttl: number
+  status: string
+  error?: string
+}
+const TTL_DONE = "done"
+const TTL_FAIL = "failed"
+const TTL_POLL_MS = 3000
+
+export function isTtlWriteInFlight(p: TtlWriteProgress | undefined): boolean {
+  return p != null && p.status !== TTL_DONE && p.status !== TTL_FAIL
+}
+
+// A resolved website-hosting record for one hostname (apex / www / additional
+// domain), read cred-free from the zone's authoritative NS for the DNS inventory.
+// `type === "none"` means the hostname has no record (e.g. www isn't configured).
+export interface HostRecord {
+  host: string // the hostname (lowercased)
+  apex: string // its zone apex
+  type: string // A | AAAA | CNAME | none
+  ttl: number | null // configured TTL (from the authoritative answer)
+  value: string // record value (IP or CNAME target)
+  pointsHere: boolean // resolves (following CNAMEs) to this server's IP
+  checkedAt: number
 }
 
 export interface DataState {
@@ -183,6 +216,14 @@ interface StoreValue extends DataState {
   // The cached zone-host for a domain (undefined = never looked up).
   zoneForDomain: (domain: string) => CachedDns | undefined
   isDnsResolving: (domain: string) => boolean
+  // Website-hosting records (apex/www/additional + TTLs), keyed by hostname.
+  // Read cred-free from each zone's authoritative NS; resolved lazily once the
+  // zone's NS are known. The migration-focused inventory reads these.
+  hostingRecords: Map<string, HostRecord>
+  // Resolve every site's hosting hostnames on a server (needs the zone NS first).
+  resolveServerHosting: (server: Server, force?: boolean) => void
+  hostingFor: (host: string) => HostRecord | undefined
+  isHostingResolving: (host: string) => boolean
   // The server whose DNS-inventory overlay is open, or null. Set by site views.
   dnsInventoryServer: Server | null
   setDnsInventoryServer: (s: Server | null) => void
@@ -204,9 +245,24 @@ interface StoreValue extends DataState {
   accessForZone: (apex: string, hostKey: string, liveNs: string[]) => AccessState
   // The connection (account) label that owns/serves a zone, or "" if none.
   accountForZone: (apex: string, hostKey: string, liveNs: string[]) => string
+  // The connection (with creds) that serves a zone, or null — drives record editing.
+  connForZone: (apex: string, hostKey: string, liveNs: string[]) => Connection | null
   // The zone whose provider-connect overlay is open (apex + its host key), or null.
   connectZoneTarget: { apex: string; hostKey: string } | null
   setConnectZoneTarget: (t: { apex: string; hostKey: string } | null) => void
+  // The zone whose DNS-records overlay is open (Phase 3: view records + edit TTL),
+  // with the connection id we'll authenticate the record calls with. `focus` (set
+  // when opened from a specific inventory record) pre-selects that record. null = closed.
+  dnsRecordsTarget: { apex: string; hostKey: string; connId: string; focus?: { name: string; type: string } } | null
+  setDnsRecordsTarget: (t: { apex: string; hostKey: string; connId: string; focus?: { name: string; type: string } } | null) => void
+  // In-flight (and just-settled) record TTL changes, keyed by the record key.
+  // Tracked in the store so a Route 53 change keeps polling after the overlay closes.
+  ttlWrites: Map<string, TtlWriteProgress>
+  // List a zone's DNS records via the serving connection (read; on demand).
+  listZoneRecords: (connId: string, apex: string) => Promise<ListResult>
+  // Change a record's TTL via the host's API and follow it to completion.
+  startTtlChange: (connId: string, zoneId: string, record: DnsRecord, ttl: number) => void
+  clearTtlWrite: (key: string) => void
   // Whether a PHP version is past end-of-life (real dates vs today, refreshed).
   isPhpEol: (version: string | null | undefined) => boolean
   // PHP versions to offer in the upgrade picker (dynamic; current always included).
@@ -286,6 +342,13 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const [dnsResolving, setDnsResolving] = useState<Set<string>>(new Set())
   const [dnsInventoryServer, setDnsInventoryServer] = useState<Server | null>(null)
 
+  // Website-hosting record lookups (Phase 3 inventory). In-memory for the session;
+  // resolved on demand once the hostname's zone NS are known. `hostingInFlight`
+  // dedupes concurrent queries without re-rendering.
+  const hostingInFlight = useRef<Set<string>>(new Set())
+  const [hostingRecords, setHostingRecords] = useState<Map<string, HostRecord>>(new Map())
+  const [hostingResolving, setHostingResolving] = useState<Set<string>>(new Set())
+
   // DNS provider connections (Phase 2). Connections hydrate from config (stored +
   // env); their verified zone sets hydrate from disk and re-verify on demand.
   const providersCacheRef = useRef<ProvidersCache | null>(null)
@@ -296,6 +359,8 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const [connections, setConnections] = useState<Record<ConnProvider, Connection[]>>(() => cfgRef.current.providerConnections)
   const [providerZones, setProviderZones] = useState<Map<string, VerifiedConn>>(() => providersCacheRef.current!.snapshot())
   const [connectZoneTarget, setConnectZoneTarget] = useState<{ apex: string; hostKey: string } | null>(null)
+  const [dnsRecordsTarget, setDnsRecordsTarget] = useState<{ apex: string; hostKey: string; connId: string; focus?: { name: string; type: string } } | null>(null)
+  const [ttlWrites, setTtlWrites] = useState<Map<string, TtlWriteProgress>>(new Map())
 
   // PHP EOL dates: embedded defaults overlaid with the last cached fetch; a
   // background refresh (endoflife.date) updates them when the cache is stale.
@@ -708,6 +773,68 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const zoneForDomain = useCallback((domain: string) => dnsZones.get(normalizeDomain(domain)), [dnsZones])
   const isDnsResolving = useCallback((domain: string) => dnsResolving.has(normalizeDomain(domain)), [dnsResolving])
 
+  // ---- Website-hosting record lookups (Phase 3 inventory) --------------------
+
+  // Resolve one hostname's record at its zone's authoritative NS. Records "none"
+  // when the hostname has no record (so it isn't retried); a network miss also
+  // caches none until a forced refresh.
+  const resolveHostingOne = useCallback(async (host: string, apex: string, ns: string[], serverIp: string | null) => {
+    if (hostingInFlight.current.has(host)) return
+    hostingInFlight.current.add(host)
+    setHostingResolving((prev) => new Set(prev).add(host))
+    try {
+      const ans = await queryAuthoritative(host, "A", ns)
+      const own = ans?.find((a) => a.name.toLowerCase() === host)
+      const here = !!(serverIp && ans?.some((a) => a.type === "A" && a.value === serverIp))
+      const rec: HostRecord = own
+        ? { host, apex, type: own.type, ttl: own.ttl, value: own.value, pointsHere: here, checkedAt: Date.now() }
+        : { host, apex, type: "none", ttl: null, value: "", pointsHere: false, checkedAt: Date.now() }
+      setHostingRecords((prev) => new Map(prev).set(host, rec))
+    } finally {
+      hostingInFlight.current.delete(host)
+      setHostingResolving((prev) => {
+        const next = new Set(prev)
+        next.delete(host)
+        return next
+      })
+    }
+  }, [])
+
+  const resolveServerHosting = useCallback(
+    (server: Server, force = false) => {
+      const serverIp = server.ip_address ?? null
+      const hosts = new Set<string>()
+      for (const s of sites) if (s.server_id === server.id) for (const h of candidateHostnames(domainsForSite(s))) hosts.add(h)
+      // Only resolve hostnames whose zone NS we already know (needed to query the
+      // authoritative server). The rest get picked up when their zone lands and
+      // this re-runs (it's cheap — already-resolved/in-flight are skipped).
+      const pool: { host: string; apex: string; ns: string[] }[] = []
+      for (const host of hosts) {
+        if (hostingInFlight.current.has(host)) continue
+        if (!force && hostingRecords.has(host)) continue
+        const z = dnsZones.get(normalizeDomain(host))
+        const ns = z?.zone?.nameservers
+        const apex = z?.zone?.apex
+        if (!ns || ns.length === 0 || !apex) continue
+        pool.push({ host, apex, ns })
+      }
+      if (pool.length === 0) return
+      const CONCURRENCY = 5
+      let cursor = 0
+      const worker = async () => {
+        while (cursor < pool.length) {
+          const { host, apex, ns } = pool[cursor++]
+          await resolveHostingOne(host, apex, ns, serverIp)
+        }
+      }
+      for (let i = 0; i < Math.min(CONCURRENCY, pool.length); i++) void worker()
+    },
+    [sites, dnsZones, hostingRecords, resolveHostingOne],
+  )
+
+  const hostingFor = useCallback((host: string) => hostingRecords.get(host.toLowerCase()), [hostingRecords])
+  const isHostingResolving = useCallback((host: string) => hostingResolving.has(host.toLowerCase()), [hostingResolving])
+
   // ---- DNS provider connections (Phase 2 access detection) -------------------
 
   const genConnId = (provider: ConnProvider) =>
@@ -717,17 +844,18 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const connectionsFor = useCallback((provider: ConnProvider) => connections[provider], [connections])
 
   // Zones we can reach, keyed by `${provider}:${apex}` → list of candidate
-  // accounts (label + the account-zone's assigned nameservers). Provider-scoped:
-  // a Cloudflare-hosted zone is only reachable via a connected CLOUDFLARE account.
+  // accounts (connection id + label + the account-zone's assigned nameservers).
+  // Provider-scoped: a Cloudflare-hosted zone is only reachable via a connected
+  // CLOUDFLARE account.
   const reachable = useMemo(() => {
-    const m = new Map<string, { label: string; ns: string[] }[]>()
+    const m = new Map<string, { id: string; label: string; ns: string[] }[]>()
     for (const conn of allConnections) {
       const v = providerZones.get(conn.id)
       if (v?.ok)
         for (const z of v.zones) {
           const key = `${conn.provider}:${z.apex}`
           const list = m.get(key) ?? []
-          list.push({ label: conn.label || conn.id, ns: z.nameservers ?? [] })
+          list.push({ id: conn.id, label: conn.label || conn.id, ns: z.nameservers ?? [] })
           m.set(key, list)
         }
     }
@@ -739,23 +867,23 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   // duplicate zones across accounts). When no NS are known (e.g. AWS), fall back
   // to membership — provider-scoping already guarantees the right provider.
   const matchedAccount = useCallback(
-    (apex: string, hostKey: string, liveNs: string[]): { editable: boolean; label: string } => {
+    (apex: string, hostKey: string, liveNs: string[]): { editable: boolean; label: string; id: string } => {
       const prov = apiProviderFor(hostKey)
-      if (!prov) return { editable: false, label: "" }
+      if (!prov) return { editable: false, label: "", id: "" }
       const candidates = reachable.get(`${prov}:${apex}`) ?? []
-      if (candidates.length === 0) return { editable: false, label: "" }
+      if (candidates.length === 0) return { editable: false, label: "", id: "" }
       const withNs = candidates.filter((c) => c.ns.length > 0)
       // If we know any candidate's NS, require a live match to count as editable.
       if (withNs.length > 0 && liveNs.length > 0) {
         const live = withNs.find((c) => nameserversMatch(c.ns, liveNs))
-        if (live) return { editable: true, label: live.label }
+        if (live) return { editable: true, label: live.label, id: live.id }
         // Some candidates have NS but none serve the live zone → only editable if
         // another candidate's NS are unknown (can't disprove it).
         const unknown = candidates.find((c) => c.ns.length === 0)
-        return unknown ? { editable: true, label: unknown.label } : { editable: false, label: "" }
+        return unknown ? { editable: true, label: unknown.label, id: unknown.id } : { editable: false, label: "", id: "" }
       }
       // No NS info to match on → membership (provider-scoped) is the best we have.
-      return { editable: true, label: candidates[0].label }
+      return { editable: true, label: candidates[0].label, id: candidates[0].id }
     },
     [reachable],
   )
@@ -778,6 +906,15 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const accountForZone = useCallback(
     (apex: string, hostKey: string, liveNs: string[]) => matchedAccount(apex, hostKey, liveNs).label,
     [matchedAccount],
+  )
+
+  const connForZone = useCallback(
+    (apex: string, hostKey: string, liveNs: string[]): Connection | null => {
+      const m = matchedAccount(apex, hostKey, liveNs)
+      if (!m.editable || !m.id) return null
+      return allConnections.find((c) => c.id === m.id) ?? null
+    },
+    [matchedAccount, allConnections],
   )
 
   // Persist the stored (non-env) connections to config, keeping cfgRef in sync.
@@ -854,6 +991,81 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     [allConnections, verifyAndCache],
   )
 
+  // ---- DNS record TTL change (Phase 3, first write) -------------------------
+
+  const listZoneRecords = useCallback(
+    async (connId: string, apex: string): Promise<ListResult> => {
+      const conn = allConnections.find((c) => c.id === connId)
+      const provider = conn ? recordProviderFor(conn.provider) : null
+      if (!conn || !provider) return { ok: false, zoneId: "", records: [], error: "No reachable connection for this zone." }
+      return provider.listRecords(conn.creds, apex)
+    },
+    [allConnections],
+  )
+
+  const setTtlWrite = (key: string, progress: TtlWriteProgress) =>
+    setTtlWrites((prev) => new Map(prev).set(key, progress))
+
+  const clearTtlWrite = useCallback(
+    (key: string) =>
+      setTtlWrites((prev) => {
+        if (!prev.has(key)) return prev
+        const next = new Map(prev)
+        next.delete(key)
+        return next
+      }),
+    [],
+  )
+
+  const startTtlChange = useCallback(
+    (connId: string, zoneId: string, record: DnsRecord, ttl: number) => {
+      const existing = ttlWrites.get(record.key)
+      if (existing && isTtlWriteInFlight(existing)) return // one change per record at a time
+
+      const conn = allConnections.find((c) => c.id === connId)
+      const provider = conn ? recordProviderFor(conn.provider) : null
+      if (!conn || !provider) {
+        setTtlWrite(record.key, { ttl, status: TTL_FAIL, error: "Lost the provider connection — reopen the records view." })
+        return
+      }
+
+      const run = async () => {
+        setTtlWrite(record.key, { ttl, status: "queued" })
+        let res
+        try {
+          res = await provider.setTtl(conn.creds, zoneId, record, ttl)
+        } catch (err) {
+          setTtlWrite(record.key, { ttl, status: TTL_FAIL, error: (err as Error).message })
+          return
+        }
+        if (!res.ok) {
+          setTtlWrite(record.key, { ttl, status: TTL_FAIL, error: res.error || "The provider rejected the change." })
+          return
+        }
+        // No poll id (Cloudflare) → already applied. Otherwise poll to INSYNC.
+        if (!res.pollId || !provider.pollChange) {
+          setTtlWrite(record.key, { ttl, status: TTL_DONE })
+          return
+        }
+        const pollId = res.pollId
+        setTtlWrite(record.key, { ttl, status: "pending" })
+        const poll = async () => {
+          try {
+            const status = await provider.pollChange!(conn.creds, pollId)
+            if (status === "done") setTtlWrite(record.key, { ttl, status: TTL_DONE })
+            else if (status === "failed") setTtlWrite(record.key, { ttl, status: TTL_FAIL, error: "The change failed to propagate." })
+            else setTimeout(() => void poll(), TTL_POLL_MS)
+          } catch (err) {
+            setTtlWrite(record.key, { ttl, status: TTL_FAIL, error: (err as Error).message })
+          }
+        }
+        setTimeout(() => void poll(), TTL_POLL_MS)
+      }
+      void run()
+    },
+    [allConnections, ttlWrites],
+  )
+
   const value: StoreValue = {
     servers,
     sites,
@@ -922,6 +1134,10 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     lookupServerDns,
     zoneForDomain,
     isDnsResolving,
+    hostingRecords,
+    resolveServerHosting,
+    hostingFor,
+    isHostingResolving,
     dnsInventoryServer,
     setDnsInventoryServer,
     connections,
@@ -933,8 +1149,15 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     verifyConnectionById,
     accessForZone,
     accountForZone,
+    connForZone,
     connectZoneTarget,
     setConnectZoneTarget,
+    dnsRecordsTarget,
+    setDnsRecordsTarget,
+    ttlWrites,
+    listZoneRecords,
+    startTtlChange,
+    clearTtlWrite,
     isPhpEol,
     offeredPhpVersions,
   }

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -30,7 +30,7 @@ import {
   type AccessState,
 } from "../lib/providers.ts"
 import { ProvidersCache, type VerifiedConn } from "../lib/providersCache.ts"
-import { recordProviderFor, type DnsRecord, type ListResult } from "../lib/dnsRecords.ts"
+import { recordProviderFor, type DnsRecord, type RecordResult } from "../lib/dnsRecords.ts"
 import type { StoredProviders } from "../config.ts"
 import { fetchRebootInfo, type RebootInfo } from "../lib/ssh.ts"
 import { StackCache, siteSignature, type CachedProbe } from "../lib/stackCache.ts"
@@ -80,6 +80,8 @@ export interface TtlWriteProgress {
   ttl: number
   status: string
   error?: string
+  host: string // record hostname (lowercased) — lets the inventory match a write to a row
+  type: string // record type (A / AAAA / CNAME …)
 }
 const TTL_DONE = "done"
 const TTL_FAIL = "failed"
@@ -225,8 +227,12 @@ interface StoreValue extends DataState {
   hostingFor: (host: string) => HostRecord | undefined
   isHostingResolving: (host: string) => boolean
   // The server whose DNS-inventory overlay is open, or null. Set by site views.
+  // `focusSiteId` (optional) scopes the overlay to a single site (opened via `n`);
+  // null shows every site on the server (opened via `N`).
   dnsInventoryServer: Server | null
-  setDnsInventoryServer: (s: Server | null) => void
+  dnsInventoryFocusSiteId: number | null
+  setDnsInventoryServer: (s: Server | null, focusSiteId?: number | null) => void
+  setDnsInventoryFocusSiteId: (id: number | null) => void
   // DNS provider connections (Phase 2), keyed by provider — each is a credential
   // ("account"). The overlay lists + manages them. `providerZones` holds each
   // connection's last verified zone set (hydrated from disk). Secrets persist to
@@ -251,15 +257,17 @@ interface StoreValue extends DataState {
   connectZoneTarget: { apex: string; hostKey: string } | null
   setConnectZoneTarget: (t: { apex: string; hostKey: string } | null) => void
   // The zone whose DNS-records overlay is open (Phase 3: view records + edit TTL),
-  // with the connection id we'll authenticate the record calls with. `focus` (set
-  // when opened from a specific inventory record) pre-selects that record. null = closed.
-  dnsRecordsTarget: { apex: string; hostKey: string; connId: string; focus?: { name: string; type: string } } | null
-  setDnsRecordsTarget: (t: { apex: string; hostKey: string; connId: string; focus?: { name: string; type: string } } | null) => void
+  // with the connection id we'll authenticate the record calls with. `record` is the
+  // single hosting record to edit (migration lens — never a whole zone). null = closed.
+  dnsRecordsTarget: { apex: string; hostKey: string; connId: string; record: { name: string; type: string } } | null
+  setDnsRecordsTarget: (t: { apex: string; hostKey: string; connId: string; record: { name: string; type: string } } | null) => void
   // In-flight (and just-settled) record TTL changes, keyed by the record key.
   // Tracked in the store so a Route 53 change keeps polling after the overlay closes.
   ttlWrites: Map<string, TtlWriteProgress>
-  // List a zone's DNS records via the serving connection (read; on demand).
-  listZoneRecords: (connId: string, apex: string) => Promise<ListResult>
+  // Read ONE hosting record via the serving connection (scoped; on demand).
+  getZoneRecord: (connId: string, apex: string, name: string, type: string) => Promise<RecordResult>
+  // The latest TTL write for a hostname+type (drives the inventory's updating status).
+  ttlWriteForHost: (host: string, type: string) => TtlWriteProgress | undefined
   // Change a record's TTL via the host's API and follow it to completion.
   startTtlChange: (connId: string, zoneId: string, record: DnsRecord, ttl: number) => void
   clearTtlWrite: (key: string) => void
@@ -340,7 +348,12 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const dnsInFlight = useRef<Set<string>>(new Set())
   const [dnsZones, setDnsZones] = useState<Map<string, CachedDns>>(() => dnsCacheRef.current!.snapshot())
   const [dnsResolving, setDnsResolving] = useState<Set<string>>(new Set())
-  const [dnsInventoryServer, setDnsInventoryServer] = useState<Server | null>(null)
+  const [dnsInventoryServer, setDnsInventoryServerState] = useState<Server | null>(null)
+  const [dnsInventoryFocusSiteId, setDnsInventoryFocusSiteId] = useState<number | null>(null)
+  const setDnsInventoryServer = useCallback((s: Server | null, focusSiteId: number | null = null) => {
+    setDnsInventoryServerState(s)
+    setDnsInventoryFocusSiteId(focusSiteId)
+  }, [])
 
   // Website-hosting record lookups (Phase 3 inventory). In-memory for the session;
   // resolved on demand once the hostname's zone NS are known. `hostingInFlight`
@@ -359,7 +372,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const [connections, setConnections] = useState<Record<ConnProvider, Connection[]>>(() => cfgRef.current.providerConnections)
   const [providerZones, setProviderZones] = useState<Map<string, VerifiedConn>>(() => providersCacheRef.current!.snapshot())
   const [connectZoneTarget, setConnectZoneTarget] = useState<{ apex: string; hostKey: string } | null>(null)
-  const [dnsRecordsTarget, setDnsRecordsTarget] = useState<{ apex: string; hostKey: string; connId: string; focus?: { name: string; type: string } } | null>(null)
+  const [dnsRecordsTarget, setDnsRecordsTarget] = useState<{ apex: string; hostKey: string; connId: string; record: { name: string; type: string } } | null>(null)
   const [ttlWrites, setTtlWrites] = useState<Map<string, TtlWriteProgress>>(new Map())
 
   // PHP EOL dates: embedded defaults overlaid with the last cached fetch; a
@@ -993,18 +1006,29 @@ export function StoreProvider({ children }: { children: ReactNode }) {
 
   // ---- DNS record TTL change (Phase 3, first write) -------------------------
 
-  const listZoneRecords = useCallback(
-    async (connId: string, apex: string): Promise<ListResult> => {
+  const getZoneRecord = useCallback(
+    async (connId: string, apex: string, name: string, type: string): Promise<RecordResult> => {
       const conn = allConnections.find((c) => c.id === connId)
       const provider = conn ? recordProviderFor(conn.provider) : null
-      if (!conn || !provider) return { ok: false, zoneId: "", records: [], error: "No reachable connection for this zone." }
-      return provider.listRecords(conn.creds, apex)
+      if (!conn || !provider) return { ok: false, zoneId: "", error: "No reachable connection for this zone." }
+      return provider.getRecord(conn.creds, apex, name, type)
     },
     [allConnections],
   )
 
   const setTtlWrite = (key: string, progress: TtlWriteProgress) =>
     setTtlWrites((prev) => new Map(prev).set(key, progress))
+
+  // The latest TTL write for a given hostname+type, if any — so the inventory can
+  // show an "updating"/just-changed status on the matching record row.
+  const ttlWriteForHost = useCallback(
+    (host: string, type: string): TtlWriteProgress | undefined => {
+      const h = host.toLowerCase()
+      for (const p of ttlWrites.values()) if (p.host === h && p.type === type) return p
+      return undefined
+    },
+    [ttlWrites],
+  )
 
   const clearTtlWrite = useCallback(
     (key: string) =>
@@ -1022,41 +1046,46 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       const existing = ttlWrites.get(record.key)
       if (existing && isTtlWriteInFlight(existing)) return // one change per record at a time
 
+      // Stamp every progress update with the record's host/type so the inventory can
+      // match an in-flight write back to its row after the editor closes.
+      const put = (status: string, error?: string) =>
+        setTtlWrite(record.key, { ttl, status, host: record.name.toLowerCase(), type: record.type, ...(error ? { error } : {}) })
+
       const conn = allConnections.find((c) => c.id === connId)
       const provider = conn ? recordProviderFor(conn.provider) : null
       if (!conn || !provider) {
-        setTtlWrite(record.key, { ttl, status: TTL_FAIL, error: "Lost the provider connection — reopen the records view." })
+        put(TTL_FAIL, "Lost the provider connection — reopen the records view.")
         return
       }
 
       const run = async () => {
-        setTtlWrite(record.key, { ttl, status: "queued" })
+        put("queued")
         let res
         try {
           res = await provider.setTtl(conn.creds, zoneId, record, ttl)
         } catch (err) {
-          setTtlWrite(record.key, { ttl, status: TTL_FAIL, error: (err as Error).message })
+          put(TTL_FAIL, (err as Error).message)
           return
         }
         if (!res.ok) {
-          setTtlWrite(record.key, { ttl, status: TTL_FAIL, error: res.error || "The provider rejected the change." })
+          put(TTL_FAIL, res.error || "The provider rejected the change.")
           return
         }
         // No poll id (Cloudflare) → already applied. Otherwise poll to INSYNC.
         if (!res.pollId || !provider.pollChange) {
-          setTtlWrite(record.key, { ttl, status: TTL_DONE })
+          put(TTL_DONE)
           return
         }
         const pollId = res.pollId
-        setTtlWrite(record.key, { ttl, status: "pending" })
+        put("pending")
         const poll = async () => {
           try {
             const status = await provider.pollChange!(conn.creds, pollId)
-            if (status === "done") setTtlWrite(record.key, { ttl, status: TTL_DONE })
-            else if (status === "failed") setTtlWrite(record.key, { ttl, status: TTL_FAIL, error: "The change failed to propagate." })
+            if (status === "done") put(TTL_DONE)
+            else if (status === "failed") put(TTL_FAIL, "The change failed to propagate.")
             else setTimeout(() => void poll(), TTL_POLL_MS)
           } catch (err) {
-            setTtlWrite(record.key, { ttl, status: TTL_FAIL, error: (err as Error).message })
+            put(TTL_FAIL, (err as Error).message)
           }
         }
         setTimeout(() => void poll(), TTL_POLL_MS)
@@ -1139,7 +1168,9 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     hostingFor,
     isHostingResolving,
     dnsInventoryServer,
+    dnsInventoryFocusSiteId,
     setDnsInventoryServer,
+    setDnsInventoryFocusSiteId,
     connections,
     connectionsFor,
     connectionCount: allConnections.length,
@@ -1155,7 +1186,8 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     dnsRecordsTarget,
     setDnsRecordsTarget,
     ttlWrites,
-    listZoneRecords,
+    getZoneRecord,
+    ttlWriteForHost,
     startTtlChange,
     clearTtlWrite,
     isPhpEol,

--- a/src/ui/views/Browser.tsx
+++ b/src/ui/views/Browser.tsx
@@ -22,7 +22,7 @@ type Focus = "servers" | "sites"
 
 export function Browser({ rows }: { rows: number }) {
   const store = useStore()
-  const { servers, sitesForServer, route, inputMode, overlayOpen, setHealthServer, runProbe, accountSlug, setPhpUpgradeSite, phpUpgrades, setServerActionsServer, serverOps, setLocalLinkSite, openLocalTerminal, openLocalUrl, localLinks, sshSite, lookupSiteDns, setDnsInventoryServer } = store
+  const { servers, sitesForServer, route, inputMode, overlayOpen, setHealthServer, runProbe, accountSlug, setPhpUpgradeSite, phpUpgrades, setServerActionsServer, serverOps, setLocalLinkSite, openLocalTerminal, openLocalUrl, localLinks, sshSite, setDnsInventoryServer } = store
 
   const [serverIndex, setServerIndex] = useState(0)
   const [siteIndex, setSiteIndex] = useState(0)
@@ -127,16 +127,11 @@ export function Browser({ rows }: { rows: number }) {
         }
         return
       case "n":
-        // Look up where the selected site's domains host DNS (shows in Details).
-        if (focus === "sites" && sites[siteIndex]) {
-          const s = sites[siteIndex]
-          lookupSiteDns(s)
-          setFlash(`Looking up DNS hosts for ${s.domain}…`)
-          setTimeout(() => setFlash(null), 1500)
-        }
+        // DNS inventory scoped to the selected site (its domains + records).
+        if (focus === "sites" && sites[siteIndex] && server) setDnsInventoryServer(server, sites[siteIndex].id)
         return
       case "N":
-        // Server-wide DNS zone-host inventory (server-scoped, both panes).
+        // Server-wide DNS inventory — every site on the server.
         if (server) setDnsInventoryServer(server)
         return
       case "a":

--- a/src/ui/views/DnsInventory.tsx
+++ b/src/ui/views/DnsInventory.tsx
@@ -1,17 +1,20 @@
-// DNS zone-host inventory for a server — the read-only first slice of the DNS
-// module. Answers "where is every domain on this server's DNS hosted?", the
-// inventory you build by hand when migrating or cloning a site.
+// DNS inventory for a server — a MIGRATION lens, not a zone editor. For every site
+// on the server it shows the website-hosting records that "count" when you move
+// the site to another server: each zone, and nested under it the site's own
+// hostnames (apex, www, additional domains) with their live record + TTL, flagged
+// when they point at THIS server. The full per-zone record list lives in the `⏎`
+// drill-down (DnsRecords) — that's where editing happens. Opened with `N`.
 //
-// The unit is the ZONE, not the hostname: www + apex collapse into one row, and a
-// separate-TLD additional domain (e.g. example.net redirecting to example.com)
-// surfaces as its OWN zone with its OWN host — because a full move must carry the
-// whole portfolio, and those can live on a different provider. Opened with `N`.
+// TTLs here are read CRED-FREE from each zone's authoritative nameserver (the
+// configured, non-decremented value), so they show for every host — not just the
+// ones we hold an API key for. Editing a TTL still needs a connected account.
 
 import { useEffect, useMemo, useState } from "react"
 import { useKeyboard, useTerminalDimensions } from "@opentui/react"
 import { theme, statusColor, statusDot } from "../../lib/theme.ts"
 import { truncate, timeAgo } from "../../lib/format.ts"
-import { normalizeDomain } from "../../lib/dns.ts"
+import { normalizeDomain, candidateHostnames } from "../../lib/dns.ts"
+import { formatTtl } from "../../lib/dnsRecords.ts"
 import { apiProviderFor, consoleForHost, type AccessState } from "../../lib/providers.ts"
 import { openUrl, copyToClipboard } from "../../lib/open.ts"
 import { List, moveSelection } from "../List.tsx"
@@ -20,15 +23,16 @@ import { Spinner } from "../components.tsx"
 import { useStore } from "../store.tsx"
 import type { Site } from "../../api/types.ts"
 
-// Fixed column widths (chars) so SITE/ZONE/HOST/ACCESS align on every row; NOTE
-// flexes to fill the remainder. Each cell truncates to width-1 for a 1-space gutter.
-const SITE_W = 38
-const ZONE_W = 44
-const HOST_W = 18
+// Fixed column widths (chars) so columns align on every row; VALUE flexes.
+const SITE_W = 22
+const NAME_W = 30
+const TYPE_W = 7
+const TTL_W = 8
+const HOST_W = 16
 const ACCESS_W = 8
-const ACCOUNT_W = 18
+const ACCOUNT_W = 16
 
-// Glyph + color for an access state (Phase 2). `·` is the resting/unknown state.
+// Glyph + color for an access state. `·` is the resting/unknown state.
 function accessGlyph(state: AccessState, selected: boolean): { glyph: string; color: string } {
   switch (state) {
     case "editable":
@@ -42,46 +46,84 @@ function accessGlyph(state: AccessState, selected: boolean): { glyph: string; co
   }
 }
 
-interface ZoneRow {
-  siteDomain: string // owning site (primary domain)
-  showSite: boolean // first zone row for this site (others blank the column)
-  status: string // owning site status (for the leading dot)
-  zone: string // zone apex (or normalized domain when unresolved)
-  hostKey: string // provider key from DNS detection (drives access + the `c` action)
-  host: string // provider label, or a lookup-state string
-  hostColor: string
-  access: AccessState // editable | needs-key | web | unknown
-  account: string // owning connection/account label (editable zones only)
-  note: string // e.g. "→ redirects to example.com"
-  checkedAt: number | null // age of the cached lookup, null when not yet known
-}
+// A zone-header row, or a hosting-record row nested under it. Both carry the zone
+// identity (apex/hostKey/access/liveNs) so access/edit actions work from either.
+type InvRow =
+  | {
+      kind: "zone"
+      siteDomain: string
+      showSite: boolean
+      status: string
+      apex: string
+      hostKey: string
+      host: string
+      hostColor: string
+      access: AccessState
+      account: string
+      liveNs: string[]
+      note: string
+      checkedAt: number | null
+    }
+  | {
+      kind: "record"
+      apex: string
+      hostKey: string
+      access: AccessState
+      liveNs: string[]
+      name: string // the hostname
+      recordType: string // A | CNAME | AAAA | "" while resolving
+      ttl: number | null
+      value: string
+      pointsHere: boolean
+      resolving: boolean
+    }
 
 export function DnsInventory() {
-  const { dnsInventoryServer, setDnsInventoryServer, sitesForServer, zoneForDomain, lookupServerDns, dnsZones, dnsResolving, accessForZone, accountForZone, setConnectZoneTarget, connectZoneTarget, connections, connectionCount, providerZones, verifyConnectionById } =
-    useStore()
+  const {
+    dnsInventoryServer,
+    setDnsInventoryServer,
+    sitesForServer,
+    zoneForDomain,
+    lookupServerDns,
+    dnsZones,
+    dnsResolving,
+    accessForZone,
+    accountForZone,
+    connForZone,
+    setConnectZoneTarget,
+    connectZoneTarget,
+    dnsRecordsTarget,
+    setDnsRecordsTarget,
+    connectionCount,
+    providerZones,
+    connections,
+    verifyConnectionById,
+    resolveServerHosting,
+    hostingFor,
+    isHostingResolving,
+  } = useStore()
   const allConnections = useMemo(() => Object.values(connections).flat(), [connections])
-  // Show the ACCOUNT column only when more than one account is connected (else
-  // it's the same label on every editable row — just noise).
   const showAccount = connectionCount >= 2
   const { height } = useTerminalDimensions()
   const [index, setIndex] = useState(0)
   const [flash, setFlash] = useState<string | null>(null)
   const server = dnsInventoryServer
 
-  // Kick off resolution for any un-cached domains when the overlay opens.
+  // Kick off zone-host resolution when the overlay opens.
   useEffect(() => {
     if (server) lookupServerDns(server.id)
   }, [server, lookupServerDns])
 
-  // Verify any configured-but-not-yet-verified connections so `✓` access appears
-  // without a manual re-verify (e.g. connections from a prior session or env).
-  // Cached ones are left alone; re-verify is on demand (connect overlay `v`).
+  // Resolve hosting records once their zone NS are known — re-runs as zones land
+  // (already-resolved/in-flight hostnames are skipped, so this is cheap).
   useEffect(() => {
-    for (const c of allConnections) {
-      if (!providerZones.has(c.id)) verifyConnectionById(c.id)
-    }
-    // providerZones intentionally omitted: verify once per connection, not on each
-    // cache update (which would re-fire mid-flight).
+    if (server) resolveServerHosting(server)
+  }, [server, dnsZones, resolveServerHosting])
+
+  // Verify configured-but-unverified connections so `✓` access appears without a
+  // manual re-verify.
+  useEffect(() => {
+    for (const c of allConnections) if (!providerZones.has(c.id)) verifyConnectionById(c.id)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allConnections, verifyConnectionById])
 
@@ -90,12 +132,11 @@ export function DnsInventory() {
     [server, sitesForServer],
   )
 
-  // Build the zone-keyed rows. Recomputes as lookups land (dnsZones changes).
-  const { rows, summary, resolvedZones, totalZones } = useMemo(() => {
-    const out: ZoneRow[] = []
-    const tally = new Map<string, number>() // host label → zone count
-    let total = 0
-    let resolved = 0
+  const { rows, summary, pending } = useMemo(() => {
+    const out: InvRow[] = []
+    let zoneCount = 0
+    let hereCount = 0
+    let resolving = false
 
     for (const site of sites) {
       const entries = [
@@ -104,7 +145,6 @@ export function DnsInventory() {
       ]
       const primaryApex = zoneForDomain(site.domain)?.zone?.apex ?? normalizeDomain(site.domain)
 
-      // Group the site's domains by zone apex.
       const groups = new Map<string, { apex: string; entries: typeof entries }>()
       for (const e of entries) {
         const apex = zoneForDomain(e.domain)?.zone?.apex ?? normalizeDomain(e.domain)
@@ -112,67 +152,115 @@ export function DnsInventory() {
         g.entries.push(e)
         groups.set(apex, g)
       }
-
-      // Primary zone first, then alphabetical.
       const ordered = [...groups.values()].sort((a, b) =>
         a.apex === primaryApex ? -1 : b.apex === primaryApex ? 1 : a.apex.localeCompare(b.apex),
       )
 
       ordered.forEach((g, idx) => {
-        total++
+        zoneCount++
         const cached = zoneForDomain(g.entries[0].domain)
-        const resolving = g.entries.some((e) => dnsResolving.has(normalizeDomain(e.domain)))
-        let host: string
-        let hostColor: string
+        const zoneResolving = g.entries.some((e) => dnsResolving.has(normalizeDomain(e.domain)))
         const hostKey = cached?.zone?.providerKey ?? ""
         const liveNs = cached?.zone?.nameservers ?? []
+        let host: string
+        let hostColor: string
         if (cached === undefined) {
-          host = resolving ? "looking up…" : "—"
-          hostColor = resolving ? theme.textDim : theme.textFaint
+          host = zoneResolving ? "looking up…" : "—"
+          hostColor = zoneResolving ? theme.textDim : theme.textFaint
+          resolving = resolving || zoneResolving
         } else if (cached.zone === null) {
           host = "no host found"
           hostColor = theme.warn
-          resolved++
         } else {
           host = cached.zone.providerLabel
           hostColor = theme.accent
-          resolved++
-          tally.set(host, (tally.get(host) ?? 0) + 1)
         }
-        // A note only when this zone is NOT the canonical one and redirects away.
         const isPrimaryZone = g.apex === primaryApex
         const redirect = g.entries.find((e) => e.redirect?.enabled)?.redirect
         const note = !isPrimaryZone && redirect ? `→ redirects to ${redirect.destination}` : ""
+        const access = accessForZone(g.apex, hostKey, liveNs)
+
         out.push({
+          kind: "zone",
           siteDomain: site.domain,
           showSite: idx === 0,
           status: site.status,
-          zone: g.apex,
+          apex: g.apex,
           hostKey,
           host,
           hostColor,
-          access: accessForZone(g.apex, hostKey, liveNs),
+          access,
           account: accountForZone(g.apex, hostKey, liveNs),
+          liveNs,
           note,
           checkedAt: cached?.checkedAt ?? null,
         })
+
+        // Nested hosting records: the site's hostnames in this zone (apex first).
+        const hosts = candidateHostnames(g.entries.map((e) => e.domain)).sort((a, b) =>
+          a === g.apex ? -1 : b === g.apex ? 1 : a.localeCompare(b),
+        )
+        for (const name of hosts) {
+          const hr = hostingFor(name)
+          if (hr && hr.type === "none") continue // no record for this hostname — nothing to migrate
+          const isResolving = isHostingResolving(name) || (!hr && cached?.zone != null)
+          if (hr?.pointsHere) hereCount++
+          if (!hr && isResolving) resolving = true
+          out.push({
+            kind: "record",
+            apex: g.apex,
+            hostKey,
+            access,
+            liveNs,
+            name,
+            recordType: hr?.type ?? "",
+            ttl: hr?.ttl ?? null,
+            value: hr?.value ?? "",
+            pointsHere: hr?.pointsHere ?? false,
+            resolving: !hr,
+          })
+        }
       })
     }
 
-    const parts = [...tally.entries()].sort((a, b) => b[1] - a[1]).map(([label, n]) => `${n} ${label}`)
-    const pending = total - resolved
-    if (pending > 0) parts.push(`${pending} resolving`)
-    const summary = `${total} zone${total === 1 ? "" : "s"}${parts.length ? " · " + parts.join(" · ") : ""}`
-    return { rows: out, summary, resolvedZones: resolved, totalZones: total }
-  }, [sites, dnsZones, dnsResolving, zoneForDomain, accessForZone, accountForZone])
+    const summary = `${zoneCount} zone${zoneCount === 1 ? "" : "s"}${hereCount ? ` · ${hereCount} point${hereCount === 1 ? "s" : ""} here` : ""}`
+    return { rows: out, summary, pending: resolving }
+  }, [sites, dnsZones, dnsResolving, zoneForDomain, accessForZone, accountForZone, hostingFor, isHostingResolving])
 
   const safeIndex = Math.min(index, Math.max(0, rows.length - 1))
   const close = () => setDnsInventoryServer(null)
 
+  function openDrill(r: InvRow) {
+    if (r.access === "web") return openWeb(r)
+    if (r.access !== "editable") return showFlash("Connect API access first — press c")
+    const conn = connForZone(r.apex, r.hostKey, r.liveNs)
+    if (!conn) return showFlash("No reachable account for this zone — press c")
+    const focus = r.kind === "record" && r.recordType ? { name: r.name, type: r.recordType } : undefined
+    setDnsRecordsTarget({ apex: r.apex, hostKey: r.hostKey, connId: conn.id, focus })
+  }
+
+  function openWeb(r: InvRow) {
+    const con = consoleForHost(r.hostKey)
+    if (con) {
+      copyToClipboard(r.apex)
+      openUrl(con.url)
+      showFlash(`${con.label} opened · ${r.apex} copied`)
+    } else {
+      showFlash("No web console for this host — c to manage access")
+    }
+  }
+
+  function showFlash(msg: string) {
+    if (!msg) return
+    setFlash(msg)
+    setTimeout(() => setFlash(null), 2200)
+  }
+
   useKeyboard((key) => {
-    if (connectZoneTarget) return // the connect overlay (on top) owns the keyboard
+    if (connectZoneTarget || dnsRecordsTarget) return // an overlay on top owns the keyboard
     const raw = key.name ?? ""
     const name = key.shift && raw.length === 1 ? raw.toUpperCase() : raw
+    const r = rows[safeIndex]
     switch (name) {
       case "escape":
       case "q":
@@ -184,76 +272,60 @@ export function DnsInventory() {
       case "j":
         return setIndex((i) => moveSelection(i, 1, rows.length))
       case "r":
-        if (server) lookupServerDns(server.id, true)
+        if (server) {
+          lookupServerDns(server.id, true)
+          resolveServerHosting(server, true)
+        }
         return
-      case "c": {
-        // Manage access for the selected zone: connect an API provider, or open
-        // the web console for a host we can't drive via API.
-        const r = rows[safeIndex]
+      case "return":
+      case "right":
+      case "l":
+      case "t":
+        if (r) openDrill(r)
+        return
+      case "c":
         if (!r) return
-        if (apiProviderFor(r.hostKey)) setConnectZoneTarget({ apex: r.zone, hostKey: r.hostKey })
+        if (apiProviderFor(r.hostKey)) setConnectZoneTarget({ apex: r.apex, hostKey: r.hostKey })
         else openWeb(r)
         return
-      }
-      case "w": {
-        // Quick web handoff for the selected zone (e.g. GoDaddy Clients hub),
-        // copying the domain so it's ready to paste — no overlay round-trip.
-        const r = rows[safeIndex]
+      case "w":
         if (r) openWeb(r)
         return
-      }
     }
   })
 
-  function openWeb(r: ZoneRow) {
-    const con = consoleForHost(r.hostKey)
-    if (con) {
-      copyToClipboard(r.zone)
-      openUrl(con.url)
-      showFlash(`${con.label} opened · ${r.zone} copied`)
-    } else {
-      showFlash("No web console for this host — c to manage access")
-    }
-  }
-
-  function showFlash(msg: string) {
-    if (!msg) return
-    setFlash(msg)
-    setTimeout(() => setFlash(null), 2000)
-  }
-
   if (!server) return null
   const listRows = Math.max(3, height - 7)
-  const oldest = rows.reduce<number | null>((min, r) => (r.checkedAt && (min === null || r.checkedAt < min) ? r.checkedAt : min), null)
+  const oldest = rows.reduce<number | null>(
+    (min, r) => (r.kind === "zone" && r.checkedAt && (min === null || r.checkedAt < min) ? r.checkedAt : min),
+    null,
+  )
 
   return (
     <box style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", flexDirection: "column", backgroundColor: theme.bg, zIndex: 216 }}>
       <box style={{ flexDirection: "row", height: 1, backgroundColor: theme.bgAlt, paddingLeft: 1, paddingRight: 1, alignItems: "center" }}>
-        <text content={`🌐 DNS hosts · ${truncate(server.name, 28)}  `} fg={theme.brand} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content={`🌐 DNS · ${truncate(server.name, 26)}  `} fg={theme.brand} wrapMode="none" style={{ flexShrink: 0 }} />
         <text content={summary} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 1 }} />
         <box style={{ flexGrow: 1 }} />
-        {resolvedZones < totalZones ? <Spinner color={theme.brand} interval={120} /> : null}
+        {pending ? <Spinner color={theme.brand} interval={120} /> : null}
       </box>
 
-      {/* Column header — fixed widths so SITE/ZONE/HOST/ACCESS line up on every row;
-          the leading "  " matches the status-dot cell. NOTE (last) flexes to fill. */}
+      {/* Column header. SITE/zone-or-record name align across both row kinds. */}
       <box style={{ flexDirection: "row", paddingLeft: 1, paddingRight: 1, height: 1 }}>
         <text content={"  " + "SITE".padEnd(SITE_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
-        <text content={"ZONE".padEnd(ZONE_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
-        <text content={"HOST".padEnd(HOST_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
-        <text content={"ACCESS".padEnd(ACCESS_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
-        {showAccount ? <text content={"ACCOUNT".padEnd(ACCOUNT_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} /> : null}
-        <text content="NOTE" fg={theme.textFaint} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
+        <text content={"ZONE / RECORD".padEnd(NAME_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content={"TYPE".padEnd(TYPE_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content={"TTL".padEnd(TTL_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content="VALUE / HOST" fg={theme.textFaint} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
       </box>
 
-      {/* Access legend — teaches the glyphs + the c action in-context. */}
+      {/* Legend — teaches access glyphs + the "points here" flag in-context. */}
       <box style={{ flexDirection: "row", paddingLeft: 1, paddingRight: 1, height: 1 }}>
-        <text content="ACCESS  " fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
         <text content="✓ editable" fg={theme.good} wrapMode="none" style={{ flexShrink: 0 }} />
-        <text content="   ↗ web only" fg={theme.accent} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content="   ↗ web" fg={theme.accent} wrapMode="none" style={{ flexShrink: 0 }} />
         <text content="   ○ needs key" fg={theme.warn} wrapMode="none" style={{ flexShrink: 0 }} />
-        <text content="   · unknown" fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
-        <text content="    c manage access" fg={theme.textDim} wrapMode="none" style={{ flexShrink: 1 }} />
+        <text content="   ◀ here = points at this server" fg={theme.good} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content="    ⏎ edit TTL · c access" fg={theme.textDim} wrapMode="none" style={{ flexShrink: 1 }} />
       </box>
 
       <box style={{ flexGrow: 1, flexDirection: "column", paddingLeft: 1, paddingRight: 1 }}>
@@ -266,31 +338,18 @@ export function DnsInventory() {
             viewportRows={listRows}
             focused
             keyFor={(_r, i) => i}
-            emptyText="—"
-            renderRow={(r, selected) => {
-              const acc = accessGlyph(r.access, selected)
-              return (
-                <>
-                  <text content={r.showSite ? statusDot(r.status) + " " : "  "} fg={statusColor(r.status)} style={{ flexShrink: 0 }} />
-                  <text content={(r.showSite ? truncate(r.siteDomain, SITE_W - 1) : "").padEnd(SITE_W)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} />
-                  <text content={truncate(r.zone, ZONE_W - 1).padEnd(ZONE_W)} fg={theme.text} wrapMode="none" style={{ flexShrink: 0 }} />
-                  <text content={truncate(r.host, HOST_W - 1).padEnd(HOST_W)} fg={selected ? theme.text : r.hostColor} wrapMode="none" style={{ flexShrink: 0 }} />
-                  <text content={(acc.glyph + " ").padEnd(ACCESS_W)} fg={acc.color} wrapMode="none" style={{ flexShrink: 0 }} />
-                  {showAccount ? <text content={truncate(r.account, ACCOUNT_W - 1).padEnd(ACCOUNT_W)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} /> : null}
-                  <text content={r.note} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
-                </>
-              )
-            }}
+            renderRow={(r, selected) => (r.kind === "zone" ? renderZone(r, selected) : renderRecord(r, selected))}
           />
         )}
       </box>
 
       <StatusBar
         hints={[
-          { key: "↑↓/jk", label: "scroll" },
+          { key: "↑↓/jk", label: "select" },
+          { key: "⏎", label: "edit TTL" },
           { key: "c", label: "manage access" },
           { key: "w", label: "web console" },
-          { key: "r", label: "refresh lookups" },
+          { key: "r", label: "refresh" },
           { key: "esc", label: "close" },
         ]}
         message={flash ?? (oldest ? `checked ${timeAgo(new Date(oldest).toISOString())}` : undefined)}
@@ -299,4 +358,43 @@ export function DnsInventory() {
       />
     </box>
   )
+
+  function renderZone(r: Extract<InvRow, { kind: "zone" }>, selected: boolean) {
+    const acc = accessGlyph(r.access, selected)
+    return (
+      <>
+        <text content={r.showSite ? statusDot(r.status) + " " : "  "} fg={statusColor(r.status)} style={{ flexShrink: 0 }} />
+        <text content={(r.showSite ? truncate(r.siteDomain, SITE_W - 1) : "").padEnd(SITE_W)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content={truncate(r.apex, NAME_W - 1).padEnd(NAME_W)} fg={selected ? theme.text : theme.text} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content={truncate(r.host, HOST_W - 1).padEnd(HOST_W)} fg={selected ? theme.text : r.hostColor} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content={(acc.glyph + " ").padEnd(ACCESS_W)} fg={acc.color} wrapMode="none" style={{ flexShrink: 0 }} />
+        {showAccount ? <text content={truncate(r.account, ACCOUNT_W - 1).padEnd(ACCOUNT_W)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} /> : null}
+        <text content={r.note} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
+      </>
+    )
+  }
+
+  function renderRecord(r: Extract<InvRow, { kind: "record" }>, selected: boolean) {
+    const ttlFg = selected ? theme.text : theme.accent
+    return (
+      <>
+        <text content="  " style={{ flexShrink: 0 }} />
+        <text content={"".padEnd(SITE_W)} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content={("  ↳ " + truncate(r.name, NAME_W - 5)).padEnd(NAME_W)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} />
+        {r.resolving ? (
+          <box style={{ flexDirection: "row", width: TYPE_W + TTL_W, flexShrink: 0 }}>
+            <Spinner color={selected ? theme.text : theme.textDim} interval={120} />
+            <text content=" looking up…" fg={selected ? theme.text : theme.textFaint} wrapMode="none" />
+          </box>
+        ) : (
+          <>
+            <text content={r.recordType.padEnd(TYPE_W)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} />
+            <text content={formatTtl(r.ttl).padEnd(TTL_W)} fg={ttlFg} wrapMode="none" style={{ flexShrink: 0 }} />
+          </>
+        )}
+        <text content={truncate(r.value, 48)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
+        {r.pointsHere ? <text content=" ◀ here" fg={selected ? theme.text : theme.good} wrapMode="none" style={{ flexShrink: 0 }} /> : null}
+      </>
+    )
+  }
 }

--- a/src/ui/views/DnsInventory.tsx
+++ b/src/ui/views/DnsInventory.tsx
@@ -14,23 +14,24 @@ import { useKeyboard, useTerminalDimensions } from "@opentui/react"
 import { theme, statusColor, statusDot } from "../../lib/theme.ts"
 import { truncate, timeAgo } from "../../lib/format.ts"
 import { normalizeDomain, candidateHostnames } from "../../lib/dns.ts"
-import { formatTtl } from "../../lib/dnsRecords.ts"
 import { apiProviderFor, consoleForHost, type AccessState } from "../../lib/providers.ts"
 import { openUrl, copyToClipboard } from "../../lib/open.ts"
 import { List, moveSelection } from "../List.tsx"
 import { StatusBar } from "../StatusBar.tsx"
 import { Spinner } from "../components.tsx"
-import { useStore } from "../store.tsx"
+import { useStore, isTtlWriteInFlight } from "../store.tsx"
 import type { Site } from "../../api/types.ts"
 
 // Fixed column widths (chars) so columns align on every row; VALUE flexes.
-const SITE_W = 22
-const NAME_W = 30
-const TYPE_W = 7
+// Fixed column widths (chars). VALUE flexes; HOST/ACCOUNT sit on the right.
+const NAME_W = 32
+const TYPE_W = 6
 const TTL_W = 8
-const HOST_W = 16
-const ACCESS_W = 8
+const HOST_W = 14
 const ACCOUNT_W = 16
+
+// Lowercase a hostname and drop a trailing dot (for comparisons).
+const norm = (d: string) => d.trim().toLowerCase().replace(/\.$/, "")
 
 // Glyph + color for an access state. `·` is the resting/unknown state.
 function accessGlyph(state: AccessState, selected: boolean): { glyph: string; color: string } {
@@ -46,13 +47,13 @@ function accessGlyph(state: AccessState, selected: boolean): { glyph: string; co
   }
 }
 
-// A zone-header row, or a hosting-record row nested under it. Both carry the zone
+// A folded zone line (zone identity + its apex hosting record, when the site is
+// served at the apex), or a hosting-record row nested under it for the non-apex
+// records that still need action (own-A www, subdomains). Both carry the zone
 // identity (apex/hostKey/access/liveNs) so access/edit actions work from either.
 type InvRow =
   | {
       kind: "zone"
-      siteDomain: string
-      showSite: boolean
       status: string
       apex: string
       hostKey: string
@@ -63,6 +64,22 @@ type InvRow =
       liveNs: string[]
       note: string
       checkedAt: number | null
+      // Site grouping: the primary zone is the site's `●` line; additional-domain
+      // zones nest under it as `↳` lines. `extraZones` (on the primary) drives the
+      // "(+N)" portfolio hint.
+      isPrimary: boolean
+      extraZones: number
+      // The site's own hosting record, folded into this line. `recordName` is the
+      // hostname it belongs to (the site's domain — apex for a root site, the
+      // subdomain for a subdomain-hosted site), used as the label + the edit target.
+      recordName: string
+      hasRecord: boolean
+      recordType: string // A | AAAA | CNAME | ""
+      ttl: number | null
+      value: string
+      pointsHere: boolean
+      resolving: boolean // apex record still being looked up
+      wwwFollows: boolean // a www CNAME that just follows the apex → shown as "+www"
     }
   | {
       kind: "record"
@@ -75,13 +92,17 @@ type InvRow =
       ttl: number | null
       value: string
       pointsHere: boolean
+      followsApex: boolean // a www/alias CNAME pointing at the apex — follows it on a move, no edit needed
       resolving: boolean
+      indent: number // 1 = record under the primary zone; 2 = under an additional-domain zone
     }
 
 export function DnsInventory() {
   const {
     dnsInventoryServer,
+    dnsInventoryFocusSiteId,
     setDnsInventoryServer,
+    setDnsInventoryFocusSiteId,
     sitesForServer,
     zoneForDomain,
     lookupServerDns,
@@ -101,6 +122,7 @@ export function DnsInventory() {
     resolveServerHosting,
     hostingFor,
     isHostingResolving,
+    ttlWriteForHost,
   } = useStore()
   const allConnections = useMemo(() => Object.values(connections).flat(), [connections])
   const showAccount = connectionCount >= 2
@@ -127,10 +149,13 @@ export function DnsInventory() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allConnections, verifyConnectionById])
 
-  const sites = useMemo<Site[]>(
+  const allSites = useMemo<Site[]>(
     () => (server ? [...sitesForServer(server.id)].sort((a, b) => a.domain.localeCompare(b.domain)) : []),
     [server, sitesForServer],
   )
+  // When opened via `n`, scope the rows to a single site; `N` shows them all.
+  const focusSite = dnsInventoryFocusSiteId != null ? allSites.find((s) => s.id === dnsInventoryFocusSiteId) ?? null : null
+  const sites = useMemo<Site[]>(() => (focusSite ? [focusSite] : allSites), [focusSite, allSites])
 
   const { rows, summary, pending } = useMemo(() => {
     const out: InvRow[] = []
@@ -155,8 +180,9 @@ export function DnsInventory() {
       const ordered = [...groups.values()].sort((a, b) =>
         a.apex === primaryApex ? -1 : b.apex === primaryApex ? 1 : a.apex.localeCompare(b.apex),
       )
+      const additionalZones = ordered.length - 1
 
-      ordered.forEach((g, idx) => {
+      ordered.forEach((g) => {
         zoneCount++
         const cached = zoneForDomain(g.entries[0].domain)
         const zoneResolving = g.entries.some((e) => dnsResolving.has(normalizeDomain(e.domain)))
@@ -180,10 +206,27 @@ export function DnsInventory() {
         const note = !isPrimaryZone && redirect ? `→ redirects to ${redirect.destination}` : ""
         const access = accessForZone(g.apex, hostKey, liveNs)
 
+        // The site's hostnames in this zone (apex first).
+        const hosts = candidateHostnames(g.entries.map((e) => e.domain)).sort((a, b) =>
+          a === g.apex ? -1 : b === g.apex ? 1 : a.localeCompare(b),
+        )
+        // The line's head = the SITE's own domain in this zone: the apex when the site
+        // is served at the root, otherwise the subdomain the site actually lives at
+        // (so three sites on one apex read as three distinct lines, not one).
+        const headHost = hosts.includes(g.apex) ? g.apex : norm(g.entries[0].domain)
+        const headRec = hostingFor(headHost)
+        const headResolving = isHostingResolving(headHost) || (!headRec && cached?.zone != null)
+        const hasRecord = !!(headRec && headRec.type !== "none")
+        // A www that merely CNAMEs to the head (or apex) follows it on a move → "+www".
+        const wwwName = "www." + headHost
+        const wwwRec = headHost.startsWith("www.") ? undefined : hostingFor(wwwName)
+        const wwwTarget = wwwRec?.type === "CNAME" ? norm(wwwRec.value) : ""
+        const wwwFollows = wwwTarget !== "" && (wwwTarget === headHost || wwwTarget === g.apex)
+        if (hasRecord && headRec!.pointsHere) hereCount++
+        if (headResolving) resolving = true
+
         out.push({
           kind: "zone",
-          siteDomain: site.domain,
-          showSite: idx === 0,
           status: site.status,
           apex: g.apex,
           hostKey,
@@ -194,18 +237,29 @@ export function DnsInventory() {
           liveNs,
           note,
           checkedAt: cached?.checkedAt ?? null,
+          isPrimary: isPrimaryZone,
+          extraZones: isPrimaryZone ? additionalZones : 0,
+          recordName: headHost,
+          hasRecord,
+          recordType: headRec?.type ?? "",
+          ttl: headRec?.ttl ?? null,
+          value: headRec?.value ?? "",
+          pointsHere: headRec?.pointsHere ?? false,
+          resolving: headResolving,
+          wwwFollows,
         })
 
-        // Nested hosting records: the site's hostnames in this zone (apex first).
-        const hosts = candidateHostnames(g.entries.map((e) => e.domain)).sort((a, b) =>
-          a === g.apex ? -1 : b === g.apex ? 1 : a.localeCompare(b),
-        )
+        // Nested rows: only the non-head records that still need action.
         for (const name of hosts) {
+          if (name === headHost) continue // folded into the site/zone line
+          if (name === wwwName && wwwFollows) continue // shown as "+www"
           const hr = hostingFor(name)
           if (hr && hr.type === "none") continue // no record for this hostname — nothing to migrate
           const isResolving = isHostingResolving(name) || (!hr && cached?.zone != null)
           if (hr?.pointsHere) hereCount++
           if (!hr && isResolving) resolving = true
+          const cnameTarget = hr?.type === "CNAME" ? hr.value.toLowerCase().replace(/\.$/, "") : ""
+          const followsApex = cnameTarget !== "" && cnameTarget === g.apex
           out.push({
             kind: "record",
             apex: g.apex,
@@ -217,7 +271,9 @@ export function DnsInventory() {
             ttl: hr?.ttl ?? null,
             value: hr?.value ?? "",
             pointsHere: hr?.pointsHere ?? false,
+            followsApex,
             resolving: !hr,
+            indent: isPrimaryZone ? 1 : 2,
           })
         }
       })
@@ -235,8 +291,20 @@ export function DnsInventory() {
     if (r.access !== "editable") return showFlash("Connect API access first — press c")
     const conn = connForZone(r.apex, r.hostKey, r.liveNs)
     if (!conn) return showFlash("No reachable account for this zone — press c")
-    const focus = r.kind === "record" && r.recordType ? { name: r.name, type: r.recordType } : undefined
-    setDnsRecordsTarget({ apex: r.apex, hostKey: r.hostKey, connId: conn.id, focus })
+    // Editing always targets ONE hosting record — never a zone. A record row edits
+    // itself; a zone-header row edits its apex A/AAAA (the record right below it).
+    let rec: { name: string; type: string } | null = null
+    if (r.kind === "record") {
+      if (r.followsApex) return showFlash(`${r.name} follows the apex — no separate change needed.`)
+      if (r.resolving) return showFlash("Still looking up this record…")
+      if (!r.recordType || r.recordType === "none") return showFlash("No record to edit here.")
+      rec = { name: r.name, type: r.recordType }
+    } else {
+      if (r.resolving) return showFlash("Still looking up this record…")
+      if (!r.hasRecord || !r.recordType) return showFlash("No record to edit on this line.")
+      rec = { name: r.recordName, type: r.recordType }
+    }
+    setDnsRecordsTarget({ apex: r.apex, hostKey: r.hostKey, connId: conn.id, record: rec })
   }
 
   function openWeb(r: InvRow) {
@@ -291,6 +359,13 @@ export function DnsInventory() {
       case "w":
         if (r) openWeb(r)
         return
+      case "a":
+        // Expand a site-scoped view (opened via `n`) to the whole server.
+        if (focusSite) {
+          setDnsInventoryFocusSiteId(null)
+          setIndex(0)
+        }
+        return
     }
   })
 
@@ -304,28 +379,21 @@ export function DnsInventory() {
   return (
     <box style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", flexDirection: "column", backgroundColor: theme.bg, zIndex: 216 }}>
       <box style={{ flexDirection: "row", height: 1, backgroundColor: theme.bgAlt, paddingLeft: 1, paddingRight: 1, alignItems: "center" }}>
-        <text content={`🌐 DNS · ${truncate(server.name, 26)}  `} fg={theme.brand} wrapMode="none" style={{ flexShrink: 0 }} />
-        <text content={summary} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 1 }} />
+        <text content={`🌐 DNS · ${truncate(focusSite ? focusSite.domain : server.name, 28)}  `} fg={theme.brand} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content={focusSite ? `${summary} · a all sites` : summary} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 1 }} />
         <box style={{ flexGrow: 1 }} />
         {pending ? <Spinner color={theme.brand} interval={120} /> : null}
       </box>
 
-      {/* Column header. SITE/zone-or-record name align across both row kinds. */}
+      {/* Column header. The dot column (2) + NAME align across both row kinds; HOST
+          sits on the right, pushed there by the growable VALUE region. */}
       <box style={{ flexDirection: "row", paddingLeft: 1, paddingRight: 1, height: 1 }}>
-        <text content={"  " + "SITE".padEnd(SITE_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
-        <text content={"ZONE / RECORD".padEnd(NAME_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content={"  " + "SITE / RECORD".padEnd(NAME_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
         <text content={"TYPE".padEnd(TYPE_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
         <text content={"TTL".padEnd(TTL_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
-        <text content="VALUE / HOST" fg={theme.textFaint} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
-      </box>
-
-      {/* Legend — teaches access glyphs + the "points here" flag in-context. */}
-      <box style={{ flexDirection: "row", paddingLeft: 1, paddingRight: 1, height: 1 }}>
-        <text content="✓ editable" fg={theme.good} wrapMode="none" style={{ flexShrink: 0 }} />
-        <text content="   ↗ web" fg={theme.accent} wrapMode="none" style={{ flexShrink: 0 }} />
-        <text content="   ○ needs key" fg={theme.warn} wrapMode="none" style={{ flexShrink: 0 }} />
-        <text content="   ◀ here = points at this server" fg={theme.good} wrapMode="none" style={{ flexShrink: 0 }} />
-        <text content="    ⏎ edit TTL · c access" fg={theme.textDim} wrapMode="none" style={{ flexShrink: 1 }} />
+        <text content="VALUE" fg={theme.textFaint} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
+        <text content="HOST" fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
+        {showAccount ? <text content={"  " + "ACCOUNT".padEnd(ACCOUNT_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} /> : null}
       </box>
 
       <box style={{ flexGrow: 1, flexDirection: "column", paddingLeft: 1, paddingRight: 1 }}>
@@ -348,7 +416,7 @@ export function DnsInventory() {
           { key: "↑↓/jk", label: "select" },
           { key: "⏎", label: "edit TTL" },
           { key: "c", label: "manage access" },
-          { key: "w", label: "web console" },
+          ...(focusSite ? [{ key: "a", label: "all sites" }] : []),
           { key: "r", label: "refresh" },
           { key: "esc", label: "close" },
         ]}
@@ -359,41 +427,98 @@ export function DnsInventory() {
     </box>
   )
 
-  function renderZone(r: Extract<InvRow, { kind: "zone" }>, selected: boolean) {
+  // The TTL cell, shared by both row kinds: a spinner while resolving, a spinner +
+  // "→<ttl>" while a write is in flight, else the value in seconds (300/3600/86400,
+  // not "1h"). A settled write shows its new value — the authoritative host has it.
+  function ttlCell(name: string, type: string, ttl: number | null, resolving: boolean, faint: boolean, selected: boolean) {
+    if (resolving) {
+      return (
+        <box style={{ flexDirection: "row", width: TTL_W, flexShrink: 0 }}>
+          <Spinner color={selected ? theme.text : theme.textDim} interval={120} />
+          <text content=" …" fg={selected ? theme.text : theme.textFaint} wrapMode="none" />
+        </box>
+      )
+    }
+    const wp = ttlWriteForHost(name, type)
+    if (isTtlWriteInFlight(wp)) {
+      return (
+        <box style={{ flexDirection: "row", width: TTL_W, flexShrink: 0 }}>
+          <Spinner color={selected ? theme.text : theme.brand} interval={120} />
+          <text content={` →${wp!.ttl}`} fg={selected ? theme.text : theme.warn} wrapMode="none" />
+        </box>
+      )
+    }
+    const effTtl = wp?.status === "done" ? wp.ttl : ttl
+    const txt = effTtl == null ? "—" : String(effTtl)
+    const fg = selected ? theme.text : faint ? theme.textFaint : theme.accent
+    return <text content={txt.padEnd(TTL_W)} fg={fg} wrapMode="none" style={{ flexShrink: 0 }} />
+  }
+
+  // host + access glyph — a right-side cluster on zone lines.
+  function hostCell(r: Extract<InvRow, { kind: "zone" }>, selected: boolean) {
     const acc = accessGlyph(r.access, selected)
     return (
+      <box style={{ flexDirection: "row", flexShrink: 0 }}>
+        <text content={truncate(r.host, HOST_W)} fg={selected ? theme.text : r.hostColor} wrapMode="none" />
+        <text content={" " + acc.glyph} fg={acc.color} wrapMode="none" />
+      </box>
+    )
+  }
+
+  // Indented "↳ name" cell for nested rows. Level 1 = directly under the site's
+  // primary line (additional-domain zone, or a record in the primary zone); level 2
+  // = a record under an additional-domain zone.
+  function indentedName(name: string, level: number): string {
+    const prefix = level >= 2 ? "     ↳ " : "  ↳ "
+    return (prefix + truncate(name, NAME_W - prefix.length - 1)).padEnd(NAME_W)
+  }
+
+  function renderZone(r: Extract<InvRow, { kind: "zone" }>, selected: boolean) {
+    // Primary zone = the site's `●` line; additional-domain zones nest as `↳`. The
+    // label is the site's own domain (recordName), not the zone apex.
+    const nameContent = r.isPrimary ? truncate(r.recordName, NAME_W - 1).padEnd(NAME_W) : indentedName(r.recordName, 1)
+    const nameColor = selected ? theme.text : r.isPrimary ? theme.text : theme.textDim
+    return (
       <>
-        <text content={r.showSite ? statusDot(r.status) + " " : "  "} fg={statusColor(r.status)} style={{ flexShrink: 0 }} />
-        <text content={(r.showSite ? truncate(r.siteDomain, SITE_W - 1) : "").padEnd(SITE_W)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} />
-        <text content={truncate(r.apex, NAME_W - 1).padEnd(NAME_W)} fg={selected ? theme.text : theme.text} wrapMode="none" style={{ flexShrink: 0 }} />
-        <text content={truncate(r.host, HOST_W - 1).padEnd(HOST_W)} fg={selected ? theme.text : r.hostColor} wrapMode="none" style={{ flexShrink: 0 }} />
-        <text content={(acc.glyph + " ").padEnd(ACCESS_W)} fg={acc.color} wrapMode="none" style={{ flexShrink: 0 }} />
-        {showAccount ? <text content={truncate(r.account, ACCOUNT_W - 1).padEnd(ACCOUNT_W)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} /> : null}
-        <text content={r.note} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
+        <text content={r.isPrimary ? statusDot(r.status) + " " : "  "} fg={r.isPrimary ? statusColor(r.status) : theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content={nameContent} fg={nameColor} wrapMode="none" style={{ flexShrink: 0 }} />
+        {r.hasRecord || r.resolving ? (
+          <>
+            <text content={r.recordType.padEnd(TYPE_W)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} />
+            {ttlCell(r.recordName, r.recordType, r.ttl, r.resolving, false, selected)}
+          </>
+        ) : (
+          <>
+            <text content={"".padEnd(TYPE_W)} wrapMode="none" style={{ flexShrink: 0 }} />
+            <text content={"".padEnd(TTL_W)} wrapMode="none" style={{ flexShrink: 0 }} />
+          </>
+        )}
+        <text content={truncate(r.value, 38)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 1 }} />
+        {r.pointsHere ? <text content=" ◀ here" fg={selected ? theme.text : theme.good} wrapMode="none" style={{ flexShrink: 0 }} /> : null}
+        {r.wwwFollows ? <text content=" +www" fg={selected ? theme.text : theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} /> : null}
+        {r.note ? <text content={"  " + r.note} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} /> : null}
+        <box style={{ flexGrow: 1 }} />
+        {hostCell(r, selected)}
+        {r.isPrimary && r.extraZones > 0 ? <text content={`  (+${r.extraZones})`} fg={selected ? theme.text : theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} /> : null}
+        {showAccount ? <text content={"  " + truncate(r.account, ACCOUNT_W).padEnd(ACCOUNT_W)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} /> : null}
       </>
     )
   }
 
   function renderRecord(r: Extract<InvRow, { kind: "record" }>, selected: boolean) {
-    const ttlFg = selected ? theme.text : theme.accent
     return (
       <>
-        <text content="  " style={{ flexShrink: 0 }} />
-        <text content={"".padEnd(SITE_W)} wrapMode="none" style={{ flexShrink: 0 }} />
-        <text content={("  ↳ " + truncate(r.name, NAME_W - 5)).padEnd(NAME_W)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} />
-        {r.resolving ? (
-          <box style={{ flexDirection: "row", width: TYPE_W + TTL_W, flexShrink: 0 }}>
-            <Spinner color={selected ? theme.text : theme.textDim} interval={120} />
-            <text content=" looking up…" fg={selected ? theme.text : theme.textFaint} wrapMode="none" />
-          </box>
-        ) : (
-          <>
-            <text content={r.recordType.padEnd(TYPE_W)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} />
-            <text content={formatTtl(r.ttl).padEnd(TTL_W)} fg={ttlFg} wrapMode="none" style={{ flexShrink: 0 }} />
-          </>
-        )}
-        <text content={truncate(r.value, 48)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
-        {r.pointsHere ? <text content=" ◀ here" fg={selected ? theme.text : theme.good} wrapMode="none" style={{ flexShrink: 0 }} /> : null}
+        <text content="  " wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content={indentedName(r.name, r.indent)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content={(r.resolving ? "" : r.recordType).padEnd(TYPE_W)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} />
+        {ttlCell(r.name, r.recordType, r.ttl, r.resolving, r.followsApex, selected)}
+        <text content={truncate(r.value, 38)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 1 }} />
+        {r.followsApex ? (
+          <text content=" follows apex" fg={selected ? theme.text : theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
+        ) : r.pointsHere ? (
+          <text content=" ◀ here" fg={selected ? theme.text : theme.good} wrapMode="none" style={{ flexShrink: 0 }} />
+        ) : null}
+        <box style={{ flexGrow: 1 }} />
       </>
     )
   }

--- a/src/ui/views/DnsRecords.tsx
+++ b/src/ui/views/DnsRecords.tsx
@@ -1,0 +1,514 @@
+// DNS records overlay — Phase 3, the module's first record-level write.
+//
+// Opened with Enter/t on an EDITABLE zone in the DNS inventory (one whose host we
+// hold a verified API key for). Lists the zone's records straight from the host
+// (Route 53 / Cloudflare) and lets you change a single field — the TTL — through
+// the same confirm-before-firing flow as the PHP upgrade. The write + its polling
+// live in the store (startTtlChange), so closing this modal doesn't abandon a
+// Route 53 change mid-propagation.
+//
+// Only the TTL is editable here, and only where that's well-defined: alias /
+// routing-policy / proxied records surface read-only with a short reason. Record
+// listing is on-demand and ephemeral (no disk cache) — re-opening re-fetches.
+
+import { useEffect, useMemo, useState } from "react"
+import { useKeyboard, useTerminalDimensions } from "@opentui/react"
+import { theme } from "../../lib/theme.ts"
+import { truncate } from "../../lib/format.ts"
+import { apiProviderFor, PROVIDER_REGISTRY, normNameservers, nameserversMatch } from "../../lib/providers.ts"
+import { resolveZone } from "../../lib/dns.ts"
+import { TTL_PRESETS, formatTtl, validateTtl, defaultTtlFor, type DnsRecord } from "../../lib/dnsRecords.ts"
+import { List, moveSelection } from "../List.tsx"
+import { StatusBar } from "../StatusBar.tsx"
+import { Panel, Spinner, Centered } from "../components.tsx"
+import { useStore } from "../store.tsx"
+import { isTtlWriteInFlight } from "../store.tsx"
+
+const NAME_W = 30
+const TYPE_W = 7
+const TTL_W = 9
+const FLAG_W = 11
+
+type Phase = "list" | "pick" | "custom" | "confirm" | "tracking"
+type LoadState = "loading" | "ready" | "error"
+
+// A TTL option in the picker. ttl = -1 is the "Custom…" sentinel.
+interface TtlOption {
+  ttl: number
+  label: string
+}
+const CUSTOM_TTL = -1
+
+export function DnsRecords() {
+  const { dnsRecordsTarget, setDnsRecordsTarget, listZoneRecords, startTtlChange, clearTtlWrite, ttlWrites, setInputMode } = useStore()
+  const target = dnsRecordsTarget
+  const provider = target ? apiProviderFor(target.hostKey) : null
+  const providerName = provider ? PROVIDER_REGISTRY[provider].name : ""
+  const { height } = useTerminalDimensions()
+
+  const [loadState, setLoadState] = useState<LoadState>("loading")
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [records, setRecords] = useState<DnsRecord[]>([])
+  const [zoneId, setZoneId] = useState("")
+  const [index, setIndex] = useState(0)
+  const [phase, setPhase] = useState<Phase>("list")
+  const [pickIndex, setPickIndex] = useState(0)
+  const [custom, setCustom] = useState("")
+  const [customError, setCustomError] = useState<string | null>(null)
+  const [targetTtl, setTargetTtl] = useState<number | null>(null)
+  const [activeKey, setActiveKey] = useState<string | null>(null)
+  const [flash, setFlash] = useState<string | null>(null)
+  // Edit-time NS-match pre-flight: when the account's hosted-zone NS don't match
+  // the FRESH live authoritative NS, this account isn't the one serving the domain
+  // (a stale/duplicate zone) — editing it would be a silent no-op or, worse, edit
+  // the wrong zone. We surface it and hard-stop writes. `null` = not yet known or
+  // not checkable (e.g. Cloudflare, whose access is already NS-matched in Phase 2).
+  const [ns, setNs] = useState<{ live: string[]; zone: string[] } | null>(null)
+  const nsMismatch = ns != null && ns.live.length > 0 && ns.zone.length > 0 && !nameserversMatch(ns.zone, ns.live)
+
+  const apex = target?.apex ?? ""
+
+  // Load the zone's records when the overlay opens.
+  useEffect(() => {
+    if (!target) return
+    let cancelled = false
+    const apexLc = target.apex.toLowerCase()
+    setLoadState("loading")
+    setNs(null)
+    // List the records and re-dig the FRESH live NS in parallel — the NS-match
+    // gate compares the live NS against the zone's own apex NS record.
+    void Promise.all([listZoneRecords(target.connId, target.apex), resolveZone(target.apex)]).then(([res, liveZone]) => {
+      if (cancelled) return
+      if (res.ok) {
+        const sorted = [...res.records].sort((a, b) => a.name.localeCompare(b.name) || a.type.localeCompare(b.type))
+        setRecords(sorted)
+        setZoneId(res.zoneId)
+        setLoadState("ready")
+        // When opened from a specific inventory record, land the cursor on it.
+        if (target.focus) {
+          const fn = target.focus.name.toLowerCase()
+          const i = sorted.findIndex((r) => r.name.toLowerCase() === fn && r.type === target.focus!.type)
+          if (i >= 0) setIndex(i)
+        }
+        // The zone's declared NS = its apex NS record (Route 53 returns it; some
+        // hosts don't, in which case we can't compare and don't block).
+        const apexNs = res.records.find((r) => r.type === "NS" && r.name.toLowerCase() === apexLc)?.values ?? []
+        setNs({ live: normNameservers(liveZone?.nameservers), zone: normNameservers(apexNs) })
+      } else {
+        setLoadError(res.error ?? "Couldn't list records.")
+        setLoadState("error")
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [target, listZoneRecords])
+
+  // The custom-TTL input owns the keyboard while it's focused.
+  useEffect(() => {
+    setInputMode(phase === "custom")
+    return () => setInputMode(false)
+  }, [phase, setInputMode])
+
+  const safeIndex = Math.min(index, Math.max(0, records.length - 1))
+  const selected = records[safeIndex]
+
+  // Reflect a settled success back into the row so the list shows the new TTL.
+  useEffect(() => {
+    if (!activeKey) return
+    const p = ttlWrites.get(activeKey)
+    if (p?.status === "done") {
+      setRecords((rs) => rs.map((r) => (r.key === activeKey ? { ...r, ttl: p.ttl } : r)))
+    }
+  }, [ttlWrites, activeKey])
+
+  // TTL options for the selected record: presets, the record's current value when
+  // off-list, and a Custom… entry.
+  const ttlOptions = useMemo<TtlOption[]>(() => {
+    const opts: TtlOption[] = [...TTL_PRESETS]
+    const cur = selected?.ttl
+    if (cur != null && !opts.some((o) => o.ttl === cur)) opts.unshift({ ttl: cur, label: "current" })
+    opts.push({ ttl: CUSTOM_TTL, label: "Custom…" })
+    return opts
+  }, [selected])
+
+  // Tracking display derives from the store, like the PHP-upgrade overlay.
+  const progress = activeKey ? ttlWrites.get(activeKey) : undefined
+  const dp: Phase | "done" | "error" =
+    phase !== "tracking"
+      ? phase
+      : !progress || isTtlWriteInFlight(progress)
+        ? "tracking"
+        : progress.status === "failed"
+          ? "error"
+          : "done"
+
+  const close = () => {
+    // Drop a settled failure so its marker doesn't linger; an in-flight change
+    // keeps polling in the store.
+    if (activeKey && progress?.status === "failed") clearTtlWrite(activeKey)
+    setInputMode(false)
+    setDnsRecordsTarget(null)
+  }
+
+  const showFlash = (msg: string) => {
+    setFlash(msg)
+    setTimeout(() => setFlash(null), 2000)
+  }
+
+  const openPicker = () => {
+    if (!selected) return
+    if (nsMismatch) return showFlash("TTL edits blocked — this account's zone isn't serving the domain live (see ⚠).")
+    if (!selected.editable) return showFlash(`Can't edit this TTL — ${selected.reason ?? "read-only"}.`)
+    // Open the cursor on the current value when it's an option.
+    const i = ttlOptions.findIndex((o) => o.ttl === selected.ttl)
+    setPickIndex(i >= 0 ? i : 0)
+    setPhase("pick")
+  }
+
+  const chooseTtl = (ttl: number) => {
+    setTargetTtl(ttl)
+    setPhase("confirm")
+  }
+
+  const submitCustom = () => {
+    if (!provider) return
+    const n = Number(custom.trim())
+    const err = !custom.trim() || Number.isNaN(n) ? "Enter a TTL in seconds." : validateTtl(provider, n)
+    if (err) return setCustomError(err)
+    setCustomError(null)
+    chooseTtl(n)
+  }
+
+  const fire = () => {
+    if (!target || !selected || targetTtl == null) return
+    startTtlChange(target.connId, zoneId, selected, targetTtl)
+    setActiveKey(selected.key)
+    setPhase("tracking")
+  }
+
+  useKeyboard((key) => {
+    const raw = key.name ?? ""
+    const name = key.shift && raw.length === 1 ? raw.toUpperCase() : raw
+
+    // Esc/q always backs out a step (or closes). In custom mode the input owns
+    // typing — only Esc reaches us.
+    if (phase === "custom") {
+      if (raw === "escape") {
+        setCustomError(null)
+        setPhase("pick")
+      }
+      return
+    }
+    if (raw === "escape" || name === "q") {
+      if (phase === "pick") return setPhase("list")
+      if (phase === "confirm") return setPhase("pick")
+      // After a successful change, Esc returns to the (now-updated) record list
+      // rather than closing — so you can edit another record in one sitting.
+      if (phase === "tracking" && dp === "done") {
+        if (activeKey) clearTtlWrite(activeKey)
+        setActiveKey(null)
+        return setPhase("list")
+      }
+      return close()
+    }
+
+    if (loadState !== "ready") return
+
+    if (phase === "list") {
+      switch (name) {
+        case "up":
+        case "k":
+          return setIndex((i) => moveSelection(i, -1, records.length))
+        case "down":
+        case "j":
+          return setIndex((i) => moveSelection(i, 1, records.length))
+        case "return":
+        case "t":
+        case "right":
+        case "l":
+          return openPicker()
+      }
+      return
+    }
+
+    if (phase === "pick") {
+      switch (name) {
+        case "up":
+        case "k":
+          return setPickIndex((i) => moveSelection(i, -1, ttlOptions.length))
+        case "down":
+        case "j":
+          return setPickIndex((i) => moveSelection(i, 1, ttlOptions.length))
+        case "return":
+        case "right":
+        case "l": {
+          const opt = ttlOptions[pickIndex]
+          if (!opt) return
+          if (opt.ttl === CUSTOM_TTL) {
+            setCustom(selected ? String(defaultTtlFor(selected)) : "")
+            setCustomError(null)
+            return setPhase("custom")
+          }
+          return chooseTtl(opt.ttl)
+        }
+      }
+      return
+    }
+
+    if (phase === "confirm") {
+      if (name === "y") return fire()
+      if (name === "left" || name === "h") return setPhase("pick")
+      return
+    }
+
+    if (dp === "error") {
+      if (name === "r") {
+        if (activeKey) clearTtlWrite(activeKey)
+        setActiveKey(null)
+        setPhase("pick")
+      }
+      return
+    }
+  })
+
+  if (!target || !provider) return null
+
+  const listRows = Math.max(3, height - 7)
+
+  return (
+    <box style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", flexDirection: "column", backgroundColor: theme.bg, zIndex: 235 }}>
+      <box style={{ flexDirection: "row", height: 1, backgroundColor: theme.bgAlt, paddingLeft: 1, paddingRight: 1, alignItems: "center" }}>
+        <text content={`🔧 DNS records · ${truncate(apex, 36)}  `} fg={theme.brand} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content={providerName} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 1 }} />
+        <box style={{ flexGrow: 1 }} />
+        {loadState === "loading" ? <Spinner color={theme.brand} interval={120} /> : null}
+      </box>
+
+      {nsMismatch && loadState === "ready" ? (
+        <box style={{ flexDirection: "column", height: 2, backgroundColor: theme.bad, paddingLeft: 1, paddingRight: 1 }}>
+          <text content={`⚠ This account's hosted zone isn't the one serving ${truncate(apex, 30)} live — TTL edits are blocked.`} fg={theme.bg} wrapMode="none" />
+          <text content={`   live NS: ${truncate(ns!.live.join(" ") || "unknown", 50)}  ·  this zone: ${truncate(ns!.zone.join(" ") || "unknown", 50)}`} fg={theme.bg} wrapMode="none" />
+        </box>
+      ) : null}
+
+      {phase === "list" && loadState === "ready" ? renderListHeader() : null}
+
+      <box style={{ flexGrow: 1, flexDirection: "column", paddingLeft: 1, paddingRight: 1 }}>
+        {loadState === "loading" ? (
+          <Centered>
+            <text content="Listing records…" fg={theme.textDim} />
+          </Centered>
+        ) : loadState === "error" ? (
+          <Centered>
+            <text content={`✕ ${loadError}`} fg={theme.bad} wrapMode="none" />
+          </Centered>
+        ) : phase === "list" ? (
+          renderList()
+        ) : (
+          <Centered>{renderEditor()}</Centered>
+        )}
+      </box>
+
+      <StatusBar hints={hints()} message={flash ?? undefined} messageColor={theme.brand} showGlobal={false} />
+    </box>
+  )
+
+  function renderListHeader() {
+    return (
+      <box style={{ flexDirection: "row", paddingLeft: 1, paddingRight: 1, height: 1 }}>
+        <text content={"NAME".padEnd(NAME_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content={"TYPE".padEnd(TYPE_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content={"TTL".padEnd(TTL_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content={"".padEnd(FLAG_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content="VALUE" fg={theme.textFaint} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
+      </box>
+    )
+  }
+
+  function renderList() {
+    return (
+      <List
+        items={records}
+        selectedIndex={safeIndex}
+        viewportRows={listRows}
+        focused
+        keyFor={(r) => r.key}
+        emptyText="No records in this zone."
+        renderRow={(r, sel) => {
+          const wp = ttlWrites.get(r.key)
+          const inFlight = isTtlWriteInFlight(wp)
+          const nameFg = sel ? theme.text : r.editable ? theme.text : theme.textFaint
+          const ttlFg = sel ? theme.text : r.editable ? theme.accent : theme.textFaint
+          return (
+            <>
+              <text content={truncate(r.name || "@", NAME_W - 1).padEnd(NAME_W)} fg={nameFg} wrapMode="none" style={{ flexShrink: 0 }} />
+              <text content={truncate(r.type, TYPE_W - 1).padEnd(TYPE_W)} fg={sel ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} />
+              {inFlight ? (
+                <box style={{ flexDirection: "row", width: TTL_W, flexShrink: 0 }}>
+                  <Spinner color={sel ? theme.text : theme.brand} interval={120} />
+                  <text content={`→${formatTtl(wp!.ttl)}`} fg={sel ? theme.text : theme.warn} wrapMode="none" />
+                </box>
+              ) : (
+                <text content={formatTtl(r.ttl).padEnd(TTL_W)} fg={ttlFg} wrapMode="none" style={{ flexShrink: 0 }} />
+              )}
+              <text
+                content={(r.editable ? "" : `· ${r.reason ?? "read-only"}`).padEnd(FLAG_W)}
+                fg={sel ? theme.text : theme.textFaint}
+                wrapMode="none"
+                style={{ flexShrink: 0 }}
+              />
+              <text content={truncate(r.values.join(" "), 80)} fg={sel ? theme.text : theme.textDim} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
+            </>
+          )
+        }}
+      />
+    )
+  }
+
+  function renderEditor() {
+    if (!selected) return null
+    const curLabel = formatTtl(selected.ttl)
+
+    if (phase === "pick") {
+      return (
+        <Panel title=" Choose a TTL " active>
+          <box style={{ flexDirection: "column", width: 44 }}>
+            <box style={{ flexDirection: "row" }}>
+              <text content={`${truncate(selected.name || "@", 28)} `} fg={theme.accent} wrapMode="none" />
+              <text content={selected.type} fg={theme.textDim} wrapMode="none" />
+              <box style={{ flexGrow: 1 }} />
+              <text content={`now ${curLabel}`} fg={theme.textFaint} wrapMode="none" />
+            </box>
+            <box style={{ height: 1 }} />
+            {ttlOptions.map((o, i) => {
+              const sel = i === pickIndex
+              const isCustom = o.ttl === CUSTOM_TTL
+              const isCurrent = o.ttl === selected.ttl
+              const text = isCustom ? "Custom…" : `${formatTtl(o.ttl)}  (${o.ttl}s)`
+              const tag = isCurrent ? "  (current)" : ""
+              return (
+                <box key={o.label + o.ttl} style={{ flexDirection: "row", height: 1, backgroundColor: sel ? theme.selectedBg : undefined }}>
+                  <text content={(sel ? "❯ " : "  ") + text} fg={sel ? theme.text : isCurrent ? theme.textFaint : theme.textDim} style={{ flexGrow: 1 }} wrapMode="none" />
+                  <text content={tag} fg={sel ? theme.text : theme.textFaint} style={{ flexShrink: 0 }} />
+                </box>
+              )
+            })}
+          </box>
+        </Panel>
+      )
+    }
+
+    if (phase === "custom") {
+      const inputStyle = { backgroundColor: theme.bgAlt, focusedBackgroundColor: theme.bgAlt, textColor: theme.text }
+      return (
+        <Panel title=" Custom TTL " active>
+          <box style={{ flexDirection: "column", width: 48, paddingTop: 1, paddingBottom: 1 }}>
+            <text content="TTL in seconds" fg={theme.accent} />
+            <input focused value={custom} placeholder="e.g. 3600" onInput={setCustom} onSubmit={submitCustom} style={inputStyle} />
+            <box style={{ height: 1 }} />
+            {customError ? <text content={customError} fg={theme.bad} wrapMode="none" /> : <text content="⏎ to continue · Esc to go back" fg={theme.textFaint} wrapMode="none" />}
+          </box>
+        </Panel>
+      )
+    }
+
+    if (phase === "confirm") {
+      return (
+        <Panel title=" Confirm TTL change " active>
+          <box style={{ flexDirection: "column", width: 56, paddingTop: 1, paddingBottom: 1 }}>
+            <box style={{ flexDirection: "row" }}>
+              <text content={`${truncate(selected.name || "@", 28)} `} fg={theme.accent} wrapMode="none" />
+              <text content={selected.type} fg={theme.textDim} wrapMode="none" />
+            </box>
+            <box style={{ flexDirection: "row" }}>
+              <text content={`TTL ${curLabel}`} fg={theme.textDim} />
+              <text content="  →  " fg={theme.textFaint} />
+              <text content={`${formatTtl(targetTtl)} (${targetTtl}s)`} fg={theme.good} wrapMode="none" />
+            </box>
+            <box style={{ height: 1 }} />
+            <text content={`This writes directly to ${providerName} — it's a live DNS change.`} fg={theme.textDim} wrapMode="none" />
+            <box style={{ height: 1 }} />
+            <text content="Press y to confirm · ← to go back · Esc to cancel" fg={theme.textFaint} wrapMode="none" />
+          </box>
+        </Panel>
+      )
+    }
+
+    if (dp === "tracking") {
+      return (
+        <box style={{ flexDirection: "column", alignItems: "center" }}>
+          <box style={{ flexDirection: "row" }}>
+            <Spinner />
+            <text content={`  Setting TTL to ${formatTtl(targetTtl)} — ${progress?.status ?? "queued"}…`} fg={theme.textDim} />
+          </box>
+          <box style={{ height: 1 }} />
+          <text content="You can press Esc — it keeps applying in the background." fg={theme.textFaint} wrapMode="none" />
+        </box>
+      )
+    }
+
+    if (dp === "done") {
+      return (
+        <Panel title=" Done " active>
+          <box style={{ flexDirection: "column", width: 52, paddingTop: 1, paddingBottom: 1 }}>
+            <box style={{ flexDirection: "row" }}>
+              <text content="✓ " fg={theme.good} />
+              <text content={`${truncate(selected.name || "@", 24)} ${selected.type}`} fg={theme.accent} wrapMode="none" />
+              <text content={` TTL is now ${formatTtl(targetTtl)}`} fg={theme.text} wrapMode="none" />
+            </box>
+            <box style={{ height: 1 }} />
+            <text content="Esc to return to the records" fg={theme.textFaint} />
+          </box>
+        </Panel>
+      )
+    }
+
+    // error
+    return (
+      <Panel title=" Change failed " active>
+        <box style={{ flexDirection: "column", width: 64, paddingTop: 1, paddingBottom: 1 }}>
+          <text content={`✕ ${progress?.error ?? "Something went wrong."}`} fg={theme.bad} wrapMode="none" />
+          <box style={{ height: 1 }} />
+          <text content="Press r to choose another TTL · Esc to close" fg={theme.textFaint} wrapMode="none" />
+        </box>
+      </Panel>
+    )
+  }
+
+  function hints() {
+    if (loadState !== "ready" && phase === "list") return [{ key: "esc", label: "close" }]
+    switch (dp) {
+      case "list":
+        return [
+          { key: "↑↓/jk", label: "record" },
+          { key: "t/⏎", label: "set TTL" },
+          { key: "esc", label: "close" },
+        ]
+      case "pick":
+        return [
+          { key: "↑↓/jk", label: "TTL" },
+          { key: "⏎", label: "choose" },
+          { key: "esc", label: "back" },
+        ]
+      case "custom":
+        return [
+          { key: "⏎", label: "continue" },
+          { key: "esc", label: "back" },
+        ]
+      case "confirm":
+        return [
+          { key: "y", label: "confirm" },
+          { key: "←", label: "back" },
+          { key: "esc", label: "cancel" },
+        ]
+      case "error":
+        return [
+          { key: "r", label: "retry" },
+          { key: "esc", label: "close" },
+        ]
+      default:
+        return [{ key: "esc", label: "close" }]
+    }
+  }
+}

--- a/src/ui/views/DnsRecords.tsx
+++ b/src/ui/views/DnsRecords.tsx
@@ -1,15 +1,17 @@
-// DNS records overlay — Phase 3, the module's first record-level write.
+// Focused TTL editor — Phase 3, the migration record manager's first write.
 //
-// Opened with Enter/t on an EDITABLE zone in the DNS inventory (one whose host we
-// hold a verified API key for). Lists the zone's records straight from the host
-// (Route 53 / Cloudflare) and lets you change a single field — the TTL — through
-// the same confirm-before-firing flow as the PHP upgrade. The write + its polling
-// live in the store (startTtlChange), so closing this modal doesn't abandon a
-// Route 53 change mid-propagation.
+// Opened with Enter on a hosting record in the DNS inventory (one whose host we
+// hold a verified API key for). This is NOT a zone editor: it reads and edits the
+// ONE record it was handed (no zone listing), so the only records reachable here
+// are a site's own hosting records — MX/TXT/DKIM/etc. are never even fetched. You
+// change a single field — the TTL — through the same confirm-before-firing flow as
+// the PHP upgrade. The write + its polling live in the store (startTtlChange), so
+// closing this modal doesn't abandon a Route 53 change mid-propagation.
 //
-// Only the TTL is editable here, and only where that's well-defined: alias /
-// routing-policy / proxied records surface read-only with a short reason. Record
-// listing is on-demand and ephemeral (no disk cache) — re-opening re-fetches.
+// Target/IP repointing (step 3 of the cutover loop) is the next write; for now only
+// the TTL is editable, and only where that's well-defined — an alias / routing-policy
+// / proxied record opens read-only with a short reason. The read is on-demand and
+// ephemeral (no disk cache) — re-opening re-fetches.
 
 import { useEffect, useMemo, useState } from "react"
 import { useKeyboard, useTerminalDimensions } from "@opentui/react"
@@ -18,18 +20,13 @@ import { truncate } from "../../lib/format.ts"
 import { apiProviderFor, PROVIDER_REGISTRY, normNameservers, nameserversMatch } from "../../lib/providers.ts"
 import { resolveZone } from "../../lib/dns.ts"
 import { TTL_PRESETS, formatTtl, validateTtl, defaultTtlFor, type DnsRecord } from "../../lib/dnsRecords.ts"
-import { List, moveSelection } from "../List.tsx"
 import { StatusBar } from "../StatusBar.tsx"
 import { Panel, Spinner, Centered } from "../components.tsx"
+import { moveSelection } from "../List.tsx"
 import { useStore } from "../store.tsx"
 import { isTtlWriteInFlight } from "../store.tsx"
 
-const NAME_W = 30
-const TYPE_W = 7
-const TTL_W = 9
-const FLAG_W = 11
-
-type Phase = "list" | "pick" | "custom" | "confirm" | "tracking"
+type Phase = "pick" | "custom" | "confirm" | "tracking"
 type LoadState = "loading" | "ready" | "error"
 
 // A TTL option in the picker. ttl = -1 is the "Custom…" sentinel.
@@ -40,7 +37,7 @@ interface TtlOption {
 const CUSTOM_TTL = -1
 
 export function DnsRecords() {
-  const { dnsRecordsTarget, setDnsRecordsTarget, listZoneRecords, startTtlChange, clearTtlWrite, ttlWrites, setInputMode } = useStore()
+  const { dnsRecordsTarget, setDnsRecordsTarget, getZoneRecord, startTtlChange, clearTtlWrite, ttlWrites, setInputMode } = useStore()
   const target = dnsRecordsTarget
   const provider = target ? apiProviderFor(target.hostKey) : null
   const providerName = provider ? PROVIDER_REGISTRY[provider].name : ""
@@ -48,10 +45,9 @@ export function DnsRecords() {
 
   const [loadState, setLoadState] = useState<LoadState>("loading")
   const [loadError, setLoadError] = useState<string | null>(null)
-  const [records, setRecords] = useState<DnsRecord[]>([])
+  const [record, setRecord] = useState<DnsRecord | null>(null)
   const [zoneId, setZoneId] = useState("")
-  const [index, setIndex] = useState(0)
-  const [phase, setPhase] = useState<Phase>("list")
+  const [phase, setPhase] = useState<Phase>("pick")
   const [pickIndex, setPickIndex] = useState(0)
   const [custom, setCustom] = useState("")
   const [customError, setCustomError] = useState<string | null>(null)
@@ -68,41 +64,33 @@ export function DnsRecords() {
 
   const apex = target?.apex ?? ""
 
-  // Load the zone's records when the overlay opens.
+  // Load the single hosting record when the overlay opens. We re-dig the FRESH live
+  // NS in parallel — the NS-match gate compares it against the zone's apex NS.
   useEffect(() => {
     if (!target) return
     let cancelled = false
-    const apexLc = target.apex.toLowerCase()
     setLoadState("loading")
     setNs(null)
-    // List the records and re-dig the FRESH live NS in parallel — the NS-match
-    // gate compares the live NS against the zone's own apex NS record.
-    void Promise.all([listZoneRecords(target.connId, target.apex), resolveZone(target.apex)]).then(([res, liveZone]) => {
+    void Promise.all([getZoneRecord(target.connId, target.apex, target.record.name, target.record.type), resolveZone(target.apex)]).then(([res, liveZone]) => {
       if (cancelled) return
-      if (res.ok) {
-        const sorted = [...res.records].sort((a, b) => a.name.localeCompare(b.name) || a.type.localeCompare(b.type))
-        setRecords(sorted)
+      if (res.ok && res.record) {
+        setRecord(res.record)
         setZoneId(res.zoneId)
         setLoadState("ready")
-        // When opened from a specific inventory record, land the cursor on it.
-        if (target.focus) {
-          const fn = target.focus.name.toLowerCase()
-          const i = sorted.findIndex((r) => r.name.toLowerCase() === fn && r.type === target.focus!.type)
-          if (i >= 0) setIndex(i)
-        }
-        // The zone's declared NS = its apex NS record (Route 53 returns it; some
-        // hosts don't, in which case we can't compare and don't block).
-        const apexNs = res.records.find((r) => r.type === "NS" && r.name.toLowerCase() === apexLc)?.values ?? []
-        setNs({ live: normNameservers(liveZone?.nameservers), zone: normNameservers(apexNs) })
+        // Open the picker cursor on the current value: a preset lands on its row; an
+        // off-list TTL is prepended as "current" at index 0; null (CF auto) → 0.
+        const i = TTL_PRESETS.findIndex((o) => o.ttl === res.record!.ttl)
+        setPickIndex(i >= 0 ? i : 0)
+        setNs({ live: normNameservers(liveZone?.nameservers), zone: normNameservers(res.apexNs) })
       } else {
-        setLoadError(res.error ?? "Couldn't list records.")
+        setLoadError(res.error ?? "Couldn't read this record.")
         setLoadState("error")
       }
     })
     return () => {
       cancelled = true
     }
-  }, [target, listZoneRecords])
+  }, [target, getZoneRecord])
 
   // The custom-TTL input owns the keyboard while it's focused.
   useEffect(() => {
@@ -110,27 +98,14 @@ export function DnsRecords() {
     return () => setInputMode(false)
   }, [phase, setInputMode])
 
-  const safeIndex = Math.min(index, Math.max(0, records.length - 1))
-  const selected = records[safeIndex]
-
-  // Reflect a settled success back into the row so the list shows the new TTL.
-  useEffect(() => {
-    if (!activeKey) return
-    const p = ttlWrites.get(activeKey)
-    if (p?.status === "done") {
-      setRecords((rs) => rs.map((r) => (r.key === activeKey ? { ...r, ttl: p.ttl } : r)))
-    }
-  }, [ttlWrites, activeKey])
-
-  // TTL options for the selected record: presets, the record's current value when
-  // off-list, and a Custom… entry.
+  // TTL options: presets, the record's current value when off-list, and a Custom… entry.
   const ttlOptions = useMemo<TtlOption[]>(() => {
     const opts: TtlOption[] = [...TTL_PRESETS]
-    const cur = selected?.ttl
+    const cur = record?.ttl
     if (cur != null && !opts.some((o) => o.ttl === cur)) opts.unshift({ ttl: cur, label: "current" })
     opts.push({ ttl: CUSTOM_TTL, label: "Custom…" })
     return opts
-  }, [selected])
+  }, [record])
 
   // Tracking display derives from the store, like the PHP-upgrade overlay.
   const progress = activeKey ? ttlWrites.get(activeKey) : undefined
@@ -143,6 +118,8 @@ export function DnsRecords() {
           ? "error"
           : "done"
 
+  const blocked = loadState === "ready" && (nsMismatch || (record != null && !record.editable))
+
   const close = () => {
     // Drop a settled failure so its marker doesn't linger; an in-flight change
     // keeps polling in the store.
@@ -154,16 +131,6 @@ export function DnsRecords() {
   const showFlash = (msg: string) => {
     setFlash(msg)
     setTimeout(() => setFlash(null), 2000)
-  }
-
-  const openPicker = () => {
-    if (!selected) return
-    if (nsMismatch) return showFlash("TTL edits blocked — this account's zone isn't serving the domain live (see ⚠).")
-    if (!selected.editable) return showFlash(`Can't edit this TTL — ${selected.reason ?? "read-only"}.`)
-    // Open the cursor on the current value when it's an option.
-    const i = ttlOptions.findIndex((o) => o.ttl === selected.ttl)
-    setPickIndex(i >= 0 ? i : 0)
-    setPhase("pick")
   }
 
   const chooseTtl = (ttl: number) => {
@@ -181,9 +148,9 @@ export function DnsRecords() {
   }
 
   const fire = () => {
-    if (!target || !selected || targetTtl == null) return
-    startTtlChange(target.connId, zoneId, selected, targetTtl)
-    setActiveKey(selected.key)
+    if (!target || !record || targetTtl == null) return
+    startTtlChange(target.connId, zoneId, record, targetTtl)
+    setActiveKey(record.key)
     setPhase("tracking")
   }
 
@@ -201,36 +168,14 @@ export function DnsRecords() {
       return
     }
     if (raw === "escape" || name === "q") {
-      if (phase === "pick") return setPhase("list")
       if (phase === "confirm") return setPhase("pick")
-      // After a successful change, Esc returns to the (now-updated) record list
-      // rather than closing — so you can edit another record in one sitting.
-      if (phase === "tracking" && dp === "done") {
-        if (activeKey) clearTtlWrite(activeKey)
-        setActiveKey(null)
-        return setPhase("list")
-      }
+      // After a successful change, Esc closes back to the inventory — we KEEP the
+      // settled write so its row there reflects the new TTL (the authoritative host
+      // already has it); only failures are dropped (in close()).
       return close()
     }
 
-    if (loadState !== "ready") return
-
-    if (phase === "list") {
-      switch (name) {
-        case "up":
-        case "k":
-          return setIndex((i) => moveSelection(i, -1, records.length))
-        case "down":
-        case "j":
-          return setIndex((i) => moveSelection(i, 1, records.length))
-        case "return":
-        case "t":
-        case "right":
-        case "l":
-          return openPicker()
-      }
-      return
-    }
+    if (loadState !== "ready" || blocked) return
 
     if (phase === "pick") {
       switch (name) {
@@ -246,7 +191,7 @@ export function DnsRecords() {
           const opt = ttlOptions[pickIndex]
           if (!opt) return
           if (opt.ttl === CUSTOM_TTL) {
-            setCustom(selected ? String(defaultTtlFor(selected)) : "")
+            setCustom(record ? String(defaultTtlFor(record)) : "")
             setCustomError(null)
             return setPhase("custom")
           }
@@ -274,13 +219,13 @@ export function DnsRecords() {
 
   if (!target || !provider) return null
 
-  const listRows = Math.max(3, height - 7)
+  const recLabel = `${truncate(target.record.name || "@", 32)} ${target.record.type}`
 
   return (
     <box style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", flexDirection: "column", backgroundColor: theme.bg, zIndex: 235 }}>
       <box style={{ flexDirection: "row", height: 1, backgroundColor: theme.bgAlt, paddingLeft: 1, paddingRight: 1, alignItems: "center" }}>
-        <text content={`🔧 DNS records · ${truncate(apex, 36)}  `} fg={theme.brand} wrapMode="none" style={{ flexShrink: 0 }} />
-        <text content={providerName} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 1 }} />
+        <text content={`🔧 Edit TTL · ${recLabel}  `} fg={theme.brand} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content={`${truncate(apex, 28)} · ${providerName}`} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 1 }} />
         <box style={{ flexGrow: 1 }} />
         {loadState === "loading" ? <Spinner color={theme.brand} interval={120} /> : null}
       </box>
@@ -292,21 +237,17 @@ export function DnsRecords() {
         </box>
       ) : null}
 
-      {phase === "list" && loadState === "ready" ? renderListHeader() : null}
-
       <box style={{ flexGrow: 1, flexDirection: "column", paddingLeft: 1, paddingRight: 1 }}>
         {loadState === "loading" ? (
           <Centered>
-            <text content="Listing records…" fg={theme.textDim} />
+            <text content="Reading record…" fg={theme.textDim} />
           </Centered>
         ) : loadState === "error" ? (
           <Centered>
             <text content={`✕ ${loadError}`} fg={theme.bad} wrapMode="none" />
           </Centered>
-        ) : phase === "list" ? (
-          renderList()
         ) : (
-          <Centered>{renderEditor()}</Centered>
+          <Centered>{renderBody()}</Centered>
         )}
       </box>
 
@@ -314,69 +255,46 @@ export function DnsRecords() {
     </box>
   )
 
-  function renderListHeader() {
-    return (
-      <box style={{ flexDirection: "row", paddingLeft: 1, paddingRight: 1, height: 1 }}>
-        <text content={"NAME".padEnd(NAME_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
-        <text content={"TYPE".padEnd(TYPE_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
-        <text content={"TTL".padEnd(TTL_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
-        <text content={"".padEnd(FLAG_W)} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
-        <text content="VALUE" fg={theme.textFaint} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
-      </box>
-    )
-  }
+  function renderBody() {
+    if (!record) return null
+    const curLabel = formatTtl(record.ttl)
 
-  function renderList() {
-    return (
-      <List
-        items={records}
-        selectedIndex={safeIndex}
-        viewportRows={listRows}
-        focused
-        keyFor={(r) => r.key}
-        emptyText="No records in this zone."
-        renderRow={(r, sel) => {
-          const wp = ttlWrites.get(r.key)
-          const inFlight = isTtlWriteInFlight(wp)
-          const nameFg = sel ? theme.text : r.editable ? theme.text : theme.textFaint
-          const ttlFg = sel ? theme.text : r.editable ? theme.accent : theme.textFaint
-          return (
-            <>
-              <text content={truncate(r.name || "@", NAME_W - 1).padEnd(NAME_W)} fg={nameFg} wrapMode="none" style={{ flexShrink: 0 }} />
-              <text content={truncate(r.type, TYPE_W - 1).padEnd(TYPE_W)} fg={sel ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} />
-              {inFlight ? (
-                <box style={{ flexDirection: "row", width: TTL_W, flexShrink: 0 }}>
-                  <Spinner color={sel ? theme.text : theme.brand} interval={120} />
-                  <text content={`→${formatTtl(wp!.ttl)}`} fg={sel ? theme.text : theme.warn} wrapMode="none" />
-                </box>
-              ) : (
-                <text content={formatTtl(r.ttl).padEnd(TTL_W)} fg={ttlFg} wrapMode="none" style={{ flexShrink: 0 }} />
-              )}
-              <text
-                content={(r.editable ? "" : `· ${r.reason ?? "read-only"}`).padEnd(FLAG_W)}
-                fg={sel ? theme.text : theme.textFaint}
-                wrapMode="none"
-                style={{ flexShrink: 0 }}
-              />
-              <text content={truncate(r.values.join(" "), 80)} fg={sel ? theme.text : theme.textDim} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
-            </>
-          )
-        }}
-      />
-    )
-  }
-
-  function renderEditor() {
-    if (!selected) return null
-    const curLabel = formatTtl(selected.ttl)
+    // NS-mismatch is already shown as the banner; non-editable records open here.
+    if (nsMismatch) {
+      return (
+        <Panel title=" Editing blocked " active>
+          <box style={{ flexDirection: "column", width: 56, paddingTop: 1, paddingBottom: 1 }}>
+            <text content="This connection can't safely edit this record — see the ⚠ above." fg={theme.textDim} wrapMode="none" />
+            <box style={{ height: 1 }} />
+            <text content="Esc to close" fg={theme.textFaint} />
+          </box>
+        </Panel>
+      )
+    }
+    if (!record.editable) {
+      return (
+        <Panel title=" Read-only record " active>
+          <box style={{ flexDirection: "column", width: 56, paddingTop: 1, paddingBottom: 1 }}>
+            <box style={{ flexDirection: "row" }}>
+              <text content={`${truncate(record.name || "@", 28)} `} fg={theme.accent} wrapMode="none" />
+              <text content={record.type} fg={theme.textDim} wrapMode="none" />
+            </box>
+            <box style={{ height: 1 }} />
+            <text content={`Can't edit this TTL — ${record.reason ?? "read-only"}.`} fg={theme.textDim} wrapMode="none" />
+            <box style={{ height: 1 }} />
+            <text content="Esc to close" fg={theme.textFaint} />
+          </box>
+        </Panel>
+      )
+    }
 
     if (phase === "pick") {
       return (
         <Panel title=" Choose a TTL " active>
           <box style={{ flexDirection: "column", width: 44 }}>
             <box style={{ flexDirection: "row" }}>
-              <text content={`${truncate(selected.name || "@", 28)} `} fg={theme.accent} wrapMode="none" />
-              <text content={selected.type} fg={theme.textDim} wrapMode="none" />
+              <text content={`${truncate(record.name || "@", 28)} `} fg={theme.accent} wrapMode="none" />
+              <text content={record.type} fg={theme.textDim} wrapMode="none" />
               <box style={{ flexGrow: 1 }} />
               <text content={`now ${curLabel}`} fg={theme.textFaint} wrapMode="none" />
             </box>
@@ -384,7 +302,7 @@ export function DnsRecords() {
             {ttlOptions.map((o, i) => {
               const sel = i === pickIndex
               const isCustom = o.ttl === CUSTOM_TTL
-              const isCurrent = o.ttl === selected.ttl
+              const isCurrent = o.ttl === record.ttl
               const text = isCustom ? "Custom…" : `${formatTtl(o.ttl)}  (${o.ttl}s)`
               const tag = isCurrent ? "  (current)" : ""
               return (
@@ -418,8 +336,8 @@ export function DnsRecords() {
         <Panel title=" Confirm TTL change " active>
           <box style={{ flexDirection: "column", width: 56, paddingTop: 1, paddingBottom: 1 }}>
             <box style={{ flexDirection: "row" }}>
-              <text content={`${truncate(selected.name || "@", 28)} `} fg={theme.accent} wrapMode="none" />
-              <text content={selected.type} fg={theme.textDim} wrapMode="none" />
+              <text content={`${truncate(record.name || "@", 28)} `} fg={theme.accent} wrapMode="none" />
+              <text content={record.type} fg={theme.textDim} wrapMode="none" />
             </box>
             <box style={{ flexDirection: "row" }}>
               <text content={`TTL ${curLabel}`} fg={theme.textDim} />
@@ -454,11 +372,11 @@ export function DnsRecords() {
           <box style={{ flexDirection: "column", width: 52, paddingTop: 1, paddingBottom: 1 }}>
             <box style={{ flexDirection: "row" }}>
               <text content="✓ " fg={theme.good} />
-              <text content={`${truncate(selected.name || "@", 24)} ${selected.type}`} fg={theme.accent} wrapMode="none" />
+              <text content={`${truncate(record.name || "@", 24)} ${record.type}`} fg={theme.accent} wrapMode="none" />
               <text content={` TTL is now ${formatTtl(targetTtl)}`} fg={theme.text} wrapMode="none" />
             </box>
             <box style={{ height: 1 }} />
-            <text content="Esc to return to the records" fg={theme.textFaint} />
+            <text content="Esc to close · r in the inventory to refresh" fg={theme.textFaint} wrapMode="none" />
           </box>
         </Panel>
       )
@@ -477,19 +395,14 @@ export function DnsRecords() {
   }
 
   function hints() {
-    if (loadState !== "ready" && phase === "list") return [{ key: "esc", label: "close" }]
+    if (loadState !== "ready") return [{ key: "esc", label: "close" }]
+    if (blocked) return [{ key: "esc", label: "close" }]
     switch (dp) {
-      case "list":
-        return [
-          { key: "↑↓/jk", label: "record" },
-          { key: "t/⏎", label: "set TTL" },
-          { key: "esc", label: "close" },
-        ]
       case "pick":
         return [
           { key: "↑↓/jk", label: "TTL" },
           { key: "⏎", label: "choose" },
-          { key: "esc", label: "back" },
+          { key: "esc", label: "close" },
         ]
       case "custom":
         return [

--- a/src/ui/views/Search.tsx
+++ b/src/ui/views/Search.tsx
@@ -32,7 +32,7 @@ function score(haystack: string, q: string): number | null {
 
 export function Search({ rows }: { rows: number }) {
   const store = useStore()
-  const { servers, sites, serverById, setInputMode, setRoute, route, overlayOpen, setHealthServer, setPhpUpgradeSite, setServerActionsServer, accountSlug, localLinks, setLocalLinkSite, openLocalTerminal, openLocalUrl, sshSite } = store
+  const { servers, sites, serverById, setInputMode, setRoute, route, overlayOpen, setHealthServer, setPhpUpgradeSite, setServerActionsServer, accountSlug, localLinks, setLocalLinkSite, openLocalTerminal, openLocalUrl, sshSite, setDnsInventoryServer } = store
   const [query, setQuery] = useState("")
   const [selected, setSelected] = useState(0)
   // "query" = typing/filtering (input focused); "actions" = input blurred so the
@@ -154,6 +154,14 @@ export function Search({ rows }: { rows: number }) {
       case "s":
         if (current?.kind === "site") flashMsg(sshSite(current.site.id))
         return
+      case "n":
+        // DNS inventory scoped to this site (its domains + records) — the migrate
+        // lens for moving one site to another server.
+        if (current?.kind === "site") {
+          const srv = serverById(current.site.server_id)
+          if (srv) setDnsInventoryServer(srv, current.site.id)
+        }
+        return
       case "h": {
         const srv =
           current?.kind === "server"
@@ -197,7 +205,7 @@ export function Search({ rows }: { rows: number }) {
         : [
             { key: "↑↓", label: "select" },
             { key: "o", label: "open" },
-            { key: "w", label: "SpinupWP" },
+            { key: "n", label: "DNS" },
             { key: "u", label: "upgrade PHP" },
             { key: "a", label: "server actions" },
             { key: "h", label: "health" },
@@ -298,6 +306,7 @@ function ActionsCard({ result, serverName }: { result: Result; serverName: strin
     ? [
         ["o", "Open site in browser"],
         ["w", "Open in SpinupWP"],
+        ["n", "DNS records for this site (migrate lens)"],
         ["s", "SSH into the site (opens a terminal)"],
         ["u", "Upgrade PHP version"],
         ["t", "Open local working copy in a terminal"],


### PR DESCRIPTION
**Status: draft / in progress.** This builds on the read-only DNS module (v0.6.0)
and is the first DNS *write* phase. Open early so anyone following the project can
see what's coming before it's released. Targets **v0.7.0**; not ready to merge until
the Cloudflare write path is verified (see checklist).

## What this is
Re-scopes the DNS module from a zone editor into a **server-migration record
manager**: it only ever shows and touches a site's *own hosting records*, so moving
a site can't disturb its MX / TXT / DKIM / other zone records. The untouchability is
the point — a novice can't move a site and knock out its email at the same time.

## Highlights
- **Edit a record's TTL (`⏎`) — the first DNS write.** Focused editor (preset or
  custom), confirm step, written to **AWS Route 53** or **Cloudflare** via your
  connected account. The prep step for a low-risk cutover: lower the TTL, repoint,
  restore. An edit-time check re-reads the live nameservers and **blocks** the write
  if the connected account's zone isn't the one actually serving the domain (no
  editing a stale/duplicate copy). Route 53 changes are followed to completion; the
  row shows an "updating" status that persists even if you leave the view.
- **The `N`/`n` view is now a site-organized migration lens.** Each **site** is a
  line, labeled by its own domain (even when it's a subdomain), with its hosting
  record's type / TTL / value, a `◀ here` flag when it points at this server, and a
  `+www` tag when `www` simply follows the apex. Additional domains nest beneath the
  site, so a domain portfolio reads as one site (e.g. `app.example.com`,
  `api.example.com` on one apex read as two distinct sites, not a repeated apex).
  TTLs render in **seconds**.
- **Scoped entry.** `n` on a site (Servers or Search) opens the inventory for just
  that site; `a` inside expands to the whole server. `N` opens the full server view.

## Safety / scope
- Reads are scoped to a single record — the zone is never enumerated, so non-hosting
  records are never even fetched.
- Only the **TTL** is editable so far (repointing a record's target is a later step).
  Cloudflare **proxied** records are read-only (TTL is managed by Cloudflare).

## Testing
- [x] Route 53 — TTL edit verified live (read paths + NS-match gate + write).
- [ ] Cloudflare — **DNS-only record** (grey cloud, points at an IP): edits like
      R53; write is synchronous; `◀ here` lights up; verify new TTL in the CF
      dashboard. (Needs a `Zone.DNS:Edit` token; `Zone:Read` shows `✓` but the write
      fails at confirm.)
- [ ] Cloudflare — **proxied record** (orange cloud): opens read-only ("proxied");
      note the known inventory blind spot (cred-free lookup returns CF's anycast IP +
      edge TTL, not the origin, so `◀ here` won't light up yet).
- [x] `typecheck` green.

## Not in this PR (follow-ups)
- Repoint a record's target/IP (cutover step 3).
- Cloudflare proxied: read the true origin via the CF API (fixes `◀ here` + enables a
  per-record cutover hint).

Spec: `docs/dns-phase3-migration-spec.md`. Changelog staged under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019aKixMUzg2tsqh1Mg8ADfv