### PR TITLE
Stacked progress readout + post-import hook scaffolding (v0.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-06-23
+
+### Added
+- **Scaffold a post-import hook from the sync screen.** When you press `p` on a
+  linked site that has no `bin/sync.d/post-import.sh`, the confirm screen now
+  explains what the hook is (it runs after the import + URL rewrite) and offers
+  `s` to write an **inert** sample for you — a documented `post-import.sh` with
+  the `WEB_DIR` / `SYNC_REMOTE_HOST` / `SYNC_LOCAL_HOST` env contract and common
+  examples (Elementor URL swaps, plugin toggles), all commented out so nothing
+  runs until you uncomment it. It never overwrites an existing hook.
+
+### Changed
+- **Backup (`d`) and sync (`p`) now show progress as a building checklist.** Each
+  step (back up local, export, download, import, rewrite URLs, run hook) is listed
+  in one bordered panel and gets a `✓` as it finishes, the running step spins, and
+  the final result (saved paths, size) appears below the completed stack — so the
+  whole operation, including the "done" summary, reads in a single frame. A
+  failure marks the exact step that broke with `✕` and shows the error inline.
+
 ## [0.7.0] - 2026-06-22
 
 ### Added
@@ -263,7 +282,8 @@ Initial tagged release.
 ### Notes
 - Read-only release: works with a SpinupWP **Read Only** API token.
 
-[Unreleased]: https://github.com/mwender/spinupwp-tui/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/mwender/spinupwp-tui/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/mwender/spinupwp-tui/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/mwender/spinupwp-tui/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/mwender/spinupwp-tui/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/mwender/spinupwp-tui/compare/v0.4.0...v0.5.0

--- a/README.md
+++ b/README.md
@@ -354,8 +354,17 @@ Everything is detected automatically, for Standard WP **and** Bedrock:
 If your project already has a `bin/sync.d/post-import.sh` (e.g. Elementor URL
 swaps, plugin toggles), it runs with `WEB_DIR`, `SYNC_REMOTE_HOST`, and
 `SYNC_LOCAL_HOST` set — so existing per-project tweaks carry over with no extra
-configuration. Backups stay **gzipped** in `sql/`; decompress with `gunzip` when
-you need one.
+configuration. When a project has **no** hook yet, the `p` confirm screen
+explains what the hook is and offers `s` to scaffold an **inert** sample
+`bin/sync.d/post-import.sh` (every example commented out, documented with the env
+vars above) for you to edit. Backups stay **gzipped** in `sql/`; decompress with
+`gunzip` when you need one.
+
+Both `d` and `p` show their progress as a **building checklist** inside the
+overlay — each step gets a `✓` as it completes, the running step spins, and a
+failure marks the exact step with `✕` — so you can see everything that happened,
+ending with the saved paths. It keeps running if you close the overlay (`Esc`);
+reopen with the same key to watch it through.
 
 ## DNS hosts, access & editing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spinupwp-tui",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A cool terminal UI for browsing and monitoring your SpinupWP servers and sites.",
   "type": "module",
   "bin": {

--- a/src/lib/dbBackup.ts
+++ b/src/lib/dbBackup.ts
@@ -97,6 +97,7 @@ export interface DbBackupProgress {
   destPath?: string
   bytes?: number
   error?: string
+  failedStage?: DbBackupStage // which step broke, so the UI can mark it ✕
 }
 
 export function isDbBackupInFlight(p: DbBackupProgress | undefined): boolean {
@@ -149,8 +150,8 @@ export async function runDbBackup(
   onProgress: (p: DbBackupProgress) => void,
 ): Promise<DbBackupProgress> {
   const target = `${plan.user}@${plan.host}`
-  const fail = (error: string): DbBackupProgress => {
-    const p: DbBackupProgress = { stage: "error", domain, error }
+  const fail = (error: string, failedStage: DbBackupStage): DbBackupProgress => {
+    const p: DbBackupProgress = { stage: "error", domain, error, failedStage }
     onProgress(p)
     return p
   }
@@ -165,7 +166,7 @@ export async function runDbBackup(
     `wp db export "$HOME/${sql}" --single-transaction >/dev/null; ` +
     `gzip -f "$HOME/${sql}"`
   const exp = await runProcess(["ssh", ...SSH_OPTS, ...sshPort(plan.port), target, remoteScript], 300_000)
-  if (exp.code !== 0) return fail(`Remote export failed — ${meaningfulError(exp.stderr, `ssh exit ${exp.code}.`)}`)
+  if (exp.code !== 0) return fail(`Remote export failed — ${meaningfulError(exp.stderr, `ssh exit ${exp.code}.`)}`, "export")
 
   // 2) Download the gzip into the project's sql/ dir.
   onProgress({ stage: "download", domain })
@@ -178,7 +179,7 @@ export async function runDbBackup(
   if (dl.code !== 0) {
     // Still try to remove the remote stage file so it doesn't linger.
     void runProcess(["ssh", ...SSH_OPTS, ...sshPort(plan.port), target, `rm -f "$HOME/${plan.remoteGz}"`], 30_000)
-    return fail(`Download failed — ${meaningfulError(dl.stderr, `scp exit ${dl.code}.`)}`)
+    return fail(`Download failed — ${meaningfulError(dl.stderr, `scp exit ${dl.code}.`)}`, "download")
   }
 
   // 3) Remove the remote stage file.

--- a/src/lib/dbSync.ts
+++ b/src/lib/dbSync.ts
@@ -12,8 +12,8 @@
 // SYNC_REMOTE_HOST / SYNC_LOCAL_HOST env contract as the sync-prod-to-local
 // script, so per-project tweaks (Elementor URL swaps, plugin toggles) carry over.
 
-import { existsSync, mkdirSync, readFileSync } from "node:fs"
-import { join } from "node:path"
+import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from "node:fs"
+import { join, dirname } from "node:path"
 import type { Server, Site } from "../api/types.ts"
 import { expandPath, findProjectRoot, type LocalLink } from "./local.ts"
 import { remoteDocRoot, backupBaseName, SSH_OPTS, sshPort, scpPort, runProcess, meaningfulError } from "./dbBackup.ts"
@@ -42,6 +42,45 @@ function readWpConfigPrefix(configPath: string): string | null {
 // Bare host of a URL (drops scheme, path, trailing slash).
 function hostOf(url: string): string {
   return url.replace(/^[a-z]+:\/\//i, "").replace(/\/.*$/, "").trim()
+}
+
+// An INERT starter post-import hook. Every real command is commented out and the
+// only live line is an echo, so scaffolding-then-pulling can't surprise anyone —
+// the user uncomments what they want deliberately. The comments document the env
+// contract (WEB_DIR / SYNC_REMOTE_HOST / SYNC_LOCAL_HOST, see runDbSync) and the
+// real-world tweaks (Elementor URL swaps, plugin toggles) the hook exists for.
+const SAMPLE_HOOK = `#!/usr/bin/env bash
+set -euo pipefail
+# Runs after Spinup pulls production → local (DB imported, URLs rewritten).
+# Spinup exports these for you:
+#   WEB_DIR           local project root (this script starts here)
+#   SYNC_REMOTE_HOST  production host, e.g. example.com
+#   SYNC_LOCAL_HOST   local host,      e.g. example.test
+cd "$WEB_DIR"
+
+# --- Examples — uncomment what your project needs ----------------------
+# Elementor stores absolute URLs in serialized data; rewrite + reflush:
+# wp elementor replace_urls "https://$SYNC_REMOTE_HOST" "https://$SYNC_LOCAL_HOST"
+# wp elementor flush_css
+#
+# Turn off prod-only plugins locally (keep non-fatal with || true):
+# wp plugin deactivate spinupwp limit-login-attempts-reloaded || true
+# wp plugin activate localdev-switcher || true
+# -----------------------------------------------------------------------
+
+echo "post-import hook ran (nothing to do yet — edit bin/sync.d/post-import.sh)"
+`
+
+// Scaffold the inert sample hook at <localRoot>/bin/sync.d/post-import.sh and
+// mark it executable. Returns the absolute path. Never overwrites an existing
+// file (callers only offer this when no hook is present). Throws on write error.
+export function writeSampleHook(localRoot: string): string {
+  const path = join(localRoot, "bin", "sync.d", "post-import.sh")
+  if (existsSync(path)) return path
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, SAMPLE_HOOK)
+  chmodSync(path, 0o755)
+  return path
 }
 
 export interface DbSyncPlan {
@@ -135,6 +174,7 @@ export interface DbSyncProgress {
   localBackupPath?: string
   ranHook?: boolean
   error?: string
+  failedStage?: DbSyncStage // which step broke, so the UI can mark it ✕
 }
 
 export function isDbSyncInFlight(p: DbSyncProgress | undefined): boolean {
@@ -145,19 +185,20 @@ export function isDbSyncInFlight(p: DbSyncProgress | undefined): boolean {
 // (done | error). Never throws. Read-only on production; destructive on local.
 export async function runDbSync(plan: DbSyncPlan, domain: string, onProgress: (p: DbSyncProgress) => void): Promise<DbSyncProgress> {
   const target = `${plan.user}@${plan.host}`
-  const fail = (error: string): DbSyncProgress => {
-    const p: DbSyncProgress = { stage: "error", domain, error }
+  const fail = (error: string, failedStage: DbSyncStage = "local-backup"): DbSyncProgress => {
+    const p: DbSyncProgress = { stage: "error", domain, error, failedStage }
     onProgress(p)
     return p
   }
   // Prefix the surfaced error with the failing stage so it's self-locating
   // (e.g. "Local DB backup failed — mysqldump: …" rather than a bare driver line).
-  const stageFail = (label: string, stderr: string, fallback: string) => fail(`${label} — ${meaningfulError(stderr, fallback)}`)
+  const stageFail = (label: string, stderr: string, fallback: string, failedStage: DbSyncStage) =>
+    fail(`${label} — ${meaningfulError(stderr, fallback)}`, failedStage)
   // Run local `wp` through a login shell so the user's PATH (composer/phar) resolves.
   const wp = (cmd: string, timeoutMs: number, env?: Record<string, string>) => runProcess(["bash", "-lc", cmd], timeoutMs, plan.localRoot, env)
 
   // 0) wp-cli must exist locally — fail with a clear message rather than cryptically.
-  if ((await wp("command -v wp", 15_000)).code !== 0) return fail("WP-CLI not found locally — install wp-cli to sync.")
+  if ((await wp("command -v wp", 15_000)).code !== 0) return fail("WP-CLI not found locally — install wp-cli to sync.", "local-backup")
 
   // 1) Safety: back up the LOCAL DB before we overwrite it (file, then gzip).
   onProgress({ stage: "local-backup", domain })
@@ -168,7 +209,7 @@ export async function runDbSync(plan: DbSyncPlan, domain: string, onProgress: (p
   }
   const localSql = plan.localBackupPath.replace(/\.gz$/, "")
   const lb = await wp(`wp db export "${localSql}" >/dev/null && gzip -f "${localSql}"`, 300_000)
-  if (lb.code !== 0) return stageFail("Local DB backup failed", lb.stderr, "couldn't export the local database.")
+  if (lb.code !== 0) return stageFail("Local DB backup failed", lb.stderr, "couldn't export the local database.", "local-backup")
 
   // 2) Export prod + download the gzip (same remote pipeline as the backup).
   onProgress({ stage: "export", domain })
@@ -176,25 +217,25 @@ export async function runDbSync(plan: DbSyncPlan, domain: string, onProgress: (p
   const remoteScript =
     `set -e; cd '${plan.docroot}'; wp db export "$HOME/${sql}" --single-transaction >/dev/null; gzip -f "$HOME/${sql}"`
   const exp = await runProcess(["ssh", ...SSH_OPTS, ...sshPort(plan.port), target, remoteScript], 300_000)
-  if (exp.code !== 0) return stageFail("Remote export failed", exp.stderr, `ssh exit ${exp.code}.`)
+  if (exp.code !== 0) return stageFail("Remote export failed", exp.stderr, `ssh exit ${exp.code}.`, "export")
 
   onProgress({ stage: "download", domain })
   const dl = await runProcess(["scp", ...SSH_OPTS, ...scpPort(plan.port), `${target}:${plan.remoteGz}`, plan.downloadPath], 300_000)
   if (dl.code !== 0) {
     void runProcess(["ssh", ...SSH_OPTS, ...sshPort(plan.port), target, `rm -f "$HOME/${plan.remoteGz}"`], 30_000)
-    return stageFail("Download failed", dl.stderr, `scp exit ${dl.code}.`)
+    return stageFail("Download failed", dl.stderr, `scp exit ${dl.code}.`, "download")
   }
   void runProcess(["ssh", ...SSH_OPTS, ...sshPort(plan.port), target, `rm -f "$HOME/${plan.remoteGz}"`], 30_000)
 
   // 3) Import into local: stream gunzip → wp db cli (no temp extract).
   onProgress({ stage: "import", domain })
   const imp = await wp(`gunzip -c "${plan.downloadPath}" | wp db cli`, 600_000)
-  if (imp.code !== 0) return stageFail("Local import failed", imp.stderr, "wp db cli error.")
+  if (imp.code !== 0) return stageFail("Local import failed", imp.stderr, "wp db cli error.", "import")
 
   // 4) Rewrite production URLs → local URLs.
   onProgress({ stage: "replace", domain })
   const sr = await wp(`wp search-replace "${plan.remoteOrigin}" "${plan.localOrigin}" --skip-columns=guid --format=count`, 300_000)
-  if (sr.code !== 0) return stageFail("URL search-replace failed", sr.stderr, "wp search-replace error.")
+  if (sr.code !== 0) return stageFail("URL search-replace failed", sr.stderr, "wp search-replace error.", "replace")
 
   // 5) Optional per-project post-import hook (Elementor swaps, plugin toggles, …).
   let ranHook = false
@@ -202,7 +243,7 @@ export async function runDbSync(plan: DbSyncPlan, domain: string, onProgress: (p
     onProgress({ stage: "hook", domain })
     const env = { ...process.env, WEB_DIR: plan.localRoot, SYNC_REMOTE_HOST: plan.remoteHost, SYNC_LOCAL_HOST: plan.localHost } as Record<string, string>
     const hk = await runProcess(["bash", plan.hookPath], 300_000, plan.localRoot, env)
-    if (hk.code !== 0) return stageFail("Post-import hook failed", hk.stderr, "hook script error.")
+    if (hk.code !== 0) return stageFail("Post-import hook failed", hk.stderr, "hook script error.", "hook")
     ranHook = true
   }
 

--- a/src/ui/components.tsx
+++ b/src/ui/components.tsx
@@ -40,6 +40,33 @@ export function Spinner({ color = theme.brand, interval = 80 }: { color?: string
   return <text content={SPINNER_FRAMES[frame]} fg={color} />
 }
 
+// A vertical checklist of stages that fills in as work progresses: completed
+// rows get a green ✓, the in-flight row spins, not-yet-reached rows are faint
+// ○, and a failed row gets a red ✕. Used by the DB backup/sync overlays so the
+// whole operation reads as one building stack rather than a swapping spinner.
+export type StepState = "done" | "active" | "pending" | "failed"
+export interface StepRow {
+  label: string
+  state: StepState
+}
+
+export function Steps({ rows }: { rows: StepRow[] }) {
+  return (
+    <box style={{ flexDirection: "column" }}>
+      {rows.map((r, i) => (
+        <box key={i} style={{ flexDirection: "row", height: 1 }}>
+          {r.state === "active" ? (
+            <Spinner color={theme.brand} />
+          ) : (
+            <text content={r.state === "done" ? "✓" : r.state === "failed" ? "✕" : "○"} fg={r.state === "done" ? theme.good : r.state === "failed" ? theme.bad : theme.textFaint} />
+          )}
+          <text content={` ${r.label}`} fg={r.state === "pending" ? theme.textFaint : theme.text} wrapMode="none" />
+        </box>
+      ))}
+    </box>
+  )
+}
+
 // A bordered panel with a consistent title style. `active` highlights the border.
 export function Panel({
   title,

--- a/src/ui/views/DbBackup.tsx
+++ b/src/ui/views/DbBackup.tsx
@@ -12,15 +12,17 @@ import { useState } from "react"
 import { useKeyboard } from "@opentui/react"
 import { theme } from "../../lib/theme.ts"
 import { truncate, formatBytes, middleTruncate } from "../../lib/format.ts"
-import { Panel, Spinner, Centered, DestPath } from "../components.tsx"
+import { Panel, Centered, DestPath, Steps, type StepRow } from "../components.tsx"
 import { StatusBar } from "../StatusBar.tsx"
 import { useStore } from "../store.tsx"
+import type { DbBackupStage } from "../../lib/dbBackup.ts"
 
-const STAGE_LABEL: Record<string, string> = {
-  export: "Exporting the database on the server…",
-  download: "Downloading the backup…",
-  cleanup: "Cleaning up the remote copy…",
-}
+// The backup's stages in run order — rendered as a building checklist.
+const BACKUP_STEPS: { stage: DbBackupStage; label: string }[] = [
+  { stage: "export", label: "Export database on server" },
+  { stage: "download", label: "Download the backup" },
+  { stage: "cleanup", label: "Clean up remote copy" },
+]
 
 export function DbBackup() {
   const { dbBackupSite: site, setDbBackupSite, serverById, planDbBackupFor, dbBackups, startDbBackup, clearDbBackup } = useStore()
@@ -154,43 +156,54 @@ export function DbBackup() {
       )
     }
 
-    if (dp === "running") {
-      return (
-        <box style={{ flexDirection: "column", alignItems: "center" }}>
-          <box style={{ flexDirection: "row" }}>
-            <Spinner />
-            <text content={`  ${STAGE_LABEL[progress?.stage ?? "export"] ?? "Working…"}`} fg={theme.textDim} />
-          </box>
-          <box style={{ height: 1 }} />
-          <text content="You can press Esc — the download keeps running in the background." fg={theme.textFaint} wrapMode="none" />
-        </box>
-      )
-    }
+    // running | done | error share one bordered checklist so the whole backup
+    // reads as a building stack; the footer carries the live/result/error status.
+    const order = BACKUP_STEPS.map((s) => s.stage)
+    const curIdx = order.indexOf((progress?.stage ?? "export") as DbBackupStage)
+    const failedIdx = progress?.failedStage ? order.indexOf(progress.failedStage) : order.length - 1
+    const rows: StepRow[] = BACKUP_STEPS.map(({ label }, i) => {
+      const state: StepRow["state"] =
+        dp === "done"
+          ? "done"
+          : dp === "error"
+            ? i < failedIdx
+              ? "done"
+              : i === failedIdx
+                ? "failed"
+                : "pending"
+            : i < curIdx
+              ? "done"
+              : i === curIdx
+                ? "active"
+                : "pending"
+      return { label, state }
+    })
 
-    if (dp === "done") {
-      return (
-        <Panel title=" Done " active>
-          <box style={{ flexDirection: "column", width: 66, paddingTop: 1, paddingBottom: 1 }}>
-            <box style={{ flexDirection: "row" }}>
-              <text content="✓ Saved " fg={theme.good} />
-              <text content={progress?.bytes != null ? formatBytes(progress.bytes) : ""} fg={theme.text} />
-            </box>
-            <box style={{ height: 1 }} />
-            {progress?.destPath ? <DestPath path={progress.destPath} fileColor={theme.accent} width={62} /> : null}
-            <box style={{ height: 1 }} />
-            <text content="Esc to close" fg={theme.textFaint} />
-          </box>
-        </Panel>
-      )
-    }
-
-    // error
     return (
-      <Panel title=" Backup failed " active>
-        <box style={{ flexDirection: "column", width: 70, paddingTop: 1, paddingBottom: 1 }}>
-          <text content={`✕ ${progress?.error ?? "Something went wrong."}`} fg={theme.bad} wrapMode="none" />
+      <Panel title=" Download production database " active>
+        <box style={{ flexDirection: "column", width: 64, paddingTop: 1, paddingBottom: 1 }}>
+          <Steps rows={rows} />
           <box style={{ height: 1 }} />
-          <text content="Press r to try again · Esc to close" fg={theme.textFaint} wrapMode="none" />
+          {dp === "done" ? (
+            <>
+              <box style={{ flexDirection: "row" }}>
+                <text content="✓ Done — saved " fg={theme.good} />
+                <text content={progress?.bytes != null ? formatBytes(progress.bytes) : ""} fg={theme.text} />
+              </box>
+              <box style={{ height: 1 }} />
+              {progress?.destPath ? <DestPath path={progress.destPath} fileColor={theme.accent} width={62} /> : null}
+              <box style={{ height: 1 }} />
+              <text content="Esc to close" fg={theme.textFaint} />
+            </>
+          ) : dp === "error" ? (
+            <>
+              <text content={`✕ ${progress?.error ?? "Something went wrong."}`} fg={theme.bad} />
+              <box style={{ height: 1 }} />
+              <text content="Press r to try again · Esc to close" fg={theme.textFaint} wrapMode="none" />
+            </>
+          ) : (
+            <text content="You can press Esc — the download keeps running in the background." fg={theme.textFaint} wrapMode="none" />
+          )}
         </box>
       </Panel>
     )

--- a/src/ui/views/DbSync.tsx
+++ b/src/ui/views/DbSync.tsx
@@ -11,18 +11,21 @@ import { useState } from "react"
 import { useKeyboard } from "@opentui/react"
 import { theme } from "../../lib/theme.ts"
 import { truncate, middleTruncate } from "../../lib/format.ts"
-import { Panel, Spinner, Centered, DestPath } from "../components.tsx"
+import { Panel, Centered, DestPath, Steps, type StepRow } from "../components.tsx"
 import { StatusBar } from "../StatusBar.tsx"
 import { useStore } from "../store.tsx"
+import { writeSampleHook, type DbSyncStage } from "../../lib/dbSync.ts"
 
-const STAGE_LABEL: Record<string, string> = {
-  "local-backup": "Backing up your local database…",
-  export: "Exporting the production database…",
-  download: "Downloading the dump…",
-  import: "Importing into your local database…",
-  replace: "Rewriting production URLs → local…",
-  hook: "Running the post-import hook…",
-}
+// The pull's stages in run order — rendered as a building checklist. The hook
+// row is included only when the plan found a bin/sync.d/post-import.sh.
+const SYNC_STEPS: { stage: DbSyncStage; label: string }[] = [
+  { stage: "local-backup", label: "Back up local database" },
+  { stage: "export", label: "Export production database" },
+  { stage: "download", label: "Download the dump" },
+  { stage: "import", label: "Import into local" },
+  { stage: "replace", label: "Rewrite production URLs → local" },
+  { stage: "hook", label: "Run post-import hook" },
+]
 
 export function DbSync() {
   const { dbSyncSite: site, setDbSyncSite, serverById, planDbSyncFor, dbSyncs, startDbSync, clearDbSync } = useStore()
@@ -30,6 +33,8 @@ export function DbSync() {
   const planResult = site ? planDbSyncFor(site) : null
   const progress = site ? dbSyncs.get(site.id) : undefined
   const [started, setStarted] = useState(false)
+  // Result of scaffolding a sample post-import hook (s on the confirm screen).
+  const [scaffold, setScaffold] = useState<{ ok: true; path: string } | { ok: false; error: string } | null>(null)
 
   const dp: "blocked" | "confirm" | "running" | "done" | "error" =
     planResult && !planResult.ok && !progress
@@ -55,6 +60,15 @@ export function DbSync() {
         if (site) {
           startDbSync(site)
           setStarted(true)
+        }
+        return
+      }
+      // s: scaffold a sample hook — only when none exists yet.
+      if (name === "s" && plan && !plan.hookPath) {
+        try {
+          setScaffold({ ok: true, path: writeSampleHook(plan.localRoot) })
+        } catch (e) {
+          setScaffold({ ok: false, error: e instanceof Error ? e.message : "Couldn't write the sample hook." })
         }
       }
       return
@@ -100,6 +114,50 @@ export function DbSync() {
     </box>
   )
 
+  // The post-import-hook line(s) on the confirm screen. Three states: a fresh
+  // scaffold result (wins, so the user sees their action land), an existing hook
+  // (it'll run), or none — in which case we explain the extension point in
+  // context and offer `s` to write an inert sample.
+  function renderHookSection() {
+    if (scaffold?.ok) {
+      return (
+        <>
+          <box style={{ height: 1 }} />
+          <box style={{ flexDirection: "row" }}>
+            <text content="✓ " fg={theme.good} />
+            <text content="wrote bin/sync.d/post-import.sh — edit it, then pull." fg={theme.text} wrapMode="none" />
+          </box>
+          <text content="  (it's inert until you uncomment a command)" fg={theme.textFaint} wrapMode="none" />
+        </>
+      )
+    }
+    if (scaffold && !scaffold.ok) {
+      return (
+        <>
+          <box style={{ height: 1 }} />
+          <text content={`✕ ${scaffold.error}`} fg={theme.bad} wrapMode="none" />
+        </>
+      )
+    }
+    if (plan?.hookPath) {
+      return (
+        <>
+          <box style={{ height: 1 }} />
+          <text content="↪ post-import hook will run (your per-project tweaks)" fg={theme.purple} wrapMode="none" />
+        </>
+      )
+    }
+    return (
+      <>
+        <box style={{ height: 1 }} />
+        <text content="No post-import hook set up for this project." fg={theme.textFaint} wrapMode="none" />
+        <text content="Spinup can run bin/sync.d/post-import.sh after each pull —" fg={theme.textFaint} wrapMode="none" />
+        <text content="e.g. swap Elementor URLs, toggle dev-only plugins." fg={theme.textFaint} wrapMode="none" />
+        <text content="  s  write a sample hook" fg={theme.textDim} wrapMode="none" />
+      </>
+    )
+  }
+
   function renderBody() {
     if (dp === "blocked") {
       return (
@@ -134,12 +192,7 @@ export function DbSync() {
             <box style={{ height: 1 }} />
             <text content="rewrite URLs" fg={theme.textFaint} />
             <text content={`  ${plan ? middleTruncate(`${plan.remoteOrigin} → ${plan.localOrigin}`, 64) : "—"}`} fg={theme.textDim} wrapMode="none" />
-            {plan?.hookPath ? (
-              <>
-                <box style={{ height: 1 }} />
-                <text content="↪ will run bin/sync.d/post-import.sh" fg={theme.purple} wrapMode="none" />
-              </>
-            ) : null}
+            {renderHookSection()}
             {plan?.prefixWarning ? (
               <>
                 <box style={{ height: 1 }} />
@@ -154,47 +207,59 @@ export function DbSync() {
       )
     }
 
-    if (dp === "running") {
-      return (
-        <box style={{ flexDirection: "column", alignItems: "center" }}>
-          <box style={{ flexDirection: "row" }}>
-            <Spinner />
-            <text content={`  ${STAGE_LABEL[progress?.stage ?? "local-backup"] ?? "Working…"}`} fg={theme.textDim} />
-          </box>
-          <box style={{ height: 1 }} />
-          <text content="You can press Esc — it keeps running in the background." fg={theme.textFaint} wrapMode="none" />
-        </box>
-      )
-    }
-
-    if (dp === "done") {
-      return (
-        <Panel title=" Done " active>
-          <box style={{ flexDirection: "column", width: 68, paddingTop: 1, paddingBottom: 1 }}>
-            <box style={{ flexDirection: "row" }}>
-              <text content="✓ " fg={theme.good} />
-              <text content="Local now mirrors production." fg={theme.text} wrapMode="none" />
-              {progress?.ranHook ? <text content="  (hook ran)" fg={theme.textFaint} wrapMode="none" /> : null}
-            </box>
-            <box style={{ height: 1 }} />
-            <text content="prod dump saved" fg={theme.textFaint} />
-            {progress?.downloadPath ? <DestPath path={progress.downloadPath} fileColor={theme.accent} width={64} /> : null}
-            <text content="local DB backup" fg={theme.textFaint} />
-            {progress?.localBackupPath ? <DestPath path={progress.localBackupPath} fileColor={theme.textDim} width={64} /> : null}
-            <box style={{ height: 1 }} />
-            <text content="Esc to close" fg={theme.textFaint} />
-          </box>
-        </Panel>
-      )
-    }
+    // running | done | error share one bordered checklist so the whole pull
+    // reads as a building stack; the footer carries the live/result/error status.
+    const steps = SYNC_STEPS.filter((s) => s.stage !== "hook" || !!plan?.hookPath)
+    const order = steps.map((s) => s.stage)
+    const curIdx = order.indexOf((progress?.stage ?? "local-backup") as DbSyncStage)
+    const failedIdx = progress?.failedStage ? order.indexOf(progress.failedStage) : order.length - 1
+    const rows: StepRow[] = steps.map(({ label }, i) => {
+      const state: StepRow["state"] =
+        dp === "done"
+          ? "done"
+          : dp === "error"
+            ? i < failedIdx
+              ? "done"
+              : i === failedIdx
+                ? "failed"
+                : "pending"
+            : i < curIdx
+              ? "done"
+              : i === curIdx
+                ? "active"
+                : "pending"
+      return { label, state }
+    })
 
     return (
-      <Panel title=" Sync failed " active>
-        <box style={{ flexDirection: "column", width: 70, paddingTop: 1, paddingBottom: 1 }}>
-          <text content={`✕ ${progress?.error ?? "Something went wrong."}`} fg={theme.bad} wrapMode="none" />
+      <Panel title=" Pull production → local " active>
+        <box style={{ flexDirection: "column", width: 64, paddingTop: 1, paddingBottom: 1 }}>
+          <Steps rows={rows} />
           <box style={{ height: 1 }} />
-          <text content="Your local DB backup is in sql/ if you need to restore." fg={theme.textFaint} wrapMode="none" />
-          <text content="Press r to try again · Esc to close" fg={theme.textFaint} wrapMode="none" />
+          {dp === "done" ? (
+            <>
+              <box style={{ flexDirection: "row" }}>
+                <text content="✓ " fg={theme.good} />
+                <text content="Done — local now mirrors production." fg={theme.text} wrapMode="none" />
+              </box>
+              <box style={{ height: 1 }} />
+              <text content="prod dump saved" fg={theme.textFaint} />
+              {progress?.downloadPath ? <DestPath path={progress.downloadPath} fileColor={theme.accent} width={62} /> : null}
+              <text content="local DB backup" fg={theme.textFaint} />
+              {progress?.localBackupPath ? <DestPath path={progress.localBackupPath} fileColor={theme.textDim} width={62} /> : null}
+              <box style={{ height: 1 }} />
+              <text content="Esc to close" fg={theme.textFaint} />
+            </>
+          ) : dp === "error" ? (
+            <>
+              <text content={`✕ ${progress?.error ?? "Something went wrong."}`} fg={theme.bad} />
+              <box style={{ height: 1 }} />
+              <text content="Your local DB backup is in sql/ if you need to restore." fg={theme.textFaint} wrapMode="none" />
+              <text content="Press r to try again · Esc to close" fg={theme.textFaint} wrapMode="none" />
+            </>
+          ) : (
+            <text content="You can press Esc — it keeps running in the background." fg={theme.textFaint} wrapMode="none" />
+          )}
         </box>
       </Panel>
     )
@@ -205,6 +270,7 @@ export function DbSync() {
       case "confirm":
         return [
           { key: "y/⏎", label: "pull" },
+          ...(plan && !plan.hookPath ? [{ key: "s", label: "sample hook" }] : []),
           { key: "esc", label: "cancel" },
         ]
       case "error":


### PR DESCRIPTION
Polish on the DB backup (`d`) and prod→local sync (`p`) overlays, cut as **v0.7.1**.

## What changed

**Stacked progress readout.** Both `d` and `p` now render their stages as one building checklist inside a bordered panel — each stage gets a `✓` as it finishes, the running stage spins, and the result summary (saved paths / size) appears below the completed stack. This unifies the old separate "running" spinner and "Done" panel into a single frame that never swaps out, so you can see everything that happened end to end. A failure marks the **exact** stage that broke with `✕` and shows the error inline (threaded through a new `failedStage` field on both progress types). New shared `Steps` component.

**Post-import hook help + scaffolding.** When you press `p` on a linked site with no `bin/sync.d/post-import.sh`, the confirm screen now explains what the hook is and offers `s` to write an **inert** sample for you — documented with the `WEB_DIR` / `SYNC_REMOTE_HOST` / `SYNC_LOCAL_HOST` env contract and common examples (Elementor URL swaps, plugin toggles), all commented out so nothing runs until you uncomment it. It never overwrites an existing hook.

## Testing

- `bun run typecheck` green.
- Scaffolder verified in isolation: writes `0755`, runs inert (only an echo), idempotent / no-overwrite.
- Live-tested both overlays against a real linked WordPress site: the checklist builds through to completion, the result summary renders, and progress survives closing + reopening the overlay (store-tracked).

## Notes

- No new SpinupWP API calls; the only new write is a local file (the sample hook), gated to when none exists.
- README "Database backup & sync" section and CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)