### PR TITLE
Production DB backup download + prod→local sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+### Added
+- **Download a production database backup.** On a linked WordPress site, press
+  `d` in Search to export the production database with `wp-cli` (into a stage file
+  *outside* the public webroot), gzip it, download it into the linked copy's
+  `sql/` folder, and remove the remote copy. **Read-only on production** and needs
+  no local WP-CLI — the export runs on the server. The remote document root and
+  SSH target are derived from the API; SSH/scp run non-interactively. A spinner on
+  the site's row tracks an in-flight download even after the overlay is closed.
+  (See "Database backup & sync" in the README.)
+- **Pull production → local DB sync (opt-in).** Press `p` on a linked WordPress
+  site to refresh your **local** database from production: it backs up the local
+  DB first, exports + downloads production, imports it locally, rewrites
+  production URLs → your local URL (`wp search-replace`), and runs an optional
+  `bin/sync.d/post-import.sh` hook if the project has one. Works with Standard WP
+  and Bedrock, detecting the local WordPress root, local URL (link or `.env`
+  `WP_HOME`), and table prefix automatically — no per-site config. **It overwrites
+  your local database, so it's off by default**; enable it with `localSync` (a
+  `config.json` field, preferred, or the `SPINUPWP_LOCAL_SYNC` env var). Read-only
+  on production.
+- **Site Control panel.** The Search result's action menu is now grouped
+  (Open / Remote / Local / Server) so the growing set of per-site actions stays
+  scannable.
+
+### Notes
+- The DB backup/sync actions only appear for **WordPress** sites (they use
+  `wp-cli`), and only when the site is **linked** to a local copy (the backup's
+  destination). The destructive sync additionally requires the `localSync` opt-in.
+
 ## [0.6.0] - 2026-06-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Once you're in, the dashboard looks like this:
   (See "Local working copies" below.)
 - **SSH into a site** — press `s` on a site to open a new terminal already running
   `ssh` into it (`{site_user}@{server_ip}`).
+- **Database backup & sync** — on a linked WordPress site (Search tab), press `d`
+  to download a gzipped production database backup into the copy's `sql/` folder
+  (**read-only on production**), or — opt-in — press `p` to pull production into
+  your **local** database (backs up local first, rewrites URLs, runs your existing
+  `sync.d` hook). Works with Standard WP and Bedrock, no per-site config. (See
+  "Database backup & sync" below.)
 - **DNS hosts & access** — press `n` on a site (or `N` on a server) to see where
   each domain's DNS is hosted, and — if you connect a provider (AWS Route 53 /
   Cloudflare / GoDaddy) — whether you can edit it and through which account. The
@@ -147,7 +153,7 @@ screen) and relaunch, or set the environment variable.
 
 ### Optional settings
 
-Both can be set in `config.json` or via an environment variable:
+These can be set in `config.json` or via an environment variable:
 
 - **`accountSlug`** / `SPINUPWP_ACCOUNT_SLUG` — your SpinupWP account/team slug
   (the first path segment in a SpinupWP URL, e.g. `wenmark-digital-solutions` in
@@ -156,6 +162,15 @@ Both can be set in `config.json` or via an environment variable:
   Without it, `w` opens the SpinupWP dashboard root.
 - **`sshUser`** / `SPINUPWP_SSH_USER` — override the SSH user for the health view
   and stack probes (see "Server health" below).
+- **`localSync`** / `SPINUPWP_LOCAL_SYNC` — opt-in for the **Pull production →
+  local** DB sync (`p`); off by default because it overwrites your local database.
+  **Prefer `"localSync": true` in `config.json`** — it's read from a fixed path
+  (`~/.config/spinupwp-tui/config.json`) so it applies wherever you launch `spinup`
+  from. The environment variable works too, but note a `.env` is only loaded when
+  you launch from the directory that contains it (Bun reads `.env` from the current
+  working directory, not from where the installed command lives) — so a repo or
+  project `.env` won't take effect for the globally-installed `spinup` run from
+  elsewhere. For a persistent, location-independent setting, use `config.json`.
 
 ## Keybindings
 
@@ -169,6 +184,8 @@ Both can be set in `config.json` or via an environment variable:
 | `g` / `G` | Jump to top / bottom |
 | `o` | Open the selected site in your browser |
 | `s` | Open a terminal and SSH into the selected site |
+| `d` | Download a production DB backup into the linked copy (Search; WordPress + linked) |
+| `p` | Pull the production DB into the linked copy — overwrites local; opt-in via `localSync` (Search) |
 | `L` | Link / edit a site's local working copy |
 | `t` / `v` | Open the linked copy in a terminal / its local URL in your browser |
 | `n` | Look up where a site's domains host DNS |
@@ -300,6 +317,44 @@ serve it; the site's details gain a "Local" field, and you can open the copy wit
 
 Config keys: `localRoots` (folders to scan) and `localSites` (per-site path +
 local URL — tool-agnostic: Valet, Cove, LocalWP, Herd, DDEV, …).
+
+## Database backup & sync
+
+For a WordPress site you've **linked** to a local copy, the Search tab can pull
+the production database down — the same idea as a hand-rolled `wp db export` +
+`scp`, without leaving the dashboard. Both actions are **read-only on production**
+(they export; they never write to the live site) and run `ssh`/`scp`
+non-interactively, so your key needs to be loaded in your agent.
+
+- **Download a backup (`d`).** Exports the production database with `wp-cli` into
+  a stage file *outside* the public webroot, gzips it, downloads it into the linked
+  copy's `sql/` folder, and removes the remote copy. Needs **no local WP-CLI** —
+  the export runs on the server. Available whenever a WordPress site is linked. A
+  spinner on the site's row tracks an in-flight download even if you close the
+  overlay; the saved path and size are shown on completion.
+- **Pull production → local (`p`, opt-in).** A full refresh of your **local**
+  database from production: it backs up the local DB first (to
+  `sql/local_<timestamp>.sql.gz`), exports + downloads production, imports it
+  locally, rewrites production URLs → your local URL (`wp search-replace`), and
+  runs an optional `bin/sync.d/post-import.sh` hook if the project has one.
+  **This overwrites your local database**, so it's **off by default** — enable it
+  with `localSync` (see "Optional settings"). It needs a working local WP-CLI; if
+  it's missing you get a clear error rather than a broken run.
+
+Everything is detected automatically, for Standard WP **and** Bedrock:
+
+- the **remote document root** from the API (`/sites/{domain}/files{public_folder}`),
+- the **SSH target** from the site/server (`{site_user}@{server_ip}`),
+- the **local WordPress root** from the linked path (where `wp` runs — wp-config
+  for Standard WP, `wp-cli.yml` for Bedrock),
+- the **local URL** for the rewrite from the link's local URL, falling back to the
+  project's `.env` `WP_HOME`.
+
+If your project already has a `bin/sync.d/post-import.sh` (e.g. Elementor URL
+swaps, plugin toggles), it runs with `WEB_DIR`, `SYNC_REMOTE_HOST`, and
+`SYNC_LOCAL_HOST` set — so existing per-project tweaks carry over with no extra
+configuration. Backups stay **gzipped** in `sql/`; decompress with `gunzip` when
+you need one.
 
 ## DNS hosts & access
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,11 @@ export interface AppConfig {
   // macOS terminal app to open for local working copies (e.g. "iTerm", "Warp").
   // When unset, inferred from $TERM_PROGRAM, falling back to Terminal.
   terminalApp: string | null
+  // Opt-in for the production→local DB sync (`p`). Off by default because it
+  // OVERWRITES the local database and assumes a working local WP dev environment
+  // (WP-CLI + a local DB). The read-only DB backup (`d`) needs neither and stays
+  // available without this. Set "localSync": true in config to enable.
+  localSync: boolean
   // Directories to (eventually) scan for local working copies. Reserved for the
   // Phase 2 auto-discovery pass; unused by Phase 1's manual linking.
   localRoots: string[]
@@ -75,6 +80,7 @@ export interface StoredConfig {
   terminalApp?: string
   localRoots?: string[]
   localSites?: Record<string, LocalLink>
+  localSync?: boolean
   providers?: StoredProviders
 }
 
@@ -144,6 +150,12 @@ export function loadConfig(): AppConfig {
     sshUser: process.env.SPINUPWP_SSH_USER?.trim() || stored.sshUser?.trim() || null,
     accountSlug: process.env.SPINUPWP_ACCOUNT_SLUG?.trim() || stored.accountSlug?.trim() || null,
     terminalApp: process.env.SPINUPWP_TERMINAL_APP?.trim() || stored.terminalApp?.trim() || null,
+    localSync: ((): boolean => {
+      // Env overrides the file when present; otherwise the stored flag (default off).
+      const env = process.env.SPINUPWP_LOCAL_SYNC?.trim()
+      if (env != null && env !== "") return /^(1|true|yes|on)$/i.test(env)
+      return stored.localSync === true
+    })(),
     localRoots: stored.localRoots ?? [],
     localSites: stored.localSites ?? {},
     providerConnections,

--- a/src/lib/dbBackup.ts
+++ b/src/lib/dbBackup.ts
@@ -1,0 +1,197 @@
+// Download a production database backup over SSH.
+//
+// Mirrors the proven sync-prod-to-local pattern: export to a stage file OUTSIDE
+// the public webroot (in $HOME), gzip it remotely, scp it down into the linked
+// project's `sql/` dir, then remove the remote copy.
+//
+// We deliberately do NOT stream `wp db export -` to stdout: plugins print to
+// stdout during WP bootstrap (e.g. GiveWP deprecation notices), which would
+// corrupt the dump. `wp db export <file>` writes pure SQL regardless of that
+// noise. SSH is non-interactive (BatchMode) — SpinupWP sites are key-only, so
+// this works headlessly from the user's agent; a missing key fails fast.
+
+import { existsSync, mkdirSync, statSync } from "node:fs"
+import { join } from "node:path"
+import type { Server, Site } from "../api/types.ts"
+import { expandPath, type LocalLink } from "./local.ts"
+
+export const SSH_OPTS = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=accept-new"]
+
+// ssh uses -p for a non-default port, scp uses -P.
+export const sshPort = (port: number | null | undefined) => (port && port !== 22 ? ["-p", String(port)] : [])
+export const scpPort = (port: number | null | undefined) => (port && port !== 22 ? ["-P", String(port)] : [])
+
+// Derive a SpinupWP site's absolute remote document root. SpinupWP serves each
+// site from `/sites/{domain}/files{public_folder}`; the API's `public_folder` is
+// only the suffix (e.g. "/public/" for standard WP, "/web/" for Bedrock), so we
+// join it onto the fixed base. wp-cli finds the install from this cwd.
+export function remoteDocRoot(domain: string, publicFolder: string | null): string {
+  const suffix = (publicFolder ?? "public").replace(/^\/+|\/+$/g, "") // strip surrounding slashes
+  const base = `/sites/${domain}/files`
+  return suffix ? `${base}/${suffix}` : base
+}
+
+const p2 = (n: number) => String(n).padStart(2, "0")
+
+// Timestamped backup base name, e.g. "hoperedefined.org_2026-06-22_1113".
+export function backupBaseName(domain: string, now: Date): string {
+  const d = `${now.getFullYear()}-${p2(now.getMonth() + 1)}-${p2(now.getDate())}`
+  const t = `${p2(now.getHours())}${p2(now.getMinutes())}`
+  return `${domain}_${d}_${t}`
+}
+
+export interface DbBackupPlan {
+  user: string
+  host: string
+  port: number | null
+  docroot: string
+  // The gzipped stage file, named relative to $HOME so scp can address it
+  // directly (e.g. "hoperedefined.org_2026-06-22_1113.sql.gz").
+  remoteGz: string
+  destDir: string // local <projectRoot>/sql
+  destPath: string // local absolute path of the downloaded .sql.gz
+}
+
+export type PlanResult = { ok: true; plan: DbBackupPlan } | { ok: false; error: string }
+
+// Resolve everything needed to run a backup, or a human-readable reason it can't
+// run. The destination lives in the linked working copy, so an unlinked (or
+// missing) local path is a hard stop.
+export function planDbBackup(
+  site: Site,
+  server: Server | undefined,
+  sshUser: string | null,
+  link: LocalLink | undefined,
+  now: Date,
+): PlanResult {
+  const host = server?.ip_address
+  const user = site.site_user ?? sshUser
+  if (!host || !user) return { ok: false, error: "Missing site user or server IP — can't reach the site." }
+  if (!link) return { ok: false, error: "Not linked — press L to link a local copy first." }
+  const dir = expandPath(link.path)
+  if (!existsSync(dir)) return { ok: false, error: "Local path is missing — press L to fix the link." }
+
+  // Drop the backup in the folder the user linked (where `t` opens a terminal),
+  // under a sql/ subdir — same convention as the sync-prod-to-local script.
+  const destDir = join(dir, "sql")
+  const remoteGz = `${backupBaseName(site.domain, now)}.sql.gz`
+  return {
+    ok: true,
+    plan: {
+      user,
+      host,
+      port: server?.ssh_port ?? null,
+      docroot: remoteDocRoot(site.domain, site.public_folder),
+      remoteGz,
+      destDir,
+      destPath: join(destDir, remoteGz),
+    },
+  }
+}
+
+export type DbBackupStage = "export" | "download" | "cleanup" | "done" | "error"
+
+export interface DbBackupProgress {
+  stage: DbBackupStage
+  domain: string
+  destPath?: string
+  bytes?: number
+  error?: string
+}
+
+export function isDbBackupInFlight(p: DbBackupProgress | undefined): boolean {
+  return p != null && p.stage !== "done" && p.stage !== "error"
+}
+
+// Run a child process to completion, capturing output with a hard timeout. An
+// optional cwd lets callers run local `wp` in a project directory.
+export async function runProcess(
+  cmd: string[],
+  timeoutMs: number,
+  cwd?: string,
+  env?: Record<string, string>,
+): Promise<{ code: number; stderr: string }> {
+  let proc: ReturnType<typeof Bun.spawn>
+  try {
+    proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "pipe", stdin: "ignore", cwd, env })
+  } catch (err) {
+    return { code: -1, stderr: `Failed to launch ${cmd[0]}: ${(err as Error).message}` }
+  }
+  const timer = setTimeout(() => {
+    try {
+      proc.kill()
+    } catch {
+      /* already gone */
+    }
+  }, timeoutMs)
+  const code = await proc.exited
+  clearTimeout(timer)
+  const stderr = await new Response(proc.stderr as ReadableStream<Uint8Array>).text()
+  return { code, stderr }
+}
+
+// Pick a meaningful error line out of ssh/wp stderr, skipping the deprecation /
+// warning noise WordPress plugins emit during bootstrap.
+export function meaningfulError(stderr: string, fallback: string): string {
+  const lines = stderr
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .filter((l) => !/^(PHP\s+)?(Deprecated|Warning|Notice):/i.test(l))
+  return lines[lines.length - 1] || fallback
+}
+
+// Run the full backup, reporting each stage through `onProgress`. Resolves with
+// the terminal progress (done | error). Never throws.
+export async function runDbBackup(
+  plan: DbBackupPlan,
+  domain: string,
+  onProgress: (p: DbBackupProgress) => void,
+): Promise<DbBackupProgress> {
+  const target = `${plan.user}@${plan.host}`
+  const fail = (error: string): DbBackupProgress => {
+    const p: DbBackupProgress = { stage: "error", domain, error }
+    onProgress(p)
+    return p
+  }
+
+  // 1) Export on the remote into a $HOME stage file (outside the webroot) and
+  //    gzip it. `wp db export <file>` writes pure SQL even when plugins print to
+  //    stdout; --single-transaction avoids locking the live DB during the dump.
+  onProgress({ stage: "export", domain })
+  const sql = plan.remoteGz.replace(/\.gz$/, "") // <base>.sql
+  const remoteScript =
+    `set -e; cd '${plan.docroot}'; ` +
+    `wp db export "$HOME/${sql}" --single-transaction >/dev/null; ` +
+    `gzip -f "$HOME/${sql}"`
+  const exp = await runProcess(["ssh", ...SSH_OPTS, ...sshPort(plan.port), target, remoteScript], 300_000)
+  if (exp.code !== 0) return fail(`Remote export failed — ${meaningfulError(exp.stderr, `ssh exit ${exp.code}.`)}`)
+
+  // 2) Download the gzip into the project's sql/ dir.
+  onProgress({ stage: "download", domain })
+  try {
+    mkdirSync(plan.destDir, { recursive: true })
+  } catch {
+    /* best-effort; scp surfaces a real write failure */
+  }
+  const dl = await runProcess(["scp", ...SSH_OPTS, ...scpPort(plan.port), `${target}:${plan.remoteGz}`, plan.destPath], 300_000)
+  if (dl.code !== 0) {
+    // Still try to remove the remote stage file so it doesn't linger.
+    void runProcess(["ssh", ...SSH_OPTS, ...sshPort(plan.port), target, `rm -f "$HOME/${plan.remoteGz}"`], 30_000)
+    return fail(`Download failed — ${meaningfulError(dl.stderr, `scp exit ${dl.code}.`)}`)
+  }
+
+  // 3) Remove the remote stage file.
+  onProgress({ stage: "cleanup", domain })
+  await runProcess(["ssh", ...SSH_OPTS, ...sshPort(plan.port), target, `rm -f "$HOME/${plan.remoteGz}"`], 30_000)
+
+  let bytes: number | undefined
+  try {
+    bytes = statSync(plan.destPath).size
+  } catch {
+    /* file exists per scp exit 0; size is cosmetic */
+  }
+  const done: DbBackupProgress = { stage: "done", domain, destPath: plan.destPath, bytes }
+  onProgress(done)
+  return done
+}

--- a/src/lib/dbSync.ts
+++ b/src/lib/dbSync.ts
@@ -1,0 +1,212 @@
+// Pull a production database down into the local working copy.
+//
+// Builds on the DB-backup pipeline: export prod (read-only), download the gzip,
+// then IMPORT it into the LOCAL WordPress DB and rewrite URLs so the local copy
+// mirrors production. This is destructive on LOCAL (it overwrites the local DB),
+// but never writes to production — so we back up the local DB first.
+//
+// Works for Standard WP and Bedrock without configuration: local `wp` auto-
+// discovers the install from the linked project dir, and the local URL / table
+// prefix are detected from the link, the project .env, or wp-config.php. It even
+// runs an existing bin/sync.d/post-import.sh hook with the same WEB_DIR /
+// SYNC_REMOTE_HOST / SYNC_LOCAL_HOST env contract as the sync-prod-to-local
+// script, so per-project tweaks (Elementor URL swaps, plugin toggles) carry over.
+
+import { existsSync, mkdirSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+import type { Server, Site } from "../api/types.ts"
+import { expandPath, findProjectRoot, type LocalLink } from "./local.ts"
+import { remoteDocRoot, backupBaseName, SSH_OPTS, sshPort, scpPort, runProcess, meaningfulError } from "./dbBackup.ts"
+
+// Read a KEY=value from a dotenv file, tolerating surrounding quotes. null if absent.
+function readEnvVar(envPath: string, key: string): string | null {
+  try {
+    const m = readFileSync(envPath, "utf8").match(new RegExp(`^\\s*${key}\\s*=\\s*(.*)\\s*$`, "m"))
+    if (!m) return null
+    return m[1].trim().replace(/^['"]|['"]$/g, "") || null
+  } catch {
+    return null
+  }
+}
+
+// Read $table_prefix from a wp-config.php (Standard WP). null if absent.
+function readWpConfigPrefix(configPath: string): string | null {
+  try {
+    const m = readFileSync(configPath, "utf8").match(/\$table_prefix\s*=\s*['"]([^'"]+)['"]/)
+    return m ? m[1] : null
+  } catch {
+    return null
+  }
+}
+
+// Bare host of a URL (drops scheme, path, trailing slash).
+function hostOf(url: string): string {
+  return url.replace(/^[a-z]+:\/\//i, "").replace(/\/.*$/, "").trim()
+}
+
+export interface DbSyncPlan {
+  user: string
+  host: string
+  port: number | null
+  docroot: string
+  remoteGz: string // $HOME-relative gz produced on the remote
+  localRoot: string // where local `wp` runs (findProjectRoot of the link)
+  sqlDir: string // localRoot/sql
+  downloadPath: string // sqlDir/<base>.sql.gz — the prod dump, kept as a backup
+  localBackupPath: string // sqlDir/local_<ts>.sql.gz — pre-import safety dump
+  remoteOrigin: string // https://prod-domain (rewritten from)
+  localOrigin: string // local URL as entered (rewritten to)
+  remoteHost: string // bare prod host (hook env)
+  localHost: string // bare local host (hook env)
+  hookPath: string | null // bin/sync.d/post-import.sh, if present
+  prefixWarning: string | null // set when remote/local table prefixes differ
+}
+
+export type SyncPlanResult = { ok: true; plan: DbSyncPlan } | { ok: false; error: string }
+
+export function planDbSync(
+  site: Site,
+  server: Server | undefined,
+  sshUser: string | null,
+  link: LocalLink | undefined,
+  now: Date,
+): SyncPlanResult {
+  const host = server?.ip_address
+  const user = site.site_user ?? sshUser
+  if (!host || !user) return { ok: false, error: "Missing site user or server IP — can't reach the site." }
+  if (!link) return { ok: false, error: "Not linked — press L to link a local copy first." }
+  const dir = expandPath(link.path)
+  if (!existsSync(dir)) return { ok: false, error: "Local path is missing — press L to fix the link." }
+
+  const localRoot = findProjectRoot(dir)
+  const envPath = join(localRoot, ".env")
+
+  // Local origin (URL rewrite target): the linked localUrl wins; fall back to the
+  // project .env WP_HOME (Bedrock). Required — without it we'd leave prod URLs.
+  const localUrlRaw = link.localUrl?.trim() || readEnvVar(envPath, "WP_HOME") || ""
+  if (!localUrlRaw) return { ok: false, error: "No local URL — press L to set one (needed to rewrite URLs)." }
+  const localOrigin = localUrlRaw.replace(/\/+$/, "")
+  const localHost = hostOf(localOrigin)
+  const remoteHost = site.domain
+  const remoteOrigin = `${site.https?.enabled ? "https" : "http"}://${remoteHost}`
+
+  // Prefix sanity: a remote↔local table-prefix mismatch makes the imported DB
+  // unusable by local wp (search-replace would target the wrong tables). Warn.
+  const remotePrefix = site.database?.table_prefix ?? null
+  const localPrefix = readEnvVar(envPath, "DB_PREFIX") ?? readWpConfigPrefix(join(localRoot, "wp-config.php"))
+  const prefixWarning =
+    remotePrefix && localPrefix && remotePrefix !== localPrefix
+      ? `Table prefix differs (remote "${remotePrefix}" vs local "${localPrefix}") — the import may not line up.`
+      : null
+
+  const sqlDir = join(localRoot, "sql")
+  const base = backupBaseName(site.domain, now)
+  const stamp = base.slice(base.indexOf("_") + 1) // the date_time part
+  return {
+    ok: true,
+    plan: {
+      user,
+      host,
+      port: server?.ssh_port ?? null,
+      docroot: remoteDocRoot(site.domain, site.public_folder),
+      remoteGz: `${base}.sql.gz`,
+      localRoot,
+      sqlDir,
+      downloadPath: join(sqlDir, `${base}.sql.gz`),
+      localBackupPath: join(sqlDir, `local_${stamp}.sql.gz`),
+      remoteOrigin,
+      localOrigin,
+      remoteHost,
+      localHost,
+      hookPath: existsSync(join(localRoot, "bin", "sync.d", "post-import.sh"))
+        ? join(localRoot, "bin", "sync.d", "post-import.sh")
+        : null,
+      prefixWarning,
+    },
+  }
+}
+
+export type DbSyncStage = "local-backup" | "export" | "download" | "import" | "replace" | "hook" | "done" | "error"
+
+export interface DbSyncProgress {
+  stage: DbSyncStage
+  domain: string
+  downloadPath?: string
+  localBackupPath?: string
+  ranHook?: boolean
+  error?: string
+}
+
+export function isDbSyncInFlight(p: DbSyncProgress | undefined): boolean {
+  return p != null && p.stage !== "done" && p.stage !== "error"
+}
+
+// Run the full pull, reporting each stage. Resolves with the terminal progress
+// (done | error). Never throws. Read-only on production; destructive on local.
+export async function runDbSync(plan: DbSyncPlan, domain: string, onProgress: (p: DbSyncProgress) => void): Promise<DbSyncProgress> {
+  const target = `${plan.user}@${plan.host}`
+  const fail = (error: string): DbSyncProgress => {
+    const p: DbSyncProgress = { stage: "error", domain, error }
+    onProgress(p)
+    return p
+  }
+  // Prefix the surfaced error with the failing stage so it's self-locating
+  // (e.g. "Local DB backup failed — mysqldump: …" rather than a bare driver line).
+  const stageFail = (label: string, stderr: string, fallback: string) => fail(`${label} — ${meaningfulError(stderr, fallback)}`)
+  // Run local `wp` through a login shell so the user's PATH (composer/phar) resolves.
+  const wp = (cmd: string, timeoutMs: number, env?: Record<string, string>) => runProcess(["bash", "-lc", cmd], timeoutMs, plan.localRoot, env)
+
+  // 0) wp-cli must exist locally — fail with a clear message rather than cryptically.
+  if ((await wp("command -v wp", 15_000)).code !== 0) return fail("WP-CLI not found locally — install wp-cli to sync.")
+
+  // 1) Safety: back up the LOCAL DB before we overwrite it (file, then gzip).
+  onProgress({ stage: "local-backup", domain })
+  try {
+    mkdirSync(plan.sqlDir, { recursive: true })
+  } catch {
+    /* best-effort */
+  }
+  const localSql = plan.localBackupPath.replace(/\.gz$/, "")
+  const lb = await wp(`wp db export "${localSql}" >/dev/null && gzip -f "${localSql}"`, 300_000)
+  if (lb.code !== 0) return stageFail("Local DB backup failed", lb.stderr, "couldn't export the local database.")
+
+  // 2) Export prod + download the gzip (same remote pipeline as the backup).
+  onProgress({ stage: "export", domain })
+  const sql = plan.remoteGz.replace(/\.gz$/, "")
+  const remoteScript =
+    `set -e; cd '${plan.docroot}'; wp db export "$HOME/${sql}" --single-transaction >/dev/null; gzip -f "$HOME/${sql}"`
+  const exp = await runProcess(["ssh", ...SSH_OPTS, ...sshPort(plan.port), target, remoteScript], 300_000)
+  if (exp.code !== 0) return stageFail("Remote export failed", exp.stderr, `ssh exit ${exp.code}.`)
+
+  onProgress({ stage: "download", domain })
+  const dl = await runProcess(["scp", ...SSH_OPTS, ...scpPort(plan.port), `${target}:${plan.remoteGz}`, plan.downloadPath], 300_000)
+  if (dl.code !== 0) {
+    void runProcess(["ssh", ...SSH_OPTS, ...sshPort(plan.port), target, `rm -f "$HOME/${plan.remoteGz}"`], 30_000)
+    return stageFail("Download failed", dl.stderr, `scp exit ${dl.code}.`)
+  }
+  void runProcess(["ssh", ...SSH_OPTS, ...sshPort(plan.port), target, `rm -f "$HOME/${plan.remoteGz}"`], 30_000)
+
+  // 3) Import into local: stream gunzip → wp db cli (no temp extract).
+  onProgress({ stage: "import", domain })
+  const imp = await wp(`gunzip -c "${plan.downloadPath}" | wp db cli`, 600_000)
+  if (imp.code !== 0) return stageFail("Local import failed", imp.stderr, "wp db cli error.")
+
+  // 4) Rewrite production URLs → local URLs.
+  onProgress({ stage: "replace", domain })
+  const sr = await wp(`wp search-replace "${plan.remoteOrigin}" "${plan.localOrigin}" --skip-columns=guid --format=count`, 300_000)
+  if (sr.code !== 0) return stageFail("URL search-replace failed", sr.stderr, "wp search-replace error.")
+
+  // 5) Optional per-project post-import hook (Elementor swaps, plugin toggles, …).
+  let ranHook = false
+  if (plan.hookPath) {
+    onProgress({ stage: "hook", domain })
+    const env = { ...process.env, WEB_DIR: plan.localRoot, SYNC_REMOTE_HOST: plan.remoteHost, SYNC_LOCAL_HOST: plan.localHost } as Record<string, string>
+    const hk = await runProcess(["bash", plan.hookPath], 300_000, plan.localRoot, env)
+    if (hk.code !== 0) return stageFail("Post-import hook failed", hk.stderr, "hook script error.")
+    ranHook = true
+  }
+
+  const done: DbSyncProgress = { stage: "done", domain, downloadPath: plan.downloadPath, localBackupPath: plan.localBackupPath, ranHook }
+  onProgress(done)
+  return done
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -80,6 +80,17 @@ export function sparkline(values: number[], width = 30, max = 100): string {
     .join("")
 }
 
+// Truncate the MIDDLE, keeping the head and tail — for long paths/filenames where
+// both ends matter (e.g. ".../app/sql/site_2026-06-22.sql.gz").
+export function middleTruncate(s: string, max: number): string {
+  if (s.length <= max) return s
+  if (max <= 1) return s.slice(0, Math.max(0, max))
+  const keep = max - 1 // room for the ellipsis
+  const head = Math.ceil(keep / 2)
+  const tail = Math.floor(keep / 2)
+  return s.slice(0, head) + "…" + s.slice(s.length - tail)
+}
+
 export function truncate(s: string | null | undefined, max: number): string {
   if (!s) return ""
   if (s.length <= max) return s

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -15,6 +15,8 @@ import { Search } from "./views/Search.tsx"
 import { Events } from "./views/Events.tsx"
 import { Health } from "./views/Health.tsx"
 import { PhpUpgrade } from "./views/PhpUpgrade.tsx"
+import { DbBackup } from "./views/DbBackup.tsx"
+import { DbSync } from "./views/DbSync.tsx"
 import { ServerActions } from "./views/ServerActions.tsx"
 import { LocalLinkOverlay } from "./views/LocalLink.tsx"
 import { Discover } from "./views/Discover.tsx"
@@ -44,6 +46,8 @@ export function App() {
     showExplain ||
     store.healthServer !== null ||
     store.phpUpgradeSite !== null ||
+    store.dbBackupSite !== null ||
+    store.dbSyncSite !== null ||
     store.serverActionsServer !== null ||
     store.localLinkSite !== null ||
     store.discoverOpen ||
@@ -75,6 +79,12 @@ export function App() {
 
     // The PHP-upgrade overlay owns the keyboard while open.
     if (store.phpUpgradeSite) return
+
+    // The DB-backup overlay owns the keyboard while open.
+    if (store.dbBackupSite) return
+
+    // The DB-sync overlay owns the keyboard while open.
+    if (store.dbSyncSite) return
 
     // The server-actions overlay owns the keyboard while open.
     if (store.serverActionsServer) return
@@ -161,6 +171,8 @@ export function App() {
       {showExplain && <ExplainOverlay route={store.route} />}
       {store.healthServer && <Health />}
       {store.phpUpgradeSite && <PhpUpgrade />}
+      {store.dbBackupSite && <DbBackup />}
+      {store.dbSyncSite && <DbSync />}
       {store.serverActionsServer && <ServerActions />}
       {store.localLinkSite && <LocalLinkOverlay />}
       {store.discoverOpen && <Discover />}

--- a/src/ui/components.tsx
+++ b/src/ui/components.tsx
@@ -3,7 +3,30 @@
 import { useEffect, useRef, useState, type ReactNode } from "react"
 import { useKeyboard, usePaste } from "@opentui/react"
 import { theme, statusColor, statusDot } from "../lib/theme.ts"
+import { middleTruncate } from "../lib/format.ts"
 import { isUpgradeInFlight, type PhpUpgradeProgress } from "./store.tsx"
+
+// Shorten a home-relative absolute path for display (~/project/sql/file.sql.gz).
+export function shortPath(path: string): string {
+  const home = process.env.HOME
+  return home && path.startsWith(home + "/") ? "~/" + path.slice(home.length + 1) : path
+}
+
+// A filesystem destination shown as two lines — folder (dim, middle-truncated)
+// above the filename (colored, middle-truncated) — so the filename always stays
+// readable instead of being clipped off the end of one long line.
+export function DestPath({ path, fileColor, width = 62 }: { path: string; fileColor: string; width?: number }) {
+  const s = shortPath(path)
+  const i = s.lastIndexOf("/")
+  const dir = i < 0 ? "" : s.slice(0, i + 1)
+  const file = i < 0 ? s : s.slice(i + 1)
+  return (
+    <box style={{ flexDirection: "column" }}>
+      {dir ? <text content={`  ${middleTruncate(dir, width)}`} fg={theme.textDim} wrapMode="none" /> : null}
+      <text content={`  ${middleTruncate(file, width)}`} fg={fileColor} wrapMode="none" />
+    </box>
+  )
+}
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -33,6 +33,8 @@ import type { StoredProviders } from "../config.ts"
 import { fetchRebootInfo, type RebootInfo } from "../lib/ssh.ts"
 import { StackCache, siteSignature, type CachedProbe } from "../lib/stackCache.ts"
 import { resolvePhpEolDates, refreshPhpEolDates, isPhpEol as isPhpEolWith, offeredPhpVersions as offeredPhpVersionsWith, type PhpEolDates } from "../lib/phpEol.ts"
+import { planDbBackup, runDbBackup, type DbBackupProgress, type PlanResult } from "../lib/dbBackup.ts"
+import { planDbSync, runDbSync, type DbSyncProgress, type SyncPlanResult } from "../lib/dbSync.ts"
 
 export type Route = "dashboard" | "servers" | "stacks" | "search" | "events"
 
@@ -153,12 +155,38 @@ interface StoreValue extends DataState {
   openLocalUrl: (siteId: number) => string
   // Open a terminal and SSH into the site (site_user@server_ip). Returns a flash.
   sshSite: (siteId: number) => string
+  // The site whose DB-backup overlay is open, or null. Set by site views.
+  dbBackupSite: Site | null
+  setDbBackupSite: (s: Site | null) => void
+  // In-flight (and just-settled) DB-backup downloads, keyed by site id. Tracked in
+  // the store — not the overlay — so the download survives closing the modal.
+  dbBackups: Map<number, DbBackupProgress>
+  // Resolve a site's backup plan (SSH target, remote docroot, local destination)
+  // or a reason it can't run — used by the overlay's confirm screen.
+  planDbBackupFor: (site: Site) => PlanResult
+  // Export the production DB and download it to the linked project's sql/ dir.
+  startDbBackup: (site: Site) => void
+  clearDbBackup: (siteId: number) => void
+  // The site whose DB-sync overlay is open, or null. Set by site views.
+  dbSyncSite: Site | null
+  setDbSyncSite: (s: Site | null) => void
+  // In-flight (and just-settled) DB syncs, keyed by site id. Tracked in the store
+  // so the (longer, destructive-on-local) sync survives closing the modal.
+  dbSyncs: Map<number, DbSyncProgress>
+  // Resolve a site's sync plan (remote + local detection) or a reason it can't run.
+  planDbSyncFor: (site: Site) => SyncPlanResult
+  // Pull production into the local copy: backup local → export/download prod →
+  // import → search-replace URLs → run post-import hook. Destructive on LOCAL.
+  startDbSync: (site: Site) => void
+  clearDbSync: (siteId: number) => void
   // Local git drift for linked sites, keyed by site id (null = not a git repo,
   // undefined = not yet computed). Computed lazily + cached; cleared on refresh.
   drift: Map<number, Drift | null>
   ensureDrift: (siteId: number, linkPath: string) => void
   // Optional SSH user override for the health view (from env/config).
   sshUser: string | null
+  // Opt-in for the destructive production→local DB sync (`p`); default off.
+  localSync: boolean
   // SpinupWP account slug (from env/config) for building web deep links.
   accountSlug: string | null
   sitesForServer: (serverId: number) => Site[]
@@ -245,6 +273,10 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const [serverActionsServer, setServerActionsServer] = useState<Server | null>(null)
   const [serverOps, setServerOps] = useState<Map<number, ServerOpProgress>>(new Map())
   const [localLinkSite, setLocalLinkSite] = useState<Site | null>(null)
+  const [dbBackupSite, setDbBackupSite] = useState<Site | null>(null)
+  const [dbBackups, setDbBackups] = useState<Map<number, DbBackupProgress>>(new Map())
+  const [dbSyncSite, setDbSyncSite] = useState<Site | null>(null)
+  const [dbSyncs, setDbSyncs] = useState<Map<number, DbSyncProgress>>(new Map())
   const [localRoots, setLocalRoots] = useState<string[]>(() => [...cfgRef.current.localRoots])
   const [discoverOpen, setDiscoverOpen] = useState(false)
   const [forgottenOpen, setForgottenOpen] = useState(false)
@@ -635,6 +667,79 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     [sites, servers],
   )
 
+  // ---- Production DB backup download ------------------------------------
+
+  const setBackup = (siteId: number, progress: DbBackupProgress) =>
+    setDbBackups((prev) => new Map(prev).set(siteId, progress))
+
+  const clearDbBackup = useCallback(
+    (siteId: number) =>
+      setDbBackups((prev) => {
+        if (!prev.has(siteId)) return prev
+        const next = new Map(prev)
+        next.delete(siteId)
+        return next
+      }),
+    [],
+  )
+
+  const planDbBackupFor = useCallback(
+    (site: Site): PlanResult =>
+      planDbBackup(site, servers.find((s) => s.id === site.server_id), cfgRef.current.sshUser, localLinks.get(site.id), new Date()),
+    [servers, localLinks],
+  )
+
+  const startDbBackup = useCallback(
+    (site: Site) => {
+      // Ignore a duplicate request while one is already running for this site.
+      const existing = dbBackups.get(site.id)
+      if (existing && existing.stage !== "done" && existing.stage !== "error") return
+      const res = planDbBackupFor(site)
+      if (!res.ok) {
+        setBackup(site.id, { stage: "error", domain: site.domain, error: res.error })
+        return
+      }
+      void runDbBackup(res.plan, site.domain, (p) => setBackup(site.id, p))
+    },
+    [dbBackups, planDbBackupFor],
+  )
+
+  // ---- Production → local DB sync ---------------------------------------
+
+  const setSync = (siteId: number, progress: DbSyncProgress) =>
+    setDbSyncs((prev) => new Map(prev).set(siteId, progress))
+
+  const clearDbSync = useCallback(
+    (siteId: number) =>
+      setDbSyncs((prev) => {
+        if (!prev.has(siteId)) return prev
+        const next = new Map(prev)
+        next.delete(siteId)
+        return next
+      }),
+    [],
+  )
+
+  const planDbSyncFor = useCallback(
+    (site: Site): SyncPlanResult =>
+      planDbSync(site, servers.find((s) => s.id === site.server_id), cfgRef.current.sshUser, localLinks.get(site.id), new Date()),
+    [servers, localLinks],
+  )
+
+  const startDbSync = useCallback(
+    (site: Site) => {
+      const existing = dbSyncs.get(site.id)
+      if (existing && existing.stage !== "done" && existing.stage !== "error") return
+      const res = planDbSyncFor(site)
+      if (!res.ok) {
+        setSync(site.id, { stage: "error", domain: site.domain, error: res.error })
+        return
+      }
+      void runDbSync(res.plan, site.domain, (p) => setSync(site.id, p))
+    },
+    [dbSyncs, planDbSyncFor],
+  )
+
   // Compute a linked site's git drift once (cached), fire-and-forget. Stable
   // across renders (uses a ref for the dedup set), so views can call it freely
   // from an effect when a linked site comes into view.
@@ -900,6 +1005,18 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     openLocalTerminal,
     openLocalUrl,
     sshSite,
+    dbBackupSite,
+    setDbBackupSite,
+    dbBackups,
+    planDbBackupFor,
+    startDbBackup,
+    clearDbBackup,
+    dbSyncSite,
+    setDbSyncSite,
+    dbSyncs,
+    planDbSyncFor,
+    startDbSync,
+    clearDbSync,
     drift,
     ensureDrift,
     rebootInfo,
@@ -907,6 +1024,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     rebootInfoErrors,
     loadRebootInfo,
     sshUser: cfgRef.current.sshUser,
+    localSync: cfgRef.current.localSync,
     accountSlug: cfgRef.current.accountSlug,
     sitesForServer,
     serverById,

--- a/src/ui/views/DbBackup.tsx
+++ b/src/ui/views/DbBackup.tsx
@@ -1,0 +1,215 @@
+// Production DB-backup overlay.
+//
+// Opened with `d` on a linked site (Search). Confirms what will run, then exports
+// the remote database, downloads it (gzipped) into the local project's sql/ dir,
+// and cleans up the remote copy. The export + download run in the store
+// (`startDbBackup`), so closing this modal (Esc/q) doesn't abandon them — the
+// download keeps going and the result is still in the store when reopened.
+//
+// The whole operation is read-only on production (an export, never a write).
+
+import { useState } from "react"
+import { useKeyboard } from "@opentui/react"
+import { theme } from "../../lib/theme.ts"
+import { truncate, formatBytes, middleTruncate } from "../../lib/format.ts"
+import { Panel, Spinner, Centered, DestPath } from "../components.tsx"
+import { StatusBar } from "../StatusBar.tsx"
+import { useStore } from "../store.tsx"
+
+const STAGE_LABEL: Record<string, string> = {
+  export: "Exporting the database on the server…",
+  download: "Downloading the backup…",
+  cleanup: "Cleaning up the remote copy…",
+}
+
+export function DbBackup() {
+  const { dbBackupSite: site, setDbBackupSite, serverById, planDbBackupFor, dbBackups, startDbBackup, clearDbBackup } = useStore()
+
+  // Resolve the plan up front so the confirm screen can show source + destination
+  // (and surface an unrunnable link before the user commits).
+  const planResult = site ? planDbBackupFor(site) : null
+  const progress = site ? dbBackups.get(site.id) : undefined
+
+  const [started, setStarted] = useState(false)
+
+  // Display phase: a planning error blocks before anything runs; otherwise the
+  // screen follows the store's progress once we've fired the backup.
+  const dp: "blocked" | "confirm" | "running" | "done" | "error" =
+    planResult && !planResult.ok && !progress
+      ? "blocked"
+      : !started && !progress
+        ? "confirm"
+        : progress?.stage === "done"
+          ? "done"
+          : progress?.stage === "error"
+            ? "error"
+            : "running"
+
+  const close = () => {
+    // Drop a settled (done/failed) entry so reopening starts fresh; leave an
+    // in-flight download running with its progress intact.
+    if (site && (progress?.stage === "done" || progress?.stage === "error")) clearDbBackup(site.id)
+    setDbBackupSite(null)
+  }
+
+  useKeyboard((key) => {
+    const name = key.name ?? ""
+    if (name === "escape" || name === "q") return close()
+
+    if (dp === "confirm") {
+      if (name === "return" || name === "y") {
+        if (site) {
+          startDbBackup(site)
+          setStarted(true)
+        }
+      }
+      return
+    }
+
+    if (dp === "error") {
+      if (name === "r") {
+        if (site) clearDbBackup(site.id)
+        setStarted(false)
+      }
+      return
+    }
+  })
+
+  if (!site) return null
+  const server = serverById(site.server_id)
+
+  return (
+    <box
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        height: "100%",
+        flexDirection: "column",
+        backgroundColor: theme.bg,
+        zIndex: 210,
+      }}
+    >
+      <box
+        style={{
+          flexDirection: "row",
+          height: 1,
+          backgroundColor: theme.bgAlt,
+          paddingLeft: 1,
+          paddingRight: 1,
+          alignItems: "center",
+        }}
+      >
+        <text content="⬇ Download DB backup  " fg={theme.brand} style={{ flexShrink: 0 }} />
+        <text content={truncate(site.domain, 40)} fg={theme.text} wrapMode="none" style={{ flexShrink: 1 }} />
+        <box style={{ flexGrow: 1 }} />
+        <text content="read-only export" fg={theme.textFaint} style={{ flexShrink: 0 }} />
+      </box>
+
+      <Centered>{renderBody()}</Centered>
+
+      <StatusBar hints={hints()} showGlobal={false} />
+    </box>
+  )
+
+  function renderBody() {
+    if (dp === "blocked") {
+      return (
+        <Panel title=" Can't back up yet " active>
+          <box style={{ flexDirection: "column", width: 64, paddingTop: 1, paddingBottom: 1 }}>
+            <text content={planResult && !planResult.ok ? planResult.error : "Unavailable."} fg={theme.warn} wrapMode="none" />
+            <box style={{ height: 1 }} />
+            <text content="The backup downloads into the linked working copy's sql/ folder." fg={theme.textDim} wrapMode="none" />
+            <box style={{ height: 1 }} />
+            <text content="Esc to close" fg={theme.textFaint} />
+          </box>
+        </Panel>
+      )
+    }
+
+    if (dp === "confirm") {
+      const plan = planResult && planResult.ok ? planResult.plan : null
+      return (
+        <Panel title=" Download production database " active>
+          <box style={{ flexDirection: "column", width: 66, paddingTop: 1, paddingBottom: 1 }}>
+            <box style={{ flexDirection: "row" }}>
+              <text content="Export " fg={theme.text} />
+              <text content={truncate(site!.domain, 36)} fg={theme.accent} wrapMode="none" />
+              <text content=" on " fg={theme.textDim} />
+              <text content={truncate(server?.name ?? "—", 24)} fg={theme.textDim} wrapMode="none" />
+            </box>
+            <box style={{ height: 1 }} />
+            <text content="from" fg={theme.textFaint} />
+            <text content={`  ${middleTruncate(plan?.docroot ?? "—", 62)}`} fg={theme.textDim} wrapMode="none" />
+            <text content="to" fg={theme.textFaint} />
+            {plan ? <DestPath path={plan.destPath} fileColor={theme.good} width={62} /> : <text content="  —" fg={theme.textDim} />}
+            <box style={{ height: 1 }} />
+            <text content="Exports with wp-cli, gzips it, downloads it, then removes the" fg={theme.textDim} wrapMode="none" />
+            <text content="remote copy. Nothing on production is modified." fg={theme.textDim} wrapMode="none" />
+            <box style={{ height: 1 }} />
+            <text content="Press y / ⏎ to download · Esc to cancel" fg={theme.textFaint} wrapMode="none" />
+          </box>
+        </Panel>
+      )
+    }
+
+    if (dp === "running") {
+      return (
+        <box style={{ flexDirection: "column", alignItems: "center" }}>
+          <box style={{ flexDirection: "row" }}>
+            <Spinner />
+            <text content={`  ${STAGE_LABEL[progress?.stage ?? "export"] ?? "Working…"}`} fg={theme.textDim} />
+          </box>
+          <box style={{ height: 1 }} />
+          <text content="You can press Esc — the download keeps running in the background." fg={theme.textFaint} wrapMode="none" />
+        </box>
+      )
+    }
+
+    if (dp === "done") {
+      return (
+        <Panel title=" Done " active>
+          <box style={{ flexDirection: "column", width: 66, paddingTop: 1, paddingBottom: 1 }}>
+            <box style={{ flexDirection: "row" }}>
+              <text content="✓ Saved " fg={theme.good} />
+              <text content={progress?.bytes != null ? formatBytes(progress.bytes) : ""} fg={theme.text} />
+            </box>
+            <box style={{ height: 1 }} />
+            {progress?.destPath ? <DestPath path={progress.destPath} fileColor={theme.accent} width={62} /> : null}
+            <box style={{ height: 1 }} />
+            <text content="Esc to close" fg={theme.textFaint} />
+          </box>
+        </Panel>
+      )
+    }
+
+    // error
+    return (
+      <Panel title=" Backup failed " active>
+        <box style={{ flexDirection: "column", width: 70, paddingTop: 1, paddingBottom: 1 }}>
+          <text content={`✕ ${progress?.error ?? "Something went wrong."}`} fg={theme.bad} wrapMode="none" />
+          <box style={{ height: 1 }} />
+          <text content="Press r to try again · Esc to close" fg={theme.textFaint} wrapMode="none" />
+        </box>
+      </Panel>
+    )
+  }
+
+  function hints() {
+    switch (dp) {
+      case "confirm":
+        return [
+          { key: "y/⏎", label: "download" },
+          { key: "esc", label: "cancel" },
+        ]
+      case "error":
+        return [
+          { key: "r", label: "retry" },
+          { key: "esc", label: "close" },
+        ]
+      default:
+        return [{ key: "esc", label: "close" }]
+    }
+  }
+}

--- a/src/ui/views/DbSync.tsx
+++ b/src/ui/views/DbSync.tsx
@@ -1,0 +1,219 @@
+// Production → local DB sync overlay.
+//
+// Opened with `p` on a linked WordPress site (Search). Pulls the production
+// database into the local working copy: backs up local first, exports/downloads
+// prod (read-only), imports it, rewrites URLs, and runs an optional post-import
+// hook. DESTRUCTIVE on local — so the confirm screen says so plainly. The work
+// runs in the store (`startDbSync`), so closing the modal (Esc/q) doesn't abandon
+// it; the row keeps a spinner and reopening shows live progress.
+
+import { useState } from "react"
+import { useKeyboard } from "@opentui/react"
+import { theme } from "../../lib/theme.ts"
+import { truncate, middleTruncate } from "../../lib/format.ts"
+import { Panel, Spinner, Centered, DestPath } from "../components.tsx"
+import { StatusBar } from "../StatusBar.tsx"
+import { useStore } from "../store.tsx"
+
+const STAGE_LABEL: Record<string, string> = {
+  "local-backup": "Backing up your local database…",
+  export: "Exporting the production database…",
+  download: "Downloading the dump…",
+  import: "Importing into your local database…",
+  replace: "Rewriting production URLs → local…",
+  hook: "Running the post-import hook…",
+}
+
+export function DbSync() {
+  const { dbSyncSite: site, setDbSyncSite, serverById, planDbSyncFor, dbSyncs, startDbSync, clearDbSync } = useStore()
+
+  const planResult = site ? planDbSyncFor(site) : null
+  const progress = site ? dbSyncs.get(site.id) : undefined
+  const [started, setStarted] = useState(false)
+
+  const dp: "blocked" | "confirm" | "running" | "done" | "error" =
+    planResult && !planResult.ok && !progress
+      ? "blocked"
+      : !started && !progress
+        ? "confirm"
+        : progress?.stage === "done"
+          ? "done"
+          : progress?.stage === "error"
+            ? "error"
+            : "running"
+
+  const close = () => {
+    if (site && (progress?.stage === "done" || progress?.stage === "error")) clearDbSync(site.id)
+    setDbSyncSite(null)
+  }
+
+  useKeyboard((key) => {
+    const name = key.name ?? ""
+    if (name === "escape" || name === "q") return close()
+    if (dp === "confirm") {
+      if (name === "return" || name === "y") {
+        if (site) {
+          startDbSync(site)
+          setStarted(true)
+        }
+      }
+      return
+    }
+    if (dp === "error") {
+      if (name === "r") {
+        if (site) clearDbSync(site.id)
+        setStarted(false)
+      }
+      return
+    }
+  })
+
+  if (!site) return null
+  const server = serverById(site.server_id)
+  const plan = planResult && planResult.ok ? planResult.plan : null
+
+  return (
+    <box
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        height: "100%",
+        flexDirection: "column",
+        backgroundColor: theme.bg,
+        zIndex: 210,
+      }}
+    >
+      <box
+        style={{ flexDirection: "row", height: 1, backgroundColor: theme.bgAlt, paddingLeft: 1, paddingRight: 1, alignItems: "center" }}
+      >
+        <text content="⇣ Pull production → local  " fg={theme.brand} style={{ flexShrink: 0 }} />
+        <text content={truncate(site.domain, 38)} fg={theme.text} wrapMode="none" style={{ flexShrink: 1 }} />
+        <box style={{ flexGrow: 1 }} />
+        <text content="overwrites local DB" fg={theme.warn} style={{ flexShrink: 0 }} />
+      </box>
+
+      <Centered>{renderBody()}</Centered>
+
+      <StatusBar hints={hints()} showGlobal={false} />
+    </box>
+  )
+
+  function renderBody() {
+    if (dp === "blocked") {
+      return (
+        <Panel title=" Can't sync yet " active>
+          <box style={{ flexDirection: "column", width: 66, paddingTop: 1, paddingBottom: 1 }}>
+            <text content={planResult && !planResult.ok ? planResult.error : "Unavailable."} fg={theme.warn} wrapMode="none" />
+            <box style={{ height: 1 }} />
+            <text content="Esc to close" fg={theme.textFaint} />
+          </box>
+        </Panel>
+      )
+    }
+
+    if (dp === "confirm") {
+      return (
+        <Panel title=" Pull production database to local " active>
+          <box style={{ flexDirection: "column", width: 68, paddingTop: 1, paddingBottom: 1 }}>
+            <box style={{ flexDirection: "row" }}>
+              <text content="⚠ " fg={theme.warn} />
+              <text content="This OVERWRITES your local database." fg={theme.text} wrapMode="none" />
+            </box>
+            <text content="  (your local DB is backed up first, just in case)" fg={theme.textFaint} wrapMode="none" />
+            <box style={{ height: 1 }} />
+            <box style={{ flexDirection: "row" }}>
+              <text content="from " fg={theme.textFaint} />
+              <text content={truncate(site!.domain, 30)} fg={theme.accent} wrapMode="none" />
+              <text content=" on " fg={theme.textDim} />
+              <text content={truncate(server?.name ?? "—", 22)} fg={theme.textDim} wrapMode="none" />
+            </box>
+            <text content="into" fg={theme.textFaint} />
+            {plan ? <DestPath path={plan.localRoot} fileColor={theme.good} width={64} /> : null}
+            <box style={{ height: 1 }} />
+            <text content="rewrite URLs" fg={theme.textFaint} />
+            <text content={`  ${plan ? middleTruncate(`${plan.remoteOrigin} → ${plan.localOrigin}`, 64) : "—"}`} fg={theme.textDim} wrapMode="none" />
+            {plan?.hookPath ? (
+              <>
+                <box style={{ height: 1 }} />
+                <text content="↪ will run bin/sync.d/post-import.sh" fg={theme.purple} wrapMode="none" />
+              </>
+            ) : null}
+            {plan?.prefixWarning ? (
+              <>
+                <box style={{ height: 1 }} />
+                <text content={`⚠ ${plan.prefixWarning}`} fg={theme.warn} wrapMode="none" />
+              </>
+            ) : null}
+            <box style={{ height: 1 }} />
+            <text content="Production is only read from — nothing there is modified." fg={theme.textFaint} wrapMode="none" />
+            <text content="Press y / ⏎ to pull · Esc to cancel" fg={theme.textFaint} wrapMode="none" />
+          </box>
+        </Panel>
+      )
+    }
+
+    if (dp === "running") {
+      return (
+        <box style={{ flexDirection: "column", alignItems: "center" }}>
+          <box style={{ flexDirection: "row" }}>
+            <Spinner />
+            <text content={`  ${STAGE_LABEL[progress?.stage ?? "local-backup"] ?? "Working…"}`} fg={theme.textDim} />
+          </box>
+          <box style={{ height: 1 }} />
+          <text content="You can press Esc — it keeps running in the background." fg={theme.textFaint} wrapMode="none" />
+        </box>
+      )
+    }
+
+    if (dp === "done") {
+      return (
+        <Panel title=" Done " active>
+          <box style={{ flexDirection: "column", width: 68, paddingTop: 1, paddingBottom: 1 }}>
+            <box style={{ flexDirection: "row" }}>
+              <text content="✓ " fg={theme.good} />
+              <text content="Local now mirrors production." fg={theme.text} wrapMode="none" />
+              {progress?.ranHook ? <text content="  (hook ran)" fg={theme.textFaint} wrapMode="none" /> : null}
+            </box>
+            <box style={{ height: 1 }} />
+            <text content="prod dump saved" fg={theme.textFaint} />
+            {progress?.downloadPath ? <DestPath path={progress.downloadPath} fileColor={theme.accent} width={64} /> : null}
+            <text content="local DB backup" fg={theme.textFaint} />
+            {progress?.localBackupPath ? <DestPath path={progress.localBackupPath} fileColor={theme.textDim} width={64} /> : null}
+            <box style={{ height: 1 }} />
+            <text content="Esc to close" fg={theme.textFaint} />
+          </box>
+        </Panel>
+      )
+    }
+
+    return (
+      <Panel title=" Sync failed " active>
+        <box style={{ flexDirection: "column", width: 70, paddingTop: 1, paddingBottom: 1 }}>
+          <text content={`✕ ${progress?.error ?? "Something went wrong."}`} fg={theme.bad} wrapMode="none" />
+          <box style={{ height: 1 }} />
+          <text content="Your local DB backup is in sql/ if you need to restore." fg={theme.textFaint} wrapMode="none" />
+          <text content="Press r to try again · Esc to close" fg={theme.textFaint} wrapMode="none" />
+        </box>
+      </Panel>
+    )
+  }
+
+  function hints() {
+    switch (dp) {
+      case "confirm":
+        return [
+          { key: "y/⏎", label: "pull" },
+          { key: "esc", label: "cancel" },
+        ]
+      case "error":
+        return [
+          { key: "r", label: "retry" },
+          { key: "esc", label: "close" },
+        ]
+      default:
+        return [{ key: "esc", label: "close" }]
+    }
+  }
+}

--- a/src/ui/views/Search.tsx
+++ b/src/ui/views/Search.tsx
@@ -9,7 +9,9 @@ import { useKeyboard } from "@opentui/react"
 import { theme, statusColor, statusDot } from "../../lib/theme.ts"
 import { classifyStack, stackColor, stackTag } from "../../lib/stack.ts"
 import { truncate } from "../../lib/format.ts"
-import { Panel, Field, StatusBadge, SiteMetaCell } from "../components.tsx"
+import { Panel, Field, StatusBadge, SiteMetaCell, Spinner } from "../components.tsx"
+import { isDbBackupInFlight } from "../../lib/dbBackup.ts"
+import { isDbSyncInFlight } from "../../lib/dbSync.ts"
 import { List, moveSelection } from "../List.tsx"
 import { ServerDetail, SiteDetail } from "../Details.tsx"
 import { StatusBar } from "../StatusBar.tsx"
@@ -32,7 +34,7 @@ function score(haystack: string, q: string): number | null {
 
 export function Search({ rows }: { rows: number }) {
   const store = useStore()
-  const { servers, sites, serverById, setInputMode, setRoute, route, overlayOpen, setHealthServer, setPhpUpgradeSite, setServerActionsServer, accountSlug, localLinks, setLocalLinkSite, openLocalTerminal, openLocalUrl, sshSite } = store
+  const { servers, sites, serverById, setInputMode, setRoute, route, overlayOpen, setHealthServer, setPhpUpgradeSite, setServerActionsServer, accountSlug, localLinks, setLocalLinkSite, openLocalTerminal, openLocalUrl, sshSite, setDbBackupSite, dbBackups, setDbSyncSite, dbSyncs, localSync } = store
   const [query, setQuery] = useState("")
   const [selected, setSelected] = useState(0)
   // "query" = typing/filtering (input focused); "actions" = input blurred so the
@@ -154,6 +156,25 @@ export function Search({ rows }: { rows: number }) {
       case "s":
         if (current?.kind === "site") flashMsg(sshSite(current.site.id))
         return
+      case "d":
+        // DB backup uses wp-cli on the remote and downloads into the linked copy,
+        // so it needs a WordPress site and a local link.
+        if (current?.kind === "site") {
+          if (!current.site.is_wordpress) flashMsg("Database backup needs WordPress (wp-cli) — this isn't a WP site")
+          else if (!localLinks.has(current.site.id)) flashMsg("Not linked — press L to link a local copy")
+          else setDbBackupSite(current.site)
+        }
+        return
+      case "p":
+        // Pull production → local: opt-in (it overwrites the local DB), and needs
+        // a WordPress site + a local link.
+        if (current?.kind === "site") {
+          if (!localSync) flashMsg('Local sync is off — set "localSync": true in config to enable')
+          else if (!current.site.is_wordpress) flashMsg("Sync needs WordPress (wp-cli) — this isn't a WP site")
+          else if (!localLinks.has(current.site.id)) flashMsg("Not linked — press L to link a local copy")
+          else setDbSyncSite(current.site)
+        }
+        return
       case "h": {
         const srv =
           current?.kind === "server"
@@ -197,10 +218,10 @@ export function Search({ rows }: { rows: number }) {
         : [
             { key: "↑↓", label: "select" },
             { key: "o", label: "open" },
-            { key: "w", label: "SpinupWP" },
-            { key: "u", label: "upgrade PHP" },
+            { key: "s", label: "SSH" },
+            { key: "d", label: "DB backup" },
+            ...(localSync ? [{ key: "p", label: "pull to local" }] : []),
             { key: "a", label: "server actions" },
-            { key: "h", label: "health" },
             { key: "←/esc", label: "back" },
           ]
 
@@ -254,6 +275,30 @@ export function Search({ rows }: { rows: number }) {
                   <text content="SITE" fg={sel ? theme.text : theme.accent} style={{ flexShrink: 0 }} />
                   <text content={" " + statusDot(r.site.status) + " "} fg={statusColor(r.site.status)} style={{ flexShrink: 0 }} />
                   <text content={truncate(r.site.domain, 44)} fg={sel ? theme.text : theme.textDim} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1, marginRight: 1 }} />
+                  {(() => {
+                    // Sync (destructive) takes visual priority over a plain backup.
+                    const sy = dbSyncs.get(r.site.id)
+                    if (sy && isDbSyncInFlight(sy))
+                      return (
+                        <box style={{ flexDirection: "row", flexShrink: 0 }}>
+                          <Spinner color={sel ? theme.text : theme.brand} interval={120} />
+                          <text content="⇣ " fg={sel ? theme.text : theme.warn} wrapMode="none" />
+                        </box>
+                      )
+                    if (sy?.stage === "done") return <text content="⇣✓ " fg={sel ? theme.text : theme.good} wrapMode="none" style={{ flexShrink: 0 }} />
+                    if (sy?.stage === "error") return <text content="⇣! " fg={sel ? theme.text : theme.bad} wrapMode="none" style={{ flexShrink: 0 }} />
+                    const b = dbBackups.get(r.site.id)
+                    if (b && isDbBackupInFlight(b))
+                      return (
+                        <box style={{ flexDirection: "row", flexShrink: 0 }}>
+                          <Spinner color={sel ? theme.text : theme.brand} interval={120} />
+                          <text content="⬇ " fg={sel ? theme.text : theme.warn} wrapMode="none" />
+                        </box>
+                      )
+                    if (b?.stage === "done") return <text content="⬇✓ " fg={sel ? theme.text : theme.good} wrapMode="none" style={{ flexShrink: 0 }} />
+                    if (b?.stage === "error") return <text content="⬇! " fg={sel ? theme.text : theme.bad} wrapMode="none" style={{ flexShrink: 0 }} />
+                    return null
+                  })()}
                   <SiteMetaCell
                     linked={localLinks.has(r.site.id)}
                     updates={(r.site.wp_plugin_updates || 0) + (r.site.wp_theme_updates || 0) + (r.site.wp_core_update ? 1 : 0)}
@@ -273,6 +318,7 @@ export function Search({ rows }: { rows: number }) {
             <ActionsCard
               result={current}
               serverName={current.kind === "site" ? (serverById(current.site.server_id)?.name ?? "—") : current.server.name}
+              localSync={localSync}
             />
           ) : current.kind === "server" ? (
             <ServerDetail server={current.server} siteCount={store.sitesForServer(current.server.id).length} />
@@ -287,30 +333,46 @@ export function Search({ rows }: { rows: number }) {
   )
 }
 
-// Compact action menu shown in the Details pane while in "actions" focus. Lists
-// the keys live for the selected result (a site gets the full suite; a server
-// gets web/health), so the available actions are discoverable, not hidden.
-function ActionsCard({ result, serverName }: { result: Result; serverName: string }) {
+// Site Control panel shown in the Details pane while in "actions" focus. Groups
+// the live single-key actions (Open / Remote / Local / Server) so the suite is
+// discoverable and scales as more actions land. A site gets the full set; a
+// server gets just the open + server actions.
+type ActionGroup = { title: string; items: [string, string][] }
+
+// The DB backup uses wp-cli on the remote, so it only applies to WordPress sites
+// — omitted for non-WP sites (their `d` keypress is also guarded in the handler).
+function siteGroups(isWordpress: boolean, localSync: boolean): ActionGroup[] {
+  const remote: [string, string][] = [["s", "SSH into the site"]]
+  if (isWordpress) {
+    remote.push(["d", "Download DB backup"])
+    if (localSync) remote.push(["p", "Pull production DB to local"])
+  }
+  remote.push(["u", "Upgrade PHP version"])
+  return [
+    { title: "Open", items: [["o", "Open site in browser"], ["w", "Open in SpinupWP"]] },
+    { title: "Remote", items: remote },
+    {
+      title: "Local",
+      items: [
+        ["t", "Open working copy in a terminal"],
+        ["v", "Open the local URL"],
+        ["L", "Link / edit local copy"],
+      ],
+    },
+    { title: "Server", items: [["a", "Server actions (reboot / restart)"], ["h", "Server health"]] },
+  ]
+}
+
+const SERVER_GROUPS: ActionGroup[] = [
+  { title: "Open", items: [["w", "Open in SpinupWP"]] },
+  { title: "Server", items: [["a", "Server actions (reboot / restart)"], ["h", "Server health"]] },
+]
+
+function ActionsCard({ result, serverName, localSync }: { result: Result; serverName: string; localSync: boolean }) {
   const isSite = result.kind === "site"
   const name = isSite ? result.site.domain : result.server.name
   const status = isSite ? result.site.status : result.server.connection_status
-  const actions: [string, string][] = isSite
-    ? [
-        ["o", "Open site in browser"],
-        ["w", "Open in SpinupWP"],
-        ["s", "SSH into the site (opens a terminal)"],
-        ["u", "Upgrade PHP version"],
-        ["t", "Open local working copy in a terminal"],
-        ["v", "Open the local URL in your browser"],
-        ["L", "Link / edit local working copy"],
-        ["a", "Server actions (reboot / restart)"],
-        ["h", "Server health"],
-      ]
-    : [
-        ["w", "Open in SpinupWP"],
-        ["a", "Server actions (reboot / restart)"],
-        ["h", "Server health"],
-      ]
+  const groups = isSite ? siteGroups(result.site.is_wordpress, localSync) : SERVER_GROUPS
   return (
     <box style={{ flexDirection: "column" }}>
       <box style={{ flexDirection: "row" }}>
@@ -335,11 +397,16 @@ function ActionsCard({ result, serverName }: { result: Result; serverName: strin
         </>
       )}
       <box style={{ height: 1 }} />
-      <text content="Actions" fg={theme.accent} />
-      {actions.map(([k, label]) => (
-        <box key={k} style={{ flexDirection: "row" }}>
-          <text content={` ${k} `} fg={theme.bg} bg={theme.brandDim} style={{ flexShrink: 0 }} />
-          <text content={`  ${label}`} fg={theme.text} wrapMode="none" />
+      <text content="Site Control" fg={theme.accent} />
+      {groups.map((group) => (
+        <box key={group.title} style={{ flexDirection: "column" }}>
+          <text content={group.title.toUpperCase()} fg={theme.textFaint} wrapMode="none" />
+          {group.items.map(([k, label]) => (
+            <box key={k} style={{ flexDirection: "row" }}>
+              <text content={` ${k} `} fg={theme.bg} bg={theme.brandDim} style={{ flexShrink: 0 }} />
+              <text content={`  ${label}`} fg={theme.text} wrapMode="none" />
+            </box>
+          ))}
         </box>
       ))}
       <box style={{ height: 1 }} />


### PR DESCRIPTION
**Status: ready for review.** A daily-driver feature: grab a production database
from the dashboard instead of hand-running `ssh` → `wp db export` → `scp`. Opened
in the Unreleased style so anyone following the project can see it before release.
Backup is the stable headline; the destructive **sync** is opt-in and off by
default. Targets the next minor.

## What this is
Two Search-tab actions for a WordPress site you've **linked** to a local copy,
built on the proven `sync-prod-to-local` pattern — export to a stage file
*outside* the public webroot, gzip, `scp` down, clean up. (We deliberately don't
stream `wp db export -`: plugins print to stdout during WP bootstrap, e.g. GiveWP
deprecation notices, which would corrupt the dump.)

## Highlights
- **Download a backup (`d`).** Exports the production DB with `wp-cli`, gzips it,
  downloads it into the linked copy's `sql/` folder, and removes the remote copy.
  **Read-only on production** and needs **no local WP-CLI** — the export runs on
  the server. Always available for a WordPress + linked site. A row spinner tracks
  an in-flight download even after the overlay is closed; the saved path + size
  show on completion.
- **Pull production → local (`p`, opt-in).** Refreshes your **local** DB from
  production: backs up local first (`sql/local_<ts>.sql.gz`), exports + downloads
  prod, imports it, rewrites prod URLs → local URL (`wp search-replace`), and runs
  an existing `bin/sync.d/post-import.sh` hook if present (with `WEB_DIR` /
  `SYNC_REMOTE_HOST` / `SYNC_LOCAL_HOST` set, so per-project tweaks carry over).
  **Overwrites the local DB**, so it's **off by default** — enable with `localSync`.
- **Site Control panel.** The Search action menu is regrouped (Open / Remote /
  Local / Server) so the growing per-site action set stays scannable.

## "Just works" detection (Standard WP **and** Bedrock)
No per-site config — derived from the API + the link + the project on disk:
- remote document root → `/sites/{domain}/files{public_folder}` (API)
- SSH target → `{site_user}@{server_ip}` (API); `ssh`/`scp` run non-interactively (BatchMode)
- local WP root → the linked path (wp-config for Standard WP, `wp-cli.yml` for Bedrock)
- local URL for the rewrite → the link's local URL, falling back to `.env` `WP_HOME`
- table-prefix mismatch (API vs local `.env`/wp-config) is surfaced as a warning

## Safety / scope
- Production is **only read from** in both actions.
- Sync is gated three ways: **WordPress** site (uses `wp-cli`), **linked** to a
  local copy (the destination), and the **`localSync`** opt-in for the destructive
  pull. It backs up the local DB before importing, and checks for local `wp-cli`
  up front (clear error, not a broken run).
- `localSync` is read from `config.json` (preferred) or `SPINUPWP_LOCAL_SYNC`.
  Documented: a project/repo `.env` only reaches the app when launched from that
  directory (Bun loads `.env` from CWD), so `config.json` is the location-
  independent home for the installed `spinup`.

## Testing
- [x] `d` backup verified live on a Standard WP site and a Bedrock site.
- [x] `p` sync verified live end-to-end on a Bedrock site (local backup → export →
      download → import → search-replace).
- [x] Plan detection verified against real Standard WP + Bedrock projects.
- [x] `localSync` defaults off (`p` hidden); enabling via config.json shows it.
- [x] `typecheck` green.

## Not in this PR (follow-ups)
- Optional uploads/media sync (currently DB-only, matching the reference script).
- A potential in-app toggle for `localSync` (config.json/env only for now).

Changelog staged under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sj1EwTVWHwYKBfogZKFct