### PR TITLE
Brighter update-available hint (v0.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-06-30
+
+### Changed
+- **The "update available" hint is easier to spot.** The `✦ vX.Y.Z` nudge in the
+  header (and the `?` About panel) is now **bright gold** and bold, instead of the
+  same green as the wordmark — so a newer release stands out at a glance.
+
 ## [0.9.0] - 2026-06-30
 
 ### Added
@@ -438,7 +445,8 @@ Initial tagged release.
 ### Notes
 - Read-only release: works with a SpinupWP **Read Only** API token.
 
-[Unreleased]: https://github.com/mwender/spinupwp-tui/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/mwender/spinupwp-tui/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/mwender/spinupwp-tui/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/mwender/spinupwp-tui/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/mwender/spinupwp-tui/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/mwender/spinupwp-tui/compare/v0.7.0...v0.7.1

--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ For a standalone binary that doesn't need Bun on `PATH` at runtime:
 bun run build:binary     # produces ./spinup — move it onto your PATH
 ```
 
+### Updating
+
+`git pull` in your checkout — the global `spinup` symlink picks up the new code
+immediately. **If a release changed dependencies, run `bun install` too** (the
+release notes call this out); a standalone binary needs a fresh `bun run
+build:binary`. The app tells you when a newer release exists — a gold `✦ vX.Y.Z`
+appears next to the version in the header (and in the `?` About panel).
+
 #### CLI subcommands
 
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spinupwp-tui",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A cool terminal UI for browsing and monitoring your SpinupWP servers and sites.",
   "type": "module",
   "bin": {

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -16,6 +16,7 @@ export const theme = {
   selectedBg: "#1f6f53",
   good: "#3fb950",
   warn: "#d29922",
+  update: "#ffd23f", // bright gold — "new version available" nudge; brighter/cleaner than warn-amber so it reads as "new", not "caution"
   bad: "#f85149",
   info: "#5ec8ff",
   purple: "#bc8cff",

--- a/src/ui/Header.tsx
+++ b/src/ui/Header.tsx
@@ -49,7 +49,7 @@ export function Header() {
       >
         <text content={`◆ ${APP_NAME}`} fg={theme.brand} style={{ flexShrink: 0 }} />
         <text content={` v${APP_VERSION}`} fg={theme.textFaint} style={{ flexShrink: 0 }} />
-        {updateReady && <text content={` ✦ v${updateInfo!.latest}`} fg={theme.brand} style={{ flexShrink: 0 }} />}
+        {updateReady && <text content={` ✦ v${updateInfo!.latest}`} fg={theme.update} attributes={1} style={{ flexShrink: 0 }} />}
         <box style={{ width: 2, flexShrink: 0 }} />
         {TABS.map((tab) => {
           const active = tab.route === route

--- a/src/ui/Help.tsx
+++ b/src/ui/Help.tsx
@@ -153,8 +153,8 @@ function AboutColumn({ width, updateInfo }: { width: number; updateInfo: UpdateI
       <text content="UPDATING" fg={theme.accent} attributes={1} />
       {updateInfo?.updateAvailable ? (
         <box style={{ flexDirection: "row" }}>
-          <Sparkle />
-          <text content={`  v${updateInfo.latest} available`} fg={theme.brand} attributes={1} wrapMode="none" />
+          <Sparkle color={theme.update} />
+          <text content={`  v${updateInfo.latest} available`} fg={theme.update} attributes={1} wrapMode="none" />
         </box>
       ) : updateInfo ? (
         line("You're on the latest.", theme.textFaint)


### PR DESCRIPTION
Makes the `✦ vX.Y.Z` update nudge stand out instead of blending into the brand green: a dedicated bright-gold `theme.update` token, bolded, in the header and the About panel. Also bumps to v0.9.1 and adds a README "Updating" note (run `bun install` after a pull when a release changes dependencies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)