### PR TITLE
Production media fallback + version/About + update check (v0.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,36 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-23
+
+### Added
+- **Production media fallback (`m`).** After a `p` DB pull, your local site shows
+  broken images because the media library isn't synced. Press `m` on a linked
+  WordPress site to drop a small, self-contained mu-plugin that serves any
+  **missing-locally** upload straight from production — so images resolve without
+  copying a single file. It runs in WordPress (pure PHP), so it works the same on
+  any local stack (Valet / Herd / LocalWP / DDEV / MAMP) with no web-server config.
+  It decides "missing" from the real document root and redirects to the **same
+  path** on production, so it covers page-builder URLs (Elementor inline CSS &
+  gallery data), **legacy `/wp-content/uploads` paths** left from a Bedrock
+  conversion, and CDN/S3 redirects (production's own routing resolves them).
+  Local-only and read-only on production; self-disables on the production domain
+  so it's inert if ever deployed. The plugin's presence is its on/off state (no
+  config); `m` toggles it and the overlay offers an in-place update when a newer
+  version ships. (See "Production media fallback" in the README.)
+- **App version, About, and update check.** The header now shows the running
+  version next to the wordmark (`◆ Spinup vX.Y.Z`). The `?` help overlay is
+  redesigned into a responsive multi-column layout with an **About** column
+  (version, how to update, repo). On launch the app checks the latest GitHub
+  release (cached on disk for 6h — no background polling) and, when a newer
+  release exists, shows a `✦ vX.Y.Z` hint in the header and the About panel.
+
+### Changed
+- **The app is now called "Spinup".** Renamed the app's own branding — the
+  header wordmark, the help/About panel, and the CLI banner — to **Spinup**, since
+  it's a control center for your *SpinupWP account*. References to the SpinupWP
+  *service* (the web app via `w`, the API, deep links) are unchanged.
+
 ## [0.7.1] - 2026-06-23
 
 ### Added
@@ -282,7 +312,8 @@ Initial tagged release.
 ### Notes
 - Read-only release: works with a SpinupWP **Read Only** API token.
 
-[Unreleased]: https://github.com/mwender/spinupwp-tui/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/mwender/spinupwp-tui/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/mwender/spinupwp-tui/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/mwender/spinupwp-tui/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/mwender/spinupwp-tui/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/mwender/spinupwp-tui/compare/v0.5.0...v0.6.0

--- a/README.md
+++ b/README.md
@@ -2,18 +2,19 @@
   <img src=".github/assets/banner.png" alt="SpinupWP TUI" width="100%">
 </p>
 
-<h1 align="center">SpinupWP TUI</h1>
+<h1 align="center">Spinup</h1>
 
 <p align="center">
-  A fast, keyboard-driven terminal dashboard for browsing and monitoring your
-  <a href="https://spinupwp.com">SpinupWP</a> servers and sites.<br>
+  A fast, keyboard-driven terminal control center for your
+  <a href="https://spinupwp.com">SpinupWP</a> account — browse and monitor your
+  servers and sites, and run local-dev workflows against them.<br>
   Built with <a href="https://opentui.com">OpenTUI</a> and <a href="https://bun.sh">Bun</a>.
 </p>
 
 Once you're in, the dashboard looks like this:
 
 ```
- ◆ SpinupWP   1 Dashboard   2 Servers   3 Stacks   4 Search   5 Events   20 servers · 171 sites
+ ◆ Spinup v0.8.0   1 Dashboard   2 Servers   3 Stacks   4 Search   5 Events   20 servers · 171 sites
 
  ┌──────────────┐ ┌───────────────┐ ┌───────────────────┐ ┌──────────────────────┐
  │ Servers      │ │ Sites         │ │ Fleet Disk        │ │ WP Updates           │
@@ -69,6 +70,12 @@ Once you're in, the dashboard looks like this:
   your **local** database (backs up local first, rewrites URLs, runs your existing
   `sync.d` hook). Works with Standard WP and Bedrock, no per-site config. (See
   "Database backup & sync" below.)
+- **Production media fallback** — after a DB pull, your local site shows broken
+  images because the (often huge) media library isn't synced. Press `m` on a
+  linked WordPress site to drop a small mu-plugin that serves any **missing-locally**
+  upload from production — so images resolve without copying a single file. Works
+  on any local stack (it's pure PHP, not web-server config). (See "Production media
+  fallback" below.)
 - **Upgrade a site's PHP version** — press `u` on a site to pick a new PHP
   version and apply it (`PUT /sites/{id}/php`), then watch the upgrade event run
   to completion. (See "Upgrading PHP" below.)
@@ -187,6 +194,7 @@ These can be set in `config.json` or via an environment variable:
 | `s` | Open a terminal and SSH into the selected site |
 | `d` | Download a production DB backup into the linked copy (Search; WordPress + linked) |
 | `p` | Pull the production DB into the linked copy — overwrites local; opt-in via `localSync` (Search) |
+| `m` | Production media fallback: serve missing-locally images from production (Search; WordPress + linked) |
 | `L` | Link / edit a site's local working copy |
 | `t` / `v` | Open the linked copy in a terminal / its local URL in your browser |
 | `n` | DNS migration view for a site — its records + TTLs (`⏎` edits a TTL; `a` shows the whole server) |
@@ -365,6 +373,34 @@ overlay — each step gets a `✓` as it completes, the running step spins, and 
 failure marks the exact step with `✕` — so you can see everything that happened,
 ending with the saved paths. It keeps running if you close the overlay (`Esc`);
 reopen with the same key to watch it through.
+
+## Production media fallback
+
+A `p` sync refreshes your local **database**, but not the media library — so the
+local site shows broken images. Syncing the files is often impractical (some
+libraries are hundreds of thousands of items). Instead, press **`m`** on a linked
+WordPress site to serve any image that's **missing locally** straight from
+production.
+
+It works by dropping a small, self-contained mu-plugin into your local copy
+(`wp-content/mu-plugins/` or Bedrock's `web/app/mu-plugins/`). The plugin rewrites
+any uploads URL whose file isn't present locally to the production origin —
+covering the standard media functions, page-builder output (e.g. Elementor inline
+CSS and gallery data), and **legacy paths** left over from a Standard-WP →
+Bedrock conversion. Because it decides "missing" from the real document root and
+redirects to the **same path** on production, your production routing (CDN/S3
+redirects included) resolves whatever it's handed.
+
+- **It runs in WordPress, not your web server**, so it works the same on Valet,
+  Herd, LocalWP, DDEV, MAMP — anything. No nginx/Apache config to get right.
+- **Local-only and read-only on production** — it just hotlinks your own
+  production images. It self-disables when running on the production domain, so
+  it's inert if it ever gets deployed.
+- **The plugin's presence is the on/off state** (no config flag). Press `m` to
+  toggle; `u` from the overlay updates it in place when a newer version ships.
+- Needs production reachable and hotlinking allowed (it won't work behind staging
+  Basic-Auth). Images delivered by external CSS files or async JS/REST are the one
+  thing server-side rewriting can't catch.
 
 ## DNS hosts, access & editing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spinupwp-tui",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "A cool terminal UI for browsing and monitoring your SpinupWP servers and sites.",
   "type": "module",
   "bin": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,7 +17,7 @@ const command = args.find((a) => !a.startsWith("-"))
 
 if (args.includes("-h") || args.includes("--help") || command === "help") {
   const cfg = loadConfig()
-  console.log(`${pkg.name} v${pkg.version} — terminal dashboard for SpinupWP
+  console.log(`Spinup v${pkg.version} — terminal dashboard for your SpinupWP account
 
 Usage:
   spinup            Launch the dashboard

--- a/src/lib/appUpdate.ts
+++ b/src/lib/appUpdate.ts
@@ -1,0 +1,125 @@
+// "Update available" check: compare the running version to the latest GitHub
+// release, so a `✨ vX.Y.Z` hint can nudge users (who update with `git pull`).
+//
+// Polling model: checked once per launch, backed by a disk cache with a 6h TTL —
+// so frequent open/close cycles reuse the cached result instead of hitting GitHub
+// each time (releases are infrequent; the unauthenticated API allows 60 req/hr).
+// Never throws and degrades gracefully offline.
+
+import { join } from "node:path"
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs"
+import { configDir } from "../config.ts"
+import { REPO_SLUG } from "../version.ts"
+
+const CACHE_VERSION = 1
+const TTL_MS = 6 * 60 * 60 * 1000 // 6 hours
+const FETCH_TIMEOUT_MS = 5000
+
+export interface UpdateInfo {
+  current: string // running version
+  latest: string // latest released version (no leading "v")
+  url: string // release page
+  updateAvailable: boolean
+}
+
+interface CacheFile {
+  version: number
+  checkedAt: number // epoch ms
+  latest: string | null
+  url: string | null
+}
+
+function cachePath(): string {
+  return join(configDir(), "update-check.json")
+}
+
+// Parse "v1.2.3" / "1.2.3" → [1,2,3]; null when it doesn't look like a version.
+function parseVersion(s: string): [number, number, number] | null {
+  const m = s.trim().replace(/^v/i, "").match(/^(\d+)\.(\d+)\.(\d+)/)
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null
+}
+
+// Strictly-newer comparison (latest > current). Unparseable → false (never nag).
+function isNewer(latest: string, current: string): boolean {
+  const a = parseVersion(latest)
+  const b = parseVersion(current)
+  if (!a || !b) return false
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] > b[i]
+  }
+  return false
+}
+
+function readCache(): CacheFile | null {
+  try {
+    const parsed = JSON.parse(readFileSync(cachePath(), "utf8")) as CacheFile
+    return parsed?.version === CACHE_VERSION ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function writeCache(latest: string | null, url: string | null): void {
+  try {
+    mkdirSync(configDir(), { recursive: true })
+    const file: CacheFile = { version: CACHE_VERSION, checkedAt: Date.now(), latest, url }
+    writeFileSync(cachePath(), JSON.stringify(file))
+  } catch {
+    /* best-effort; a failed cache write just means we re-check next launch */
+  }
+}
+
+function deriveInfo(current: string, latest: string | null, url: string | null): UpdateInfo | null {
+  if (!latest) return null
+  return { current, latest, url: url ?? `https://github.com/${REPO_SLUG}/releases`, updateAvailable: isNewer(latest, current) }
+}
+
+// Synchronous read of whatever we last cached — used to show a hint instantly on
+// launch without waiting on the network. Returns null when nothing is cached.
+export function cachedUpdateInfo(current: string): UpdateInfo | null {
+  const c = readCache()
+  return c ? deriveInfo(current, c.latest, c.url) : null
+}
+
+// Hit GitHub for the latest release; null on any failure (offline, rate limit, no
+// releases yet). Times out so it can't hang the launch.
+async function fetchLatestRelease(): Promise<{ latest: string; url: string } | null> {
+  const ctrl = new AbortController()
+  const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS)
+  try {
+    const res = await fetch(`https://api.github.com/repos/${REPO_SLUG}/releases/latest`, {
+      headers: {
+        "User-Agent": "spinup-tui",
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      signal: ctrl.signal,
+    })
+    if (!res.ok) return null
+    const json = (await res.json()) as { tag_name?: string; html_url?: string }
+    const tag = json.tag_name?.replace(/^v/i, "")
+    if (!tag) return null
+    return { latest: tag, url: json.html_url ?? `https://github.com/${REPO_SLUG}/releases` }
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+// The launch-time check: returns the freshest info we can, hitting GitHub only
+// when the cache is stale (older than the TTL). Falls back to a stale cache if
+// the network fails. Returns null only when we have nothing at all.
+export async function refreshUpdateInfo(current: string): Promise<UpdateInfo | null> {
+  const cache = readCache()
+  if (cache && Date.now() - cache.checkedAt < TTL_MS) {
+    return deriveInfo(current, cache.latest, cache.url)
+  }
+  const fetched = await fetchLatestRelease()
+  if (fetched) {
+    writeCache(fetched.latest, fetched.url)
+    return deriveInfo(current, fetched.latest, fetched.url)
+  }
+  // Network failed — keep whatever we had so the hint doesn't flicker off.
+  return cache ? deriveInfo(current, cache.latest, cache.url) : null
+}

--- a/src/lib/mediaFallback.ts
+++ b/src/lib/mediaFallback.ts
@@ -1,0 +1,288 @@
+// Production media fallback for a linked local site.
+//
+// After a `p` prod→local DB sync the local DB is current but media files aren't
+// pulled down, so browsing locally shows broken images. This drops a small,
+// self-contained mu-plugin into the LOCAL WordPress copy that rewrites any
+// uploads URL whose file is MISSING locally to the production origin — so images
+// resolve without syncing the (often huge) media library.
+//
+// The feature is LOCAL-ONLY and read-only on production (it just hotlinks the
+// site's own production images). Its on/off state is the file's presence — no
+// config flag — so enabling/disabling is just writing/removing the plugin. The
+// plugin self-configures from `wp_get_upload_dir()` (correct for Standard WP,
+// Bedrock, and multisite) and self-disables when running on the production
+// domain, so it's inert if ever deployed.
+
+import { existsSync, mkdirSync, writeFileSync, readFileSync, unlinkSync } from "node:fs"
+import { join } from "node:path"
+import type { Site } from "../api/types.ts"
+import { expandPath, findProjectRoot, type LocalLink } from "./local.ts"
+
+const PLUGIN_FILE = "spinup-media-fallback.php"
+// Identifies a plugin WE generated, so we never touch a user's own file.
+const MARKER = "spinup:media-fallback"
+// Bumped whenever the generated PHP changes; an installed file older than this
+// surfaces an "update available" prompt in the overlay. A file carrying our
+// marker but no version tag predates versioning and counts as v1.
+const PLUGIN_VERSION = 2
+
+export interface MediaFallbackPlan {
+  localRoot: string // where the local WordPress install lives
+  muDir: string // the mu-plugins dir (created on enable)
+  pluginPath: string // muDir/spinup-media-fallback.php
+  prodOrigin: string // https://prod-domain — the fallback source
+  stack: "bedrock" | "standard"
+  enabled: boolean // our plugin currently present
+  version: number // the version this build would write
+  installedVersion: number | null // version on disk, or null when not installed
+  updateAvailable: boolean // installed but older than `version`
+}
+
+export type MediaFallbackResult = { ok: true; plan: MediaFallbackPlan } | { ok: false; error: string }
+
+// Bedrock keeps wp-content under web/app; Standard WP under wp-content. Detect by
+// the on-disk content dir so the plugin lands where WordPress autoloads mu-plugins.
+function contentMuDir(localRoot: string): { dir: string; stack: "bedrock" | "standard" } {
+  if (existsSync(join(localRoot, "web", "app"))) return { dir: join(localRoot, "web", "app", "mu-plugins"), stack: "bedrock" }
+  return { dir: join(localRoot, "wp-content", "mu-plugins"), stack: "standard" }
+}
+
+// True only when the file exists AND carries our marker (never report or remove a
+// user's own same-named plugin).
+function isOurs(pluginPath: string): boolean {
+  return installedVersion(pluginPath) !== null
+}
+
+// Version of an installed plugin: the tagged number, 1 for a marked-but-untagged
+// file (predates versioning), or null when the file is absent / not ours.
+function installedVersion(pluginPath: string): number | null {
+  try {
+    const txt = readFileSync(pluginPath, "utf8")
+    if (!txt.includes(MARKER)) return null
+    const m = txt.match(/spinup:media-fallback v(\d+)/)
+    return m ? parseInt(m[1], 10) : 1
+  } catch {
+    return null
+  }
+}
+
+export function planMediaFallback(site: Site, link: LocalLink | undefined): MediaFallbackResult {
+  if (!link) return { ok: false, error: "Not linked — press L to link a local copy first." }
+  const dir = expandPath(link.path)
+  if (!existsSync(dir)) return { ok: false, error: "Local path is missing — press L to fix the link." }
+
+  const localRoot = findProjectRoot(dir)
+  const { dir: muDir, stack } = contentMuDir(localRoot)
+  const pluginPath = join(muDir, PLUGIN_FILE)
+  const prodOrigin = `${site.https?.enabled ? "https" : "http"}://${site.domain}`
+  const iv = installedVersion(pluginPath)
+  return {
+    ok: true,
+    plan: {
+      localRoot,
+      muDir,
+      pluginPath,
+      prodOrigin,
+      stack,
+      enabled: iv !== null,
+      version: PLUGIN_VERSION,
+      installedVersion: iv,
+      updateAvailable: iv !== null && iv < PLUGIN_VERSION,
+    },
+  }
+}
+
+// Write (or refresh) the mu-plugin. Idempotent; safe to call repeatedly.
+export function enableMediaFallback(plan: MediaFallbackPlan): void {
+  mkdirSync(plan.muDir, { recursive: true })
+  writeFileSync(plan.pluginPath, pluginSource(plan.prodOrigin))
+}
+
+// Remove the mu-plugin — but only if it's the one we generated.
+export function disableMediaFallback(plan: MediaFallbackPlan): void {
+  if (isOurs(plan.pluginPath)) unlinkSync(plan.pluginPath)
+}
+
+// The generated mu-plugin. String.raw keeps PHP backslashes (regex) intact; the
+// only interpolation is the production origin. The marker comment must survive.
+function pluginSource(origin: string): string {
+  return String.raw`<?php
+/**
+ * Plugin Name: Spinup Media Fallback (local dev)
+ * Description: Serve missing local uploads from production so images resolve without syncing the whole media library. Managed by spinup — safe to delete.
+ *
+ * ${MARKER} v${PLUGIN_VERSION}
+ *
+ * Generated by the spinup TUI for local development. When an uploaded file is
+ * not present locally, its URL is rewritten to the production origin below.
+ * Self-disables when the site runs on its production domain, so it is inert if
+ * ever deployed. Define SPINUP_MEDIA_FALLBACK_DISABLE truthy to force it off.
+ */
+
+if (!defined('ABSPATH')) {
+    return;
+}
+
+if (!defined('SPINUP_MEDIA_FALLBACK_ORIGIN')) {
+    define('SPINUP_MEDIA_FALLBACK_ORIGIN', '${origin}');
+}
+
+/**
+ * Active only on a non-production host (computed once, lazily — after options are
+ * loaded). Prevents borrowing from ourselves and makes an accidental deploy inert.
+ */
+function spinup_mf_active() {
+    static $active = null;
+    if ($active !== null) {
+        return $active;
+    }
+    $active = false;
+    if (defined('SPINUP_MEDIA_FALLBACK_DISABLE') && SPINUP_MEDIA_FALLBACK_DISABLE) {
+        return $active;
+    }
+    $origin = SPINUP_MEDIA_FALLBACK_ORIGIN;
+    $prod_host = $origin ? parse_url($origin, PHP_URL_HOST) : '';
+    $home_host = parse_url(home_url(), PHP_URL_HOST);
+    if (!$prod_host || !$home_host) {
+        return $active;
+    }
+    $suffix = '.' . $prod_host;
+    // On the production domain (or a clone using it)? Then do nothing.
+    if ($home_host === $prod_host || substr($home_host, -strlen($suffix)) === $suffix) {
+        return $active;
+    }
+    $active = true;
+    return $active;
+}
+
+/**
+ * [local base URL, local base dir, production base URL] for uploads. Cached.
+ */
+function spinup_mf_base() {
+    static $cache = null;
+    if ($cache !== null) {
+        return $cache;
+    }
+    $u = wp_get_upload_dir();
+    $base_url = rtrim($u['baseurl'], '/');
+    $base_dir = rtrim($u['basedir'], '/');
+    $path = parse_url($base_url, PHP_URL_PATH);
+    $prod_base = rtrim(SPINUP_MEDIA_FALLBACK_ORIGIN, '/') . $path;
+    $cache = array($base_url, $base_dir, $prod_base);
+    return $cache;
+}
+
+/**
+ * Is the uploads-relative file (e.g. /2024/05/x-300x200.jpg) present locally?
+ */
+function spinup_mf_local_has($rel) {
+    $base = spinup_mf_base();
+    $rel_path = strtok($rel, '?'); // drop any ?ver= cache buster
+    return @file_exists($base[1] . $rel_path);
+}
+
+/**
+ * Rewrite a full local uploads URL to production when the file is missing.
+ */
+function spinup_mf_map_url($url) {
+    if (!is_string($url) || $url === '' || !spinup_mf_active()) {
+        return $url;
+    }
+    $base = spinup_mf_base();
+    if (strpos($url, $base[0]) !== 0) {
+        return $url;
+    }
+    $rel = substr($url, strlen($base[0]));
+    if (spinup_mf_local_has($rel)) {
+        return $url;
+    }
+    return $base[2] . $rel;
+}
+
+// Core-generated URLs (blocks, themes, and the admin media library).
+add_filter('wp_get_attachment_url', 'spinup_mf_map_url', 99);
+add_filter('wp_get_attachment_image_src', function ($image) {
+    if (is_array($image) && isset($image[0])) {
+        $image[0] = spinup_mf_map_url($image[0]);
+    }
+    return $image;
+}, 99);
+add_filter('wp_calculate_image_srcset', function ($sources) {
+    if (is_array($sources)) {
+        foreach ($sources as $k => $s) {
+            if (isset($s['url'])) {
+                $sources[$k]['url'] = spinup_mf_map_url($s['url']);
+            }
+        }
+    }
+    return $sources;
+}, 99);
+
+/**
+ * Would a local-origin request for $path 404? Decide from the real document root
+ * (what the web server itself would resolve), so this works for ANY path — the
+ * current uploads dir, a legacy /wp-content/uploads after a Bedrock conversion,
+ * or a CDN-offloaded path. Returns the production URL to use, or null to keep the
+ * local one. Deferring to production by path means production's own routing
+ * (redirects, S3/CDN) resolves whatever we hand it.
+ */
+function spinup_mf_map_path($path) {
+    $root = isset($_SERVER['DOCUMENT_ROOT']) ? rtrim($_SERVER['DOCUMENT_ROOT'], '/') : '';
+    if ($root !== '' && @file_exists($root . $path)) {
+        return null; // present locally — leave it
+    }
+    return rtrim(SPINUP_MEDIA_FALLBACK_ORIGIN, '/') . $path;
+}
+
+// Front-end catch-all: rewrite any local-origin media URL in the final HTML whose
+// file is missing locally — covers hardcoded URLs and page builders (e.g.
+// Elementor inline background-image CSS) that bypass the attachment filters, plus
+// JSON-escaped URLs (\/) that Elementor embeds for galleries/lightboxes.
+add_action('template_redirect', function () {
+    if (!spinup_mf_active()) {
+        return;
+    }
+    if (is_admin() || is_feed()
+        || (defined('DOING_AJAX') && DOING_AJAX)
+        || (defined('REST_REQUEST') && REST_REQUEST)
+        || (defined('WP_CLI') && WP_CLI)) {
+        return;
+    }
+    ob_start('spinup_mf_filter_html');
+});
+
+function spinup_mf_filter_html($html) {
+    if (!is_string($html) || $html === '' || !spinup_mf_active()) {
+        return $html;
+    }
+    $home_host = parse_url(home_url(), PHP_URL_HOST);
+    if (!$home_host) {
+        return $html;
+    }
+    $host = preg_quote($home_host, '#');
+    // Media-ish extensions worth a production fallback (not js/css — those are
+    // local code, and the file-exists check would leave them alone anyway).
+    $ext = 'jpe?g|png|gif|webp|avif|svg|bmp|ico|tiff?|heic|pdf|mp4|m4v|mov|webm|ogv|mp3|wav|ogg|m4a|woff2?|ttf|otf|eot';
+    // A slash that may be JSON-escaped (\/), so one pass matches plain, protocol-
+    // relative, and escaped URLs alike.
+    $sl = '(?:\\\\?/)';
+    $seg = '[^\s"\'()<>\\\\/]';
+    $re = '#(?:https?:)?' . $sl . $sl . $host . '(?:' . $sl . $seg . '+)+\.(?:' . $ext . ')(?:\?' . $seg . '*)?#i';
+    return preg_replace_callback($re, function ($m) use ($host) {
+        $url = $m[0];
+        $escaped = strpos($url, '\\/') !== false;
+        $norm = $escaped ? str_replace('\\/', '/', $url) : $url;
+        $rest = preg_replace('#^(?:https?:)?//' . $host . '#i', '', $norm); // /path(?query)
+        $qpos = strpos($rest, '?');
+        $path = $qpos === false ? $rest : substr($rest, 0, $qpos);
+        $query = $qpos === false ? '' : substr($rest, $qpos);
+        $prod = spinup_mf_map_path($path);
+        if ($prod === null) {
+            return $m[0];
+        }
+        $out = $prod . $query;
+        return $escaped ? str_replace('/', '\\/', $out) : $out;
+    }, $html);
+}
+`
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -17,6 +17,7 @@ import { Health } from "./views/Health.tsx"
 import { PhpUpgrade } from "./views/PhpUpgrade.tsx"
 import { DbBackup } from "./views/DbBackup.tsx"
 import { DbSync } from "./views/DbSync.tsx"
+import { MediaFallback } from "./views/MediaFallback.tsx"
 import { ServerActions } from "./views/ServerActions.tsx"
 import { LocalLinkOverlay } from "./views/LocalLink.tsx"
 import { Discover } from "./views/Discover.tsx"
@@ -49,6 +50,7 @@ export function App() {
     store.phpUpgradeSite !== null ||
     store.dbBackupSite !== null ||
     store.dbSyncSite !== null ||
+    store.mediaFallbackSite !== null ||
     store.serverActionsServer !== null ||
     store.localLinkSite !== null ||
     store.discoverOpen ||
@@ -87,6 +89,9 @@ export function App() {
 
     // The DB-sync overlay owns the keyboard while open.
     if (store.dbSyncSite) return
+
+    // The media-fallback overlay owns the keyboard while open.
+    if (store.mediaFallbackSite) return
 
     // The server-actions overlay owns the keyboard while open.
     if (store.serverActionsServer) return
@@ -178,6 +183,7 @@ export function App() {
       {store.phpUpgradeSite && <PhpUpgrade />}
       {store.dbBackupSite && <DbBackup />}
       {store.dbSyncSite && <DbSync />}
+      {store.mediaFallbackSite && <MediaFallback />}
       {store.serverActionsServer && <ServerActions />}
       {store.localLinkSite && <LocalLinkOverlay />}
       {store.discoverOpen && <Discover />}

--- a/src/ui/Explain.tsx
+++ b/src/ui/Explain.tsx
@@ -82,6 +82,7 @@ const GUIDES: Record<Route, Guide> = {
       ["o / w / u", "Open · open in SpinupWP · change PHP"],
       ["s", "SSH into the site (opens a terminal)"],
       ["t / v / L", "Local copy: terminal · local URL · link or edit"],
+      ["d / p / m", "DB backup · pull prod→local · production media fallback"],
       ["a / h", "Server actions · server health"],
     ],
   },

--- a/src/ui/Header.tsx
+++ b/src/ui/Header.tsx
@@ -4,6 +4,7 @@ import { theme } from "../lib/theme.ts"
 import { useStore, type Route } from "./store.tsx"
 import { timeAgo } from "../lib/format.ts"
 import { Spinner } from "./components.tsx"
+import { APP_NAME, APP_VERSION } from "../version.ts"
 
 const TABS: { route: Route; key: string; label: string }[] = [
   { route: "dashboard", key: "1", label: "Dashboard" },
@@ -25,7 +26,8 @@ const SUBTITLES: Record<Route, string> = {
 }
 
 export function Header() {
-  const { route, servers, sites, loading, lastUpdated } = useStore()
+  const { route, servers, sites, loading, lastUpdated, updateInfo } = useStore()
+  const updateReady = updateInfo?.updateAvailable ?? false
 
   return (
     <box style={{ flexDirection: "column", flexShrink: 0 }}>
@@ -39,7 +41,9 @@ export function Header() {
           alignItems: "center",
         }}
       >
-        <text content="◆ SpinupWP" fg={theme.brand} style={{ flexShrink: 0 }} />
+        <text content={`◆ ${APP_NAME}`} fg={theme.brand} style={{ flexShrink: 0 }} />
+        <text content={` v${APP_VERSION}`} fg={theme.textFaint} style={{ flexShrink: 0 }} />
+        {updateReady && <text content={` ✦ v${updateInfo!.latest}`} fg={theme.brand} style={{ flexShrink: 0 }} />}
         <box style={{ width: 2, flexShrink: 0 }} />
         {TABS.map((tab) => {
           const active = tab.route === route

--- a/src/ui/Help.tsx
+++ b/src/ui/Help.tsx
@@ -1,75 +1,200 @@
-// Modal-style help overlay listing all keybindings. Rendered on top via zIndex.
+// Help overlay: an "About Spinup" column plus the keybindings, laid out in
+// responsive columns so it stays short on wide terminals and stacks on narrow
+// ones. Rendered on top via zIndex. Opened/closed with `?`.
 
+import type { ReactNode } from "react"
+import { useTerminalDimensions } from "@opentui/react"
 import { theme } from "../lib/theme.ts"
+import { APP_NAME, APP_VERSION, REPO_URL } from "../version.ts"
+import { Sparkle } from "./components.tsx"
+import { useStore } from "./store.tsx"
+import type { UpdateInfo } from "../lib/appUpdate.ts"
 
-const SECTIONS: { title: string; keys: [string, string][] }[] = [
-  {
-    title: "Global",
-    keys: [
-      ["1 … 5", "Switch tabs: Dashboard · Servers · Stacks · Search · Events"],
-      ["r", "Refresh data from the API"],
-      ["/", "Jump to global search"],
-      ["?", "Toggle this help"],
-      ["q", "Quit"],
-      ["Ctrl+C", "Force quit"],
-    ],
-  },
-  {
-    title: "Lists & Panels",
-    keys: [
-      ["↑ / ↓  or  j / k", "Move selection"],
-      ["Enter / →", "Drill in (server → its sites, site → details)"],
-      ["← / Esc", "Go back / collapse"],
-      ["Tab", "Switch focus between columns"],
-      ["o", "Open the selected site's URL in your browser"],
-      ["s", "Open a terminal and SSH into the selected site"],
-      ["h", "Live server health (CPU/mem/disk over SSH)"],
-      ["d", "Identify the app running on a site, via SSH (Servers / Stacks)"],
-      ["D", "Identify every app in the selected group (Stacks tab)"],
-      ["u", "Change a site's PHP version (needs a Read/Write token)"],
-      ["a", "Server actions: reboot or restart a service (Read/Write token)"],
-      ["w", "Open the selected server/site in the SpinupWP web app"],
-      ["g / G", "Jump to top / bottom"],
-    ],
-  },
-  {
-    title: "Local working copy",
-    keys: [
-      ["L", "Link / edit the selected site's local copy"],
-      ["t", "Open the local copy in a terminal"],
-      ["v", "Open the local URL in your browser"],
-      ["S", "Scan for local copies & batch-link them (Stacks tab)"],
-      ["f", "Report sites with no usable local copy (Stacks tab)"],
-    ],
-  },
-  {
-    title: "DNS hosts",
-    keys: [
-      ["n", "Look up where the selected site's domains host DNS"],
-      ["N", "DNS zone-host inventory for the selected server"],
-      ["c", "In the inventory: connect a provider / open its console for the zone"],
-      ["✓ ↗ ○ ·", "Access: editable · web only · needs key · unknown"],
-      ["GoDaddy", "Assumes Delegate Access from one main account: c → w opens your Clients hub (domain copied) → Login as client → paste → Exit access"],
-    ],
-  },
-  {
-    title: "Row markers",
-    keys: [
-      ["◆", "A local working copy is linked for this site"],
-      ["↑N", "N pending WordPress updates"],
-    ],
-  },
-  {
-    title: "Search tab",
-    keys: [
-      ["Tab / →", "Hand focus from the search box to the result's actions"],
-      ["o w u t v L a h", "Act on the selected result (see sections above)"],
-      ["← / Esc", "Return to the search box"],
-    ],
-  },
+type Section = { title: string; keys: [string, string][] }
+
+const GLOBAL: Section = {
+  title: "Global",
+  keys: [
+    ["1 … 5", "Switch tabs"],
+    ["r", "Refresh from the API"],
+    ["/", "Global search"],
+    ["i", "Explain the current screen"],
+    ["?", "This help"],
+    ["q · Ctrl+C", "Quit · force quit"],
+  ],
+}
+
+const NAV: Section = {
+  title: "Navigate & act",
+  keys: [
+    ["↑/↓  j/k", "Move selection"],
+    ["Enter / →", "Drill in"],
+    ["← / Esc", "Back / collapse"],
+    ["Tab", "Switch column focus"],
+    ["g / G", "Jump to top / bottom"],
+    ["o", "Open the site's URL"],
+    ["s", "SSH into the site"],
+    ["h", "Server health (SSH)"],
+    ["w", "Open in SpinupWP web app"],
+    ["a", "Server actions (reboot/restart)"],
+    ["u", "Change PHP version"],
+    ["d", "Identify a site's app (SSH)"],
+  ],
+}
+
+const LOCAL: Section = {
+  title: "Local working copy",
+  keys: [
+    ["L", "Link / edit local copy"],
+    ["t", "Terminal at the local copy"],
+    ["v", "Open the local URL"],
+    ["S", "Scan & batch-link (Stacks)"],
+    ["f", "Sites needing a local copy"],
+  ],
+}
+
+const DBMEDIA: Section = {
+  title: "Database & media (local)",
+  keys: [
+    ["d", "Download prod DB backup (Search)"],
+    ["p", "Pull prod DB → local (opt-in)"],
+    ["m", "Production media fallback"],
+  ],
+}
+
+const DNS: Section = {
+  title: "DNS hosts",
+  keys: [
+    ["n / N", "Site / server DNS inventory"],
+    ["Enter", "Edit a record's TTL"],
+    ["c", "Connect provider / open console"],
+    ["✓ ↗ ○ ·", "editable · web · needs key · ?"],
+  ],
+}
+
+const MARKERS: Section = {
+  title: "Row markers",
+  keys: [
+    ["◆", "Local copy linked"],
+    ["↑N", "Pending WP updates"],
+    ["⇣ / ⬇", "Sync / backup running"],
+  ],
+}
+
+const SEARCHTAB: Section = {
+  title: "Search tab",
+  keys: [
+    ["Tab / →", "Box → result actions"],
+    ["← / Esc", "Back to the box"],
+  ],
+}
+
+// Column groupings: two balanced columns on wide screens, one column otherwise.
+const TWO_COLS: Section[][] = [
+  [GLOBAL, NAV, SEARCHTAB],
+  [LOCAL, DBMEDIA, DNS, MARKERS],
 ]
+const ONE_COL: Section[][] = [[GLOBAL, NAV, LOCAL, DBMEDIA, DNS, MARKERS, SEARCHTAB]]
 
-export function HelpOverlay({ onClose }: { onClose: () => void }) {
+const ABOUT_W = 34
+const SC_W_MIN = 34 // never narrower than this; below it, fall back to one column
+
+function KeyRow({ k, desc }: { k: string; desc: string }) {
+  return (
+    <box style={{ flexDirection: "row" }}>
+      <box style={{ width: 13, flexShrink: 0 }}>
+        <text content={k} fg={theme.brand} wrapMode="none" />
+      </box>
+      <text content={desc} fg={theme.text} style={{ flexGrow: 1, flexShrink: 1 }} />
+    </box>
+  )
+}
+
+function SectionBlock({ section }: { section: Section }) {
+  return (
+    <box style={{ flexDirection: "column" }}>
+      <text content={section.title} fg={theme.accent} attributes={1} />
+      {section.keys.map(([k, desc]) => (
+        <KeyRow key={k} k={k} desc={desc} />
+      ))}
+      <box style={{ height: 1 }} />
+    </box>
+  )
+}
+
+function ShortcutColumn({ sections, width }: { sections: Section[]; width: number }) {
+  return (
+    <box style={{ flexDirection: "column", width, flexShrink: 0 }}>
+      {sections.map((s) => (
+        <SectionBlock key={s.title} section={s} />
+      ))}
+    </box>
+  )
+}
+
+function AboutColumn({ width, updateInfo }: { width: number; updateInfo: UpdateInfo | null }) {
+  const line = (content: string, fg: string = theme.textDim): ReactNode => (
+    <text content={content} fg={fg} wrapMode="none" />
+  )
+  return (
+    <box style={{ flexDirection: "column", width, flexShrink: 0 }}>
+      <box style={{ flexDirection: "row" }}>
+        <text content={`◆ ${APP_NAME}`} fg={theme.brand} attributes={1} />
+        <text content={`  v${APP_VERSION}`} fg={theme.text} />
+      </box>
+      <box style={{ height: 1 }} />
+      {line("A terminal control center for")}
+      {line("your SpinupWP account.")}
+      <box style={{ height: 1 }} />
+      <text content="UPDATING" fg={theme.accent} attributes={1} />
+      {updateInfo?.updateAvailable ? (
+        <box style={{ flexDirection: "row" }}>
+          <Sparkle />
+          <text content={`  v${updateInfo.latest} available`} fg={theme.brand} attributes={1} wrapMode="none" />
+        </box>
+      ) : updateInfo ? (
+        line("You're on the latest.", theme.textFaint)
+      ) : null}
+      {line("git pull in your checkout —")}
+      {line("the global spinup command")}
+      {line("picks it up immediately.")}
+      <box style={{ height: 1 }} />
+      <box style={{ flexDirection: "row" }}>
+        <text content="check  " fg={theme.textFaint} />
+        <text content="spinup --version" fg={theme.text} wrapMode="none" />
+      </box>
+      <box style={{ height: 1 }} />
+      {line(REPO_URL.replace(/^https:\/\//, ""), theme.textFaint)}
+      {line("Built with OpenTUI", theme.textFaint)}
+    </box>
+  )
+}
+
+export function HelpOverlay({ onClose: _onClose }: { onClose: () => void }) {
+  const { width } = useTerminalDimensions()
+  const { updateInfo } = useStore()
+  const aboutLeft = width >= 96
+  const twoShortcutCols = width >= 118
+
+  // Fill the terminal up to a cap, then size columns to the content area (box
+  // width − 2 border − 4 padding). Computing widths from the real space keeps it
+  // from clipping on narrow terminals and from sprawling on ultra-wide ones.
+  const GAP = 3
+  const boxWidth = Math.min(width - 4, 152)
+  const content = boxWidth - 6
+
+  const groups = twoShortcutCols ? TWO_COLS : ONE_COL
+  const cols = groups.length
+  const aboutWidth = aboutLeft ? ABOUT_W : content
+  const scArea = aboutLeft ? content - ABOUT_W - GAP : content
+  const scWidth = Math.max(SC_W_MIN, Math.floor((scArea - (cols - 1) * GAP) / cols))
+
+  const shortcutCols = groups.map((sections, i) => (
+    <box key={i} style={{ marginLeft: aboutLeft || i > 0 ? GAP : 0 }}>
+      <ShortcutColumn sections={sections} width={scWidth} />
+    </box>
+  ))
+
   return (
     <box
       style={{
@@ -84,28 +209,27 @@ export function HelpOverlay({ onClose }: { onClose: () => void }) {
       }}
     >
       <box
-        title=" Keyboard Shortcuts "
+        title={` ${APP_NAME} — Help `}
         titleColor={theme.brand}
         bottomTitle=" press ? or Esc to close "
         bottomTitleAlignment="center"
         border
         borderColor={theme.borderActive}
         backgroundColor={theme.bgPanel}
-        style={{ flexDirection: "column", width: 64, paddingLeft: 2, paddingRight: 2, paddingTop: 1, paddingBottom: 1 }}
+        style={{ flexDirection: "column", width: boxWidth, paddingLeft: 2, paddingRight: 2, paddingTop: 1, paddingBottom: 1 }}
       >
-        {SECTIONS.map((section) => (
-          <box key={section.title} style={{ flexDirection: "column" }}>
-            <text content={section.title} fg={theme.accent} attributes={1} />
-            {section.keys.map(([k, desc]) => (
-              <box key={k} style={{ flexDirection: "row" }}>
-                <text content={k.padEnd(18)} fg={theme.brand} />
-                <text content={desc} fg={theme.text} />
-              </box>
-            ))}
-            <box style={{ height: 1 }} />
+        {aboutLeft ? (
+          <box style={{ flexDirection: "row", alignItems: "flex-start" }}>
+            <AboutColumn width={aboutWidth} updateInfo={updateInfo} />
+            {shortcutCols}
           </box>
-        ))}
-        <text content="A SpinupWP control center · built with OpenTUI" fg={theme.textFaint} />
+        ) : (
+          <box style={{ flexDirection: "column" }}>
+            <AboutColumn width={aboutWidth} updateInfo={updateInfo} />
+            <box style={{ height: 1 }} />
+            {shortcutCols}
+          </box>
+        )}
       </box>
     </box>
   )

--- a/src/ui/components.tsx
+++ b/src/ui/components.tsx
@@ -40,6 +40,19 @@ export function Spinner({ color = theme.brand, interval = 80 }: { color?: string
   return <text content={SPINNER_FRAMES[frame]} fg={color} />
 }
 
+const SPARKLE_FRAMES = ["✦", "✧", "✶", "✧"]
+
+// A gentle twinkling glyph for drawing the eye to a notice (e.g. an available
+// update) without the urgency of a spinner.
+export function Sparkle({ color = theme.brand, interval = 360 }: { color?: string; interval?: number }) {
+  const [frame, setFrame] = useState(0)
+  useEffect(() => {
+    const id = setInterval(() => setFrame((f) => (f + 1) % SPARKLE_FRAMES.length), interval)
+    return () => clearInterval(id)
+  }, [interval])
+  return <text content={SPARKLE_FRAMES[frame]} fg={color} />
+}
+
 // A vertical checklist of stages that fills in as work progresses: completed
 // rows get a green ✓, the in-flight row spins, not-yet-reached rows are faint
 // ○, and a failed row gets a red ✕. Used by the DB backup/sync overlays so the

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -9,6 +9,8 @@ import { createContext, useContext, useCallback, useEffect, useMemo, useRef, use
 import { SpinupWPClient, ApiError, type ServerService } from "../api/client.ts"
 import type { Server, Site, Event } from "../api/types.ts"
 import { loadConfig, saveConfig } from "../config.ts"
+import { APP_VERSION } from "../version.ts"
+import { cachedUpdateInfo, refreshUpdateInfo, type UpdateInfo } from "../lib/appUpdate.ts"
 import { resolveLocalLink, expandPath, normalizeLink, type LocalLink } from "../lib/local.ts"
 import type { Stack } from "../lib/stack.ts"
 import { openTerminalAt, openUrl, openSshSession } from "../lib/open.ts"
@@ -37,6 +39,7 @@ import { StackCache, siteSignature, type CachedProbe } from "../lib/stackCache.t
 import { resolvePhpEolDates, refreshPhpEolDates, isPhpEol as isPhpEolWith, offeredPhpVersions as offeredPhpVersionsWith, type PhpEolDates } from "../lib/phpEol.ts"
 import { planDbBackup, runDbBackup, type DbBackupProgress, type PlanResult } from "../lib/dbBackup.ts"
 import { planDbSync, runDbSync, type DbSyncProgress, type SyncPlanResult } from "../lib/dbSync.ts"
+import { planMediaFallback, type MediaFallbackResult } from "../lib/mediaFallback.ts"
 
 export type Route = "dashboard" | "servers" | "stacks" | "search" | "events"
 
@@ -115,6 +118,8 @@ export interface DataState {
   ready: boolean
   error: string | null
   lastUpdated: Date | null
+  // Latest released version vs. the running one (null until/unless we learn it).
+  updateInfo: UpdateInfo | null
 }
 
 interface StoreValue extends DataState {
@@ -214,6 +219,12 @@ interface StoreValue extends DataState {
   // import → search-replace URLs → run post-import hook. Destructive on LOCAL.
   startDbSync: (site: Site) => void
   clearDbSync: (siteId: number) => void
+
+  // Production media fallback overlay (mu-plugin in the linked local copy). State
+  // is the plugin file's presence, resolved fresh by planMediaFallbackFor.
+  mediaFallbackSite: Site | null
+  setMediaFallbackSite: (s: Site | null) => void
+  planMediaFallbackFor: (site: Site) => MediaFallbackResult
   // Local git drift for linked sites, keyed by site id (null = not a git repo,
   // undefined = not yet computed). Computed lazily + cached; cleared on refresh.
   drift: Map<number, Drift | null>
@@ -328,6 +339,14 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const [ready, setReady] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
+  // Update check: show any cached result immediately, then refresh once per launch
+  // (disk-cached, 6h TTL — see appUpdate.ts).
+  const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(() => cachedUpdateInfo(APP_VERSION))
+  useEffect(() => {
+    void refreshUpdateInfo(APP_VERSION).then((info) => {
+      if (info) setUpdateInfo(info)
+    })
+  }, [])
   const [route, setRoute] = useState<Route>("dashboard")
   const [inputMode, setInputMode] = useState(false)
   const [overlayOpen, setOverlayOpen] = useState(false)
@@ -341,6 +360,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const [dbBackups, setDbBackups] = useState<Map<number, DbBackupProgress>>(new Map())
   const [dbSyncSite, setDbSyncSite] = useState<Site | null>(null)
   const [dbSyncs, setDbSyncs] = useState<Map<number, DbSyncProgress>>(new Map())
+  const [mediaFallbackSite, setMediaFallbackSite] = useState<Site | null>(null)
   const [localRoots, setLocalRoots] = useState<string[]>(() => [...cfgRef.current.localRoots])
   const [discoverOpen, setDiscoverOpen] = useState(false)
   const [forgottenOpen, setForgottenOpen] = useState(false)
@@ -804,6 +824,8 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     [servers, localLinks],
   )
 
+  const planMediaFallbackFor = useCallback((site: Site): MediaFallbackResult => planMediaFallback(site, localLinks.get(site.id)), [localLinks])
+
   const startDbSync = useCallback(
     (site: Site) => {
       const existing = dbSyncs.get(site.id)
@@ -1208,6 +1230,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     ready,
     error,
     lastUpdated,
+    updateInfo,
     client,
     route,
     setRoute,
@@ -1254,6 +1277,9 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     clearDbBackup,
     dbSyncSite,
     setDbSyncSite,
+    mediaFallbackSite,
+    setMediaFallbackSite,
+    planMediaFallbackFor,
     dbSyncs,
     planDbSyncFor,
     startDbSync,

--- a/src/ui/views/DbSync.tsx
+++ b/src/ui/views/DbSync.tsx
@@ -28,7 +28,7 @@ const SYNC_STEPS: { stage: DbSyncStage; label: string }[] = [
 ]
 
 export function DbSync() {
-  const { dbSyncSite: site, setDbSyncSite, serverById, planDbSyncFor, dbSyncs, startDbSync, clearDbSync } = useStore()
+  const { dbSyncSite: site, setDbSyncSite, serverById, planDbSyncFor, dbSyncs, startDbSync, clearDbSync, planMediaFallbackFor, setMediaFallbackSite } = useStore()
 
   const planResult = site ? planDbSyncFor(site) : null
   const progress = site ? dbSyncs.get(site.id) : undefined
@@ -80,11 +80,23 @@ export function DbSync() {
       }
       return
     }
+    if (dp === "done") {
+      // m: hand off to the media-fallback overlay for the just-synced site.
+      if (name === "m" && site) {
+        close()
+        setMediaFallbackSite(site)
+      }
+      return
+    }
   })
 
   if (!site) return null
   const server = serverById(site.server_id)
   const plan = planResult && planResult.ok ? planResult.plan : null
+  // Whether this site already has the production media-fallback plugin (shapes the
+  // Done-screen nudge). Only meaningful on the done screen.
+  const mfPlan = dp === "done" ? planMediaFallbackFor(site) : null
+  const mediaFallbackEnabled = !!(mfPlan && mfPlan.ok && mfPlan.plan.enabled)
 
   return (
     <box
@@ -248,6 +260,11 @@ export function DbSync() {
               <text content="local DB backup" fg={theme.textFaint} />
               {progress?.localBackupPath ? <DestPath path={progress.localBackupPath} fileColor={theme.textDim} width={62} /> : null}
               <box style={{ height: 1 }} />
+              {mediaFallbackEnabled ? (
+                <text content="✓ Missing images load from production (media fallback on)." fg={theme.textFaint} wrapMode="none" />
+              ) : (
+                <text content="Images 404ing locally? Press m to serve them from production." fg={theme.purple} wrapMode="none" />
+              )}
               <text content="Esc to close" fg={theme.textFaint} />
             </>
           ) : dp === "error" ? (
@@ -276,6 +293,11 @@ export function DbSync() {
       case "error":
         return [
           { key: "r", label: "retry" },
+          { key: "esc", label: "close" },
+        ]
+      case "done":
+        return [
+          ...(mediaFallbackEnabled ? [] : [{ key: "m", label: "media fallback" }]),
           { key: "esc", label: "close" },
         ]
       default:

--- a/src/ui/views/MediaFallback.tsx
+++ b/src/ui/views/MediaFallback.tsx
@@ -1,0 +1,180 @@
+// Production media fallback overlay.
+//
+// Opened with `m` on a linked WordPress site (Search), or from the `p` sync Done
+// screen. Toggles a small mu-plugin in the local copy that serves missing-locally
+// uploads from production — so a synced site's images resolve without pulling the
+// whole media library. The plugin's presence IS the on/off state (no config), so
+// this is just a file write/remove; nothing runs in the background.
+
+import { useState } from "react"
+import { useKeyboard } from "@opentui/react"
+import { theme } from "../../lib/theme.ts"
+import { truncate } from "../../lib/format.ts"
+import { Panel, Centered, DestPath, Sparkle } from "../components.tsx"
+import { StatusBar } from "../StatusBar.tsx"
+import { useStore } from "../store.tsx"
+import { enableMediaFallback, disableMediaFallback } from "../../lib/mediaFallback.ts"
+
+export function MediaFallback() {
+  const { mediaFallbackSite: site, setMediaFallbackSite, planMediaFallbackFor } = useStore()
+  // Re-resolve every render so the panel reflects the file on disk after a toggle.
+  const planResult = site ? planMediaFallbackFor(site) : null
+  const [changed, setChanged] = useState<"enabled" | "disabled" | "updated" | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const plan = planResult && planResult.ok ? planResult.plan : null
+
+  const close = () => setMediaFallbackSite(null)
+
+  useKeyboard((key) => {
+    const name = key.name ?? ""
+    if (name === "escape" || name === "q") return close()
+    if (!plan) return
+    try {
+      if (!plan.enabled && (name === "return" || name === "y")) {
+        enableMediaFallback(plan)
+        setChanged("enabled")
+        setError(null)
+      } else if (plan.enabled && plan.updateAvailable && name === "u") {
+        enableMediaFallback(plan) // overwrite in place with the current version
+        setChanged("updated")
+        setError(null)
+      } else if (plan.enabled && name === "x") {
+        disableMediaFallback(plan)
+        setChanged("disabled")
+        setError(null)
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Couldn't update the media-fallback plugin.")
+    }
+  })
+
+  if (!site) return null
+
+  return (
+    <box
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        height: "100%",
+        flexDirection: "column",
+        backgroundColor: theme.bg,
+        zIndex: 210,
+      }}
+    >
+      <box style={{ flexDirection: "row", height: 1, backgroundColor: theme.bgAlt, paddingLeft: 1, paddingRight: 1, alignItems: "center" }}>
+        <text content="🖼 Production media fallback  " fg={theme.brand} style={{ flexShrink: 0 }} />
+        <text content={truncate(site.domain, 38)} fg={theme.text} wrapMode="none" style={{ flexShrink: 1 }} />
+        <box style={{ flexGrow: 1 }} />
+        <text content="local only" fg={theme.textFaint} style={{ flexShrink: 0 }} />
+      </box>
+
+      <Centered>{renderBody()}</Centered>
+
+      <StatusBar hints={hints()} showGlobal={false} />
+    </box>
+  )
+
+  function renderBody() {
+    if (!plan) {
+      return (
+        <Panel title=" Can't set up media fallback " active>
+          <box style={{ flexDirection: "column", width: 66, paddingTop: 1, paddingBottom: 1 }}>
+            <text content={planResult && !planResult.ok ? planResult.error : "Unavailable."} fg={theme.warn} wrapMode="none" />
+            <box style={{ height: 1 }} />
+            <text content="Esc to close" fg={theme.textFaint} />
+          </box>
+        </Panel>
+      )
+    }
+
+    return (
+      <Panel title=" Serve missing images from production " active>
+        <box style={{ flexDirection: "column", width: 68, paddingTop: 1, paddingBottom: 1 }}>
+          {plan.enabled && plan.updateAvailable && changed !== "updated" ? (
+            <box
+              title=" ✨ Update available "
+              titleColor={theme.brand}
+              border
+              borderColor={theme.brand}
+              style={{ flexDirection: "column", width: 66, paddingLeft: 1, paddingRight: 1, marginBottom: 1 }}
+            >
+              <box style={{ flexDirection: "row" }}>
+                <Sparkle />
+                <text content={`  Newer missing-images plugin ready (v${plan.installedVersion} → v${plan.version}).`} fg={theme.text} wrapMode="none" />
+              </box>
+              <text content="Now covers legacy /wp-content/uploads paths, CDN/S3" fg={theme.textDim} wrapMode="none" />
+              <text content="redirects, and Elementor gallery URLs." fg={theme.textDim} wrapMode="none" />
+              <box style={{ flexDirection: "row" }}>
+                <text content="Press " fg={theme.textDim} />
+                <text content="u" fg={theme.brand} />
+                <text content=" to update in place." fg={theme.textDim} />
+              </box>
+            </box>
+          ) : null}
+          <text content="When an upload is missing locally, its URL is rewritten to" fg={theme.textDim} wrapMode="none" />
+          <text content="production — so images resolve without syncing the library." fg={theme.textDim} wrapMode="none" />
+          <box style={{ height: 1 }} />
+          <box style={{ flexDirection: "row" }}>
+            <text content="source " fg={theme.textFaint} />
+            <text content={plan.prodOrigin} fg={theme.accent} wrapMode="none" />
+            <text content={`  (${plan.stack === "bedrock" ? "Bedrock" : "Standard WP"})`} fg={theme.textFaint} wrapMode="none" />
+          </box>
+          <text content="plugin" fg={theme.textFaint} />
+          <DestPath path={plan.pluginPath} fileColor={plan.enabled ? theme.good : theme.textDim} width={64} />
+          <box style={{ height: 1 }} />
+          {renderStatus()}
+          <box style={{ height: 1 }} />
+          <text content="Needs production reachable + hotlinking allowed (no staging" fg={theme.textFaint} wrapMode="none" />
+          <text content="Basic-Auth / hotlink protection). Read-only on production." fg={theme.textFaint} wrapMode="none" />
+        </box>
+      </Panel>
+    )
+  }
+
+  function renderStatus() {
+    if (error) return <text content={`✕ ${error}`} fg={theme.bad} />
+    if (plan!.enabled) {
+      const note =
+        changed === "updated"
+          ? `  — updated to v${plan!.version}. Reload the local site.`
+          : changed === "enabled"
+            ? "  — enabled. Reload the local site; images now load from production."
+            : "  — missing images load from production."
+      return (
+        <>
+          <box style={{ flexDirection: "row" }}>
+            <text content="● ON" fg={theme.good} />
+            <text content={note} fg={theme.text} wrapMode="none" />
+          </box>
+          <text content="Press x to turn off" fg={theme.textFaint} />
+        </>
+      )
+    }
+    return (
+      <>
+        <box style={{ flexDirection: "row" }}>
+          <text content="○ OFF" fg={theme.textDim} />
+          <text content={changed === "disabled" ? "  — removed. Missing images will 404 locally again." : "  — missing images 404 locally."} fg={theme.text} wrapMode="none" />
+        </box>
+        <text content="Press y / ⏎ to turn on" fg={theme.textFaint} />
+      </>
+    )
+  }
+
+  function hints() {
+    if (!plan) return [{ key: "esc", label: "close" }]
+    if (!plan.enabled)
+      return [
+        { key: "y/⏎", label: "turn on" },
+        { key: "esc", label: "close" },
+      ]
+    return [
+      ...(plan.updateAvailable && changed !== "updated" ? [{ key: "u", label: "update" }] : []),
+      { key: "x", label: "turn off" },
+      { key: "esc", label: "close" },
+    ]
+  }
+}

--- a/src/ui/views/Search.tsx
+++ b/src/ui/views/Search.tsx
@@ -34,7 +34,7 @@ function score(haystack: string, q: string): number | null {
 
 export function Search({ rows }: { rows: number }) {
   const store = useStore()
-  const { servers, sites, serverById, setInputMode, setRoute, route, overlayOpen, setHealthServer, setPhpUpgradeSite, setServerActionsServer, accountSlug, localLinks, setLocalLinkSite, openLocalTerminal, openLocalUrl, sshSite, setDnsInventoryServer, setDbBackupSite, dbBackups, setDbSyncSite, dbSyncs, localSync } = store
+  const { servers, sites, serverById, setInputMode, setRoute, route, overlayOpen, setHealthServer, setPhpUpgradeSite, setServerActionsServer, accountSlug, localLinks, setLocalLinkSite, openLocalTerminal, openLocalUrl, sshSite, setDnsInventoryServer, setDbBackupSite, dbBackups, setDbSyncSite, dbSyncs, localSync, setMediaFallbackSite } = store
   const [query, setQuery] = useState("")
   const [selected, setSelected] = useState(0)
   // "query" = typing/filtering (input focused); "actions" = input blurred so the
@@ -175,6 +175,15 @@ export function Search({ rows }: { rows: number }) {
           else setDbSyncSite(current.site)
         }
         return
+      case "m":
+        // Production media fallback: drops a mu-plugin into the linked local copy,
+        // so it needs a WordPress site and a local link (same gate as backup).
+        if (current?.kind === "site") {
+          if (!current.site.is_wordpress) flashMsg("Media fallback needs WordPress — this isn't a WP site")
+          else if (!localLinks.has(current.site.id)) flashMsg("Not linked — press L to link a local copy")
+          else setMediaFallbackSite(current.site)
+        }
+        return
       case "n":
         // DNS inventory scoped to this site (its domains + records) — the migrate
         // lens for moving one site to another server.
@@ -230,6 +239,7 @@ export function Search({ rows }: { rows: number }) {
             { key: "n", label: "DNS" },
             { key: "d", label: "DB backup" },
             ...(localSync ? [{ key: "p", label: "pull to local" }] : []),
+            ...(current?.kind === "site" && current.site.is_wordpress && localLinks.has(current.site.id) ? [{ key: "m", label: "media fallback" }] : []),
             { key: "a", label: "server actions" },
             { key: "←/esc", label: "back" },
           ]
@@ -360,18 +370,17 @@ function siteGroups(isWordpress: boolean, localSync: boolean): ActionGroup[] {
     remote.push(["d", "Download DB backup"])
     if (localSync) remote.push(["p", "Pull production DB to local"])
   }
+  const local: [string, string][] = [
+    ["t", "Open working copy in a terminal"],
+    ["v", "Open the local URL"],
+    ["L", "Link / edit local copy"],
+  ]
+  if (isWordpress) local.push(["m", "Media: serve missing images from production"])
   remote.push(["u", "Upgrade PHP version"])
   return [
     { title: "Open", items: [["o", "Open site in browser"], ["w", "Open in SpinupWP"]] },
     { title: "Remote", items: remote },
-    {
-      title: "Local",
-      items: [
-        ["t", "Open working copy in a terminal"],
-        ["v", "Open the local URL"],
-        ["L", "Link / edit local copy"],
-      ],
-    },
+    { title: "Local", items: local },
     { title: "Server", items: [["a", "Server actions (reboot / restart)"], ["h", "Server health"]] },
   ]
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,8 @@
+// The app's own identity. "Spinup" is the app (a control center for your
+// SpinupWP account); keep that distinct from "SpinupWP", the service it talks to.
+import pkg from "../package.json" with { type: "json" }
+
+export const APP_NAME = "Spinup"
+export const APP_VERSION = pkg.version
+export const REPO_SLUG = "mwender/spinupwp-tui"
+export const REPO_URL = `https://github.com/${REPO_SLUG}`


### PR DESCRIPTION
Three features and a rebrand, cut as **v0.8.0**.

## Production media fallback (`m`)
After a `p` DB pull the local site shows broken images (the media library isn't synced). Press `m` on a linked WordPress site to drop a small, self-contained mu-plugin that serves any **missing-locally** upload from production — images resolve without copying a file.

- Runs in WordPress (pure PHP) → works the same on Valet / Herd / LocalWP / DDEV / MAMP, **no web-server config**.
- Decides "missing" from the real document root and redirects to the **same path** on production → covers Elementor inline-CSS/gallery URLs, **legacy `/wp-content/uploads`** paths from a Standard-WP→Bedrock conversion, and CDN/S3 redirects (production routing resolves them).
- Local-only, read-only on production; **self-disables on the production domain** (inert if deployed). Plugin presence is the on/off state (no config); versioned so the overlay offers an in-place update.

## Version, About & update check
- Header shows `◆ Spinup vX.Y.Z`.
- `?` Help overlay redesigned into a **responsive multi-column** layout with an **About** column (version, how to update, repo).
- Once-per-launch GitHub-release check (disk-cached 6h, no background loop) → `✦ vX.Y.Z` hint when a newer release exists. Never nags when current ≥ latest.

## Rebrand to "Spinup"
The app's own branding (header, help, CLI banner) is now **Spinup** — a control center for your *SpinupWP account*. References to the SpinupWP *service* (the `w` web app, API, deep links) are unchanged.

## Testing
- `bun run typecheck` green.
- mu-plugin: `php -l` + a stubbed-WP harness covering current/legacy/JSON-escaped/query/protocol-relative/foreign/non-media URLs and the prod-domain self-disable; update-version detection round-trip. User live-tested on a real Elementor+Bedrock+S3 site — fixed all broken images.
- Update check verified against live GitHub (update / no-nag / cache+TTL); header `✦` indicator PTY-rendered.
- Help 3-column layout PTY-rendered at 180×50; no clipping.

## Notes
- Only new write is a local file (the mu-plugin), gated to linked WordPress sites. No new SpinupWP API calls; production stays read-only.
- README ("Production media fallback" section, Features, Keybindings) and CHANGELOG updated; the app/README rebranded to **Spinup**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)