### PR TITLE
Clone wizard: production-migration hardening + files-only clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,13 @@ versions; such changes are called out here.
   is deliberately opinionated about. Root-webroot sites keep the stock layout
   untouched; subdirectory installs clone as-is; anything unrecognizable
   refuses with a clear message instead of a mystery failure.
-- **Sites SpinupWP marks as not-WordPress (redirect shells, static
-  placeholders) are excluded from the clone plan up front** — tagged "not WP"
-  instead of failing mid-pull with a cryptic error.
+- **Sites SpinupWP marks as not-WordPress (redirect shells, static/PHP
+  sites) now clone as "files only"** — opt-in in the Plan step (tagged, default
+  off). The destination is created with no database, the whole files tree
+  transfers verbatim over the same hardened transport (with byte progress),
+  and verification compares file count, total size, and HTTP response instead
+  of WordPress facts. Previously these sites failed mid-pull with a cryptic
+  error; an interim fix merely excluded them.
 - **Cloned databases keep the source's table prefix** — the destination DB
   was previously always created with `wp_`, breaking sites with custom
   prefixes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,21 @@ versions; such changes are called out here.
   full set on the destination right after the site is created — verified by
   the destination's nginx `server_name` picking up every hostname.
 
+### Changed
+- **The clone wizard no longer jumps to DNS cutover on its own.** When the
+  clone roster settles, the wizard now stays put so you can eyeball every
+  site's final state — press `c` to continue to the cutover step (which moves
+  live traffic) when you're ready.
+
 ### Added
+- **The API client is now rate-limit aware.** It watches
+  `X-RateLimit-Remaining` on every response and paces itself as the window
+  runs low, and a 429 is absorbed with a Retry-After backoff instead of
+  surfacing as a failure. This matters: during a real migration, rate-limited
+  polling made three *successful* operations report as failures. Event
+  polling is also slower-cadence and tolerates transient API errors, and a
+  genuinely failed domain-add now includes SpinupWP's own event output in the
+  error.
 - **Every clone job now writes a full log** to `~/.config/spinupwp-tui/logs/`
   (one JSONL file per job: every remote script, exit code, and complete
   output, with passwords redacted). Previously errors were truncated to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,27 @@ versions; such changes are called out here.
   the message that would have explained it. Warnings are now tolerated (real
   transfer errors still fail) and logged with the exact file named.
 
+- **Large file transfers no longer get killed by the wizard's own timeout.**
+  A ~15-minute production pull was cut off at exactly 900s by two stacked
+  timeouts — and the error surfaced a harmless tar warning instead of the
+  real cause. The file-transfer budget is now 60 minutes, the outer session
+  timeout strictly exceeds the in-script one, and an actual timeout says
+  "file transfer timed out after 60 minutes" in so many words.
+- **Manual DNS records in the cutover now show your access note** ("Delegate
+  Access" by default, or whatever you've written for that zone) instead of
+  wrongly telling you to connect an account for registrars that are managed
+  by hand on purpose. API-connectable hosts (Cloudflare, Route 53) keep the
+  actionable "connect an account" message.
+
 ### Changed
+- **The DNS cutover screen grew real controls.** ↑↓ moves a cursor over the
+  records; space includes/excludes any ready record from the batch flip
+  (◉/◯, same as the Plan step); ⏎ on a record opens its zone's registrar
+  web console with the zone name copied to the clipboard (the
+  delegate-access flow); `c` cuts over exactly the included records; finish
+  moved to `f`.
+- **In-flight clone stages show a live elapsed timer** in the roster, so a
+  long file pull reads as working rather than frozen.
 - **The clone wizard no longer jumps to DNS cutover on its own.** When the
   clone roster settles, the wizard now stays put so you can eyeball every
   site's final state — press `c` to continue to the cutover step (which moves

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,36 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+### Fixed
+- **The clone wizard now detects each site's real webroot instead of assuming
+  it.** The first clone of a long-lived production server failed every site:
+  they all used a `/public/` public folder while the pull chain hardcoded
+  `files/` as the webroot. And the `public_folder` *setting* alone can't be
+  trusted either — SpinupWP never moves files when you configure one (its UI
+  tells you to move them yourself). The Standard-WP pull now finds where
+  WordPress actually lives on the source, and when a site is mid-move (core
+  still at the files root, setting pointing deeper) the clone completes the
+  move on the destination — placing `wp-config.php` one directory **above**
+  the webroot, the long-standing config-outside-the-docroot hardening Spinup
+  is deliberately opinionated about. Root-webroot sites keep the stock layout
+  untouched; subdirectory installs clone as-is; anything unrecognizable
+  refuses with a clear message instead of a mystery failure.
+- **Sites SpinupWP marks as not-WordPress (redirect shells, static
+  placeholders) are excluded from the clone plan up front** — tagged "not WP"
+  instead of failing mid-pull with a cryptic error.
+- **Cloned databases keep the source's table prefix** — the destination DB
+  was previously always created with `wp_`, breaking sites with custom
+  prefixes.
+
+### Added
+- **Every clone job now writes a full log** to `~/.config/spinupwp-tui/logs/`
+  (one JSONL file per job: every remote script, exit code, and complete
+  output, with passwords redacted). Previously errors were truncated to the
+  roster's width and lost when the app closed.
+- **Press `⏎` on a failed site in the clone roster** to see the full
+  untruncated error, the failing step, and the log path — and `r` there
+  retries just that site.
+
 ## [0.11.0] - 2026-07-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,8 +75,10 @@ versions; such changes are called out here.
   `pull · files · 1.2 GB · 18 MB/s · 4m32s` while a transfer runs. Measured
   by a read-only sidecar that stats the growing archive over its own SSH
   session every few seconds, so the progress display can never interfere
-  with the transfer itself. Bytes and rate are exact (no estimated percent —
-  the archive is compressed on the fly, so a percent would lie).
+  with the transfer itself. File transfers show the Plan-measured size as a
+  soft ceiling (`1.2 GB of ~2.9 GB` — approximate because the archive
+  compresses in flight), and database pulls show a true percent (the dump
+  is staged and gzipped on the source first, so its final size is a fact).
 - **The clone wizard no longer jumps to DNS cutover on its own.** When the
   clone roster settles, the wizard now stays put so you can eyeball every
   site's final state — press `c` to continue to the cutover step (which moves

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,12 @@ versions; such changes are called out here.
   moved to `f`.
 - **In-flight clone stages show a live elapsed timer** in the roster, so a
   long file pull reads as working rather than frozen.
+- **File and database transfers show live byte progress** — the roster reads
+  `pull · files · 1.2 GB · 18 MB/s · 4m32s` while a transfer runs. Measured
+  by a read-only sidecar that stats the growing archive over its own SSH
+  session every few seconds, so the progress display can never interfere
+  with the transfer itself. Bytes and rate are exact (no estimated percent —
+  the archive is compressed on the fly, so a percent would lie).
 - **The clone wizard no longer jumps to DNS cutover on its own.** When the
   clone roster settles, the wizard now stays put so you can eyeball every
   site's final state — press `c` to continue to the cutover step (which moves

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,9 @@ versions; such changes are called out here.
 - **Every clone job now writes a full log** to `~/.config/spinupwp-tui/logs/`
   (one JSONL file per job: every remote script, exit code, and complete
   output, with passwords redacted). Previously errors were truncated to the
-  roster's width and lost when the app closed.
+  roster's width and lost when the app closed. Logs self-prune when a new
+  job starts: anything older than 30 days or beyond the 20 most recent job
+  logs is removed (copy a log elsewhere to keep it longer).
 - **Press `⏎` on a failed site in the clone roster** to see the full
   untruncated error, the failing step, and the log path — and `r` there
   retries just that site.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ versions; such changes are called out here.
 - **Cloned databases keep the source's table prefix** — the destination DB
   was previously always created with `wp_`, breaking sites with custom
   prefixes.
+- **Cloned sites now carry over the source's additional domains** (with their
+  redirect settings). A freshly created site only answers for its primary
+  domain, so `www.` and every extra hostname would have pointed at a server
+  that didn't serve them after DNS cutover. The wizard now re-creates the
+  full set on the destination right after the site is created — verified by
+  the destination's nginx `server_name` picking up every hostname.
 
 ### Added
 - **Every clone job now writes a full log** to `~/.config/spinupwp-tui/logs/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@ versions; such changes are called out here.
   full set on the destination right after the site is created — verified by
   the destination's nginx `server_name` picking up every hostname.
 
+### Fixed (during live migration hardening)
+- **Concurrent clones no longer sabotage each other's SSH.** The server-to-server
+  pull authenticated every site with one shared temporary key, so with three
+  sites in flight each site's setup/cleanup replaced or deleted the key the
+  others were actively using — at most one site per run could survive. Each
+  site now gets its own key, created and revoked independently.
+- **A file changing on the live source mid-transfer no longer kills the whole
+  site's clone.** tar reports "file changed as we read it" with a warning exit
+  code that was being treated as fatal — and the wizard's own flags suppressed
+  the message that would have explained it. Warnings are now tolerated (real
+  transfer errors still fail) and logged with the exact file named.
+
 ### Changed
 - **The clone wizard no longer jumps to DNS cutover on its own.** When the
   clone roster settles, the wizard now stays put so you can eyeball every

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,28 @@ terminal app for the SpinupWP API.
 - `bun run typecheck` — `tsc --noEmit`. Keep this green.
 - Must run under **Bun**, not Node — OpenTUI loads native code via Bun's FFI.
 
+## WordPress layout rules (deliberate product stance)
+
+These are NOT one user's personal habits — they encode well-known WordPress
+conventions that Spinup is deliberately opinionated about, to the point of helping
+establish best practice for everyone who uses the app. **Every feature that
+creates, moves, or reasons about WP site files must honor them** (clone wizard,
+future site-creation, maintenance tooling, …):
+
+- **`public_folder` is a *setting*, not a fact.** SpinupWP never moves files when a
+  public folder is configured — its UI warns users to move them by hand, so setting
+  and reality legitimately diverge. Code must **detect** the real WP dir
+  (`detectWpDirScript`/`planWebroot` in `src/lib/serverClone.ts`), never assume
+  `files/` or trust the setting alone.
+- **`public/`-style webroot ⇒ `wp-config.php` ONE directory above it** — the
+  long-standing WordPress hardening pattern (config outside the docroot), which is
+  the main reason to run a `public/` layout at all. Copying an existing tree
+  verbatim preserves whatever the site owner arranged; anything that *builds or
+  normalizes* a layout must place wp-config above the webroot itself (see
+  `normalizeWebrootScript`).
+- **Root webroot (`/`) ⇒ standard WP layout**: `wp-config.php` sits alongside core
+  in `files/`, exactly as a stock install ships. Never relocate it in that case.
+
 ## Testing the clone wizard
 
 Re-driving the server-clone wizard (`C`) against the dedicated test boxes

--- a/docs/clone-wizard-testing.md
+++ b/docs/clone-wizard-testing.md
@@ -114,6 +114,18 @@ proven (HTTP 200, clean source-key revoke); `blank`+`database` create; Plan sizi
   errors; `⏎` on a failed site shows the full error + the log path. Read the log
   before re-driving anything.
 
+- **The pull key must be PER SITE** (`/root/.clone_pull_<domain>` + per-domain
+  authorized_keys marker). A single shared key file + concurrency 3 meant each
+  site's auth stage regenerated it and each revoke deleted it — breaking every
+  other in-flight site's SSH mid-chain (proven live 2026-07-02: a db pull got
+  "Permission denied (publickey)" seconds after another site's auth replaced the
+  key; only ever ONE site per run survived, whichever ran unopposed).
+- **Remote tar exit 1 is a WARNING, not a failure.** Live sites change files
+  mid-read (every-minute WP cron + bot traffic; one growing log file suffices) →
+  GNU tar exits 1, and `--warning=no-file-changed` suppressed the message but NOT
+  the exit code — silent fatal "file pull failed". The files stage now tolerates
+  rc ≤ 1 and keeps tar's warnings unsuppressed so the clone log names the exact
+  file; ≥2 / 124 (timeout) / 255 (ssh) still fail hard.
 - **rsync-over-ssh HANGS** in the sudo transport → files use **tar-over-ssh**, the DB uses
   **cat-over-ssh**, each bounded with `timeout -k 5 N`.
 - Order is **files → re-stamp wp-config → db import** (import needs wp-config already

--- a/docs/clone-wizard-testing.md
+++ b/docs/clone-wizard-testing.md
@@ -118,7 +118,9 @@ proven (HTTP 200, clean source-key revoke); `blank`+`database` create; Plan sizi
 - **Every clone job writes a JSONL log** to `<configDir>/logs/clone-<ts>-<src>-to-<dst>.jsonl`
   (every sudo script + full stdout/stderr, passwords redacted). The roster truncates
   errors; `⏎` on a failed site shows the full error + the log path. Read the log
-  before re-driving anything.
+  before re-driving anything. Retention: swept when a new job's logger is created —
+  older than 30 days OR beyond the 20 newest job logs → deleted (copy a log
+  elsewhere to keep it).
 
 - **The pull key must be PER SITE** (`/root/.clone_pull_<domain>` + per-domain
   authorized_keys marker). A single shared key file + concurrency 3 meant each

--- a/docs/clone-wizard-testing.md
+++ b/docs/clone-wizard-testing.md
@@ -88,9 +88,15 @@ proven (HTTP 200, clean source-key revoke); `blank`+`database` create; Plan sizi
   `/public/` site — `pub.spinuptui.com` on web1 was created for exactly this (WP at
   files root + `/public/` setting = the mid-SOP state; a correct clone comes out
   *healed* and serving).
-- **`is_wordpress: false` non-git sites can't be cloned** (redirect shells, static
-  placeholders — no wp-config, often no DB). Plan now excludes them up front
-  (`cloneSiteSupported`); the toggle refuses to select them.
+- **`is_wordpress: false` non-git sites clone as FILES-ONLY** (stack `"files"`:
+  redirect shells, static/PHP sites — no DB, no wp-cli). Opt-in in Plan (default
+  deselected, tagged "files only"); dest is created blank with NO database block;
+  `runFilesOnlyPull` reuses the hardened tar transport (per-site key, tolerant
+  tar, 60-min budget, byte meter) minus all WP stages; `verifyFilesClone` compares
+  file count + total bytes (1% tolerance) + HTTP. Validated live web1→web2 with
+  `static.spinuptui.com` (fixture left in place; PHP executes on the clone).
+  Additional-domain carry-over applies as usual — that's the main event for
+  redirect shells.
 - **Dest DB `table_prefix` must match the source** (production uses `wzl_`, `s81_`,
   etc.) — the create payload now copies `database.table_prefix`.
 - **Additional domains must be re-created on the dest** — a fresh site's nginx

--- a/docs/clone-wizard-testing.md
+++ b/docs/clone-wizard-testing.md
@@ -93,6 +93,22 @@ proven (HTTP 200, clean source-key revoke); `blank`+`database` create; Plan sizi
   (`cloneSiteSupported`); the toggle refuses to select them.
 - **Dest DB `table_prefix` must match the source** (production uses `wzl_`, `s81_`,
   etc.) — the create payload now copies `database.table_prefix`.
+- **Additional domains must be re-created on the dest** — a fresh site's nginx
+  `server_name` holds ONLY the primary domain (verified on the test boxes), so
+  `www.` + extra hostnames would 404/default-vhost after cutover.
+  `syncAdditionalDomains` (`src/lib/cloneDomains.ts`) copies the source's set —
+  redirect settings included — right after the dest create; idempotent (skips
+  domains already present), so per-site retries are safe. Proof of success =
+  the dest's nginx `server_name` line; a `www` request answering 301 (WordPress
+  canonical redirect) means it's working.
+- **`DELETE /sites/{id}` orphans the SpinupWP database RECORD unless you pass
+  `delete_database=true`** (also `delete_backups=true`). An orphaned record —
+  even with the actual MySQL DB dropped by hand — makes any later create that
+  reuses the db name fail with a 422 ("already exists on this server"), and
+  orphaned records can only be removed in the SpinupWP web UI. When deleting
+  clone leftovers, always delete the database with the site. (web2 currently
+  has an orphaned `pubsite` DB record from learning this; the live fixture
+  clone uses `pubsite2`.)
 - **Every clone job writes a JSONL log** to `<configDir>/logs/clone-<ts>-<src>-to-<dst>.jsonl`
   (every sudo script + full stdout/stderr, passwords redacted). The roster truncates
   errors; `⏎` on a failed site shows the full error + the log path. Read the log

--- a/docs/clone-wizard-testing.md
+++ b/docs/clone-wizard-testing.md
@@ -70,6 +70,34 @@ proven (HTTP 200, clean source-key revoke); `blank`+`database` create; Plan sizi
 
 ## Hard-won lessons baked into the code (don't relearn)
 
+- **The webroot is DETECTED, never assumed.** The 2026-07-02 web2→mercury production
+  run failed all 6 sites because every long-lived Standard-WP site there uses
+  `/public/` while both test sites use `/`. And the `public_folder` *setting* can't be
+  trusted either: SpinupWP never moves files (the panel warns you to do it yourself —
+  the user's SOP), so setting and reality can disagree. The Standard-WP pull now runs
+  a `detect` stage on the source (`detectWpDirScript` — wp-settings.php is the core
+  marker), `planWebroot` decides the action (match → as-is; core at files root +
+  deeper setting → **normalize the dest**: sweep files under the configured folder
+  with **wp-config.php placed one level ABOVE the webroot** (the config-above-webroot
+  convention — a deliberate product stance, see CLAUDE.md "WordPress layout rules"),
+  completing the move-the-files step; subdirectory install → as-is; two custom dirs →
+  clear refusal),
+  and verify/sizing use the same detection. Local matrix test:
+  `layout-test.ts` pattern (fake trees + the exact bash fragments). Bedrock keeps
+  running wp-cli from the project root. Any new test coverage should include a
+  `/public/` site — `pub.spinuptui.com` on web1 was created for exactly this (WP at
+  files root + `/public/` setting = the mid-SOP state; a correct clone comes out
+  *healed* and serving).
+- **`is_wordpress: false` non-git sites can't be cloned** (redirect shells, static
+  placeholders — no wp-config, often no DB). Plan now excludes them up front
+  (`cloneSiteSupported`); the toggle refuses to select them.
+- **Dest DB `table_prefix` must match the source** (production uses `wzl_`, `s81_`,
+  etc.) — the create payload now copies `database.table_prefix`.
+- **Every clone job writes a JSONL log** to `<configDir>/logs/clone-<ts>-<src>-to-<dst>.jsonl`
+  (every sudo script + full stdout/stderr, passwords redacted). The roster truncates
+  errors; `⏎` on a failed site shows the full error + the log path. Read the log
+  before re-driving anything.
+
 - **rsync-over-ssh HANGS** in the sudo transport → files use **tar-over-ssh**, the DB uses
   **cat-over-ssh**, each bounded with `timeout -k 5 N`.
 - Order is **files → re-stamp wp-config → db import** (import needs wp-config already

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -13,6 +13,8 @@ import type {
   ProviderMetadata,
   CreateServerPayload,
   CreateSitePayload,
+  AdditionalDomain,
+  AddDomainPayload,
 } from "./types.ts"
 
 // The restartable services SpinupWP exposes (POST /servers/{id}/services/{svc}/restart).
@@ -203,6 +205,19 @@ export class SpinupWPClient {
   // enableHttps().
   createSite(payload: CreateSitePayload): Promise<{ event_id: number }> {
     return this.mutate<{ event_id: number }>("/sites", "POST", payload)
+  }
+
+  // Additional domains on a site (the extra hostnames nginx answers for). The
+  // clone wizard re-creates the source's set on the dest — a fresh site only
+  // serves its primary domain otherwise.
+  async listSiteDomains(siteId: number): Promise<AdditionalDomain[]> {
+    return this.listAll<AdditionalDomain>(`/sites/${siteId}/domains`)
+  }
+
+  // Add an additional domain to a site. Async (nginx reconfig) → returns an
+  // event_id to poll. Needs a Read/Write token.
+  addSiteDomain(siteId: number, payload: AddDomainPayload): Promise<{ event_id: number }> {
+    return this.mutate<{ event_id: number }>(`/sites/${siteId}/domains`, "POST", payload)
   }
 
   // Enable HTTPS on a site. `type: "webroot"` requests a Let's Encrypt cert (the

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -38,6 +38,35 @@ export interface ClientOptions {
 
 const MAX_PAGES = 100 // hard safety cap when auto-paginating
 
+// ---- Rate-limit awareness -------------------------------------------------
+// SpinupWP sends X-RateLimit-Remaining on every response (Laravel throttle,
+// 1-minute windows). All traffic funnels through fetchWithRateLimit below:
+// PROACTIVE pacing — when the window is nearly spent, spread the remaining
+// requests across what's left of it instead of slamming into the wall — plus
+// REACTIVE Retry-After backoff on 429 (safe to retry: a 429 was rejected before
+// any processing). Module-level so every client instance shares one budget.
+// Born from the 2026-07-02 prod clone retry, where three concurrent site workers'
+// event polling burned the window and made SUCCESSFUL operations look failed.
+let rlRemaining = Infinity
+let rlResetAt = 0
+const RL_LOW_WATER = 8 // start pacing when fewer than this many requests remain
+const RL_MAX_RETRIES = 3
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+function rlUpdate(headers: Headers): void {
+  const rem = Number(headers.get("x-ratelimit-remaining"))
+  if (Number.isFinite(rem)) rlRemaining = rem
+  // No reset header outside 429s — assume the standard 1-minute window rolls over.
+  if (rlResetAt < Date.now()) rlResetAt = Date.now() + 60_000
+}
+
+async function rlGate(): Promise<void> {
+  if (rlRemaining > RL_LOW_WATER) return
+  const windowLeft = Math.max(0, rlResetAt - Date.now())
+  const delay = rlRemaining <= 1 ? windowLeft : Math.ceil(windowLeft / Math.max(1, rlRemaining))
+  if (delay > 0) await sleep(delay + Math.random() * 300)
+}
+
 export class SpinupWPClient {
   private token: string
   private baseUrl: string
@@ -45,6 +74,30 @@ export class SpinupWPClient {
   constructor(opts: ClientOptions) {
     this.token = opts.token
     this.baseUrl = opts.baseUrl.replace(/\/+$/, "")
+  }
+
+  // Gate → fetch → learn from headers; on 429 wait out Retry-After (default 20s)
+  // and retry a few times before surfacing it. Network errors become ApiError(0).
+  private async fetchWithRateLimit(url: string, init: RequestInit): Promise<Response> {
+    for (let attempt = 0; ; attempt++) {
+      await rlGate()
+      let res: Response
+      try {
+        res = await fetch(url, init)
+      } catch (err) {
+        throw new ApiError(`Network error reaching the SpinupWP API: ${(err as Error).message}`, 0)
+      }
+      rlUpdate(res.headers)
+      if (res.status === 429 && attempt < RL_MAX_RETRIES) {
+        const ra = Number(res.headers.get("retry-after"))
+        const waitMs = (Number.isFinite(ra) && ra > 0 ? ra : 20) * 1000
+        rlRemaining = 0
+        rlResetAt = Date.now() + waitMs
+        await sleep(waitMs + Math.random() * 500)
+        continue
+      }
+      return res
+    }
   }
 
   private async request<T>(path: string, params?: Record<string, string | number | undefined>): Promise<T> {
@@ -55,21 +108,13 @@ export class SpinupWPClient {
       }
     }
 
-    let res: Response
-    try {
-      res = await fetch(url.toString(), {
-        headers: {
-          Authorization: `Bearer ${this.token}`,
-          Accept: "application/json",
-          "User-Agent": "spinupwp-tui",
-        },
-      })
-    } catch (err) {
-      throw new ApiError(
-        `Network error reaching the SpinupWP API: ${(err as Error).message}`,
-        0,
-      )
-    }
+    const res = await this.fetchWithRateLimit(url.toString(), {
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        Accept: "application/json",
+        "User-Agent": "spinupwp-tui",
+      },
+    })
 
     if (res.status === 401) {
       throw new ApiError("Unauthorized — your access token was rejected (401).", 401)
@@ -94,21 +139,16 @@ export class SpinupWPClient {
   // 403 into an actionable message. All other statuses mirror request().
   private async mutate<T>(path: string, method: string, body?: unknown): Promise<T> {
     const url = this.baseUrl + path
-    let res: Response
-    try {
-      res = await fetch(url, {
-        method,
-        headers: {
-          Authorization: `Bearer ${this.token}`,
-          Accept: "application/json",
-          "Content-Type": "application/json",
-          "User-Agent": "spinupwp-tui",
-        },
-        body: body === undefined ? undefined : JSON.stringify(body),
-      })
-    } catch (err) {
-      throw new ApiError(`Network error reaching the SpinupWP API: ${(err as Error).message}`, 0)
-    }
+    const res = await this.fetchWithRateLimit(url, {
+      method,
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        "User-Agent": "spinupwp-tui",
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    })
 
     if (res.status === 401) {
       throw new ApiError("Unauthorized — your access token was rejected (401).", 401)

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -156,6 +156,14 @@ export interface CreateServerPayload {
 // POST /sites. HTTPS is NOT a creation field — it's enabled afterward via
 // POST /sites/{id}/https (see SpinupWPClient.enableHttps). For a vanity/placeholder
 // site we use installation_method "blank" (empty docroot we drop an index.php into).
+// POST /sites/{id}/domains — add an additional domain (async, returns event_id).
+// redirect.type: 301/302/307/308 (defaults 301); redirect.destination defaults to
+// the site's primary domain.
+export interface AddDomainPayload {
+  domain: string
+  redirect?: { enabled?: boolean; type?: number; destination?: string }
+}
+
 export interface CreateSitePayload {
   server_id: number
   domain: string

--- a/src/lib/cloneDomains.ts
+++ b/src/lib/cloneDomains.ts
@@ -11,16 +11,20 @@ import type { AdditionalDomain } from "../api/types.ts"
 const EVENT_DONE = new Set(["deployed", "completed", "provisioned", "finished", "success"])
 const EVENT_FAIL = new Set(["failed", "errored", "error"])
 
-async function pollEvent(client: SpinupWPClient, eventId: number, timeoutMs = 120_000): Promise<boolean> {
+// 5s cadence; a transient failure to READ the event is not the event failing —
+// tolerate a few consecutive API errors (the client already absorbs 429 bursts).
+async function pollEvent(client: SpinupWPClient, eventId: number, timeoutMs = 180_000): Promise<boolean> {
   const deadline = Date.now() + timeoutMs
+  let apiErrs = 0
   while (Date.now() < deadline) {
-    await new Promise((r) => setTimeout(r, 3000))
+    await new Promise((r) => setTimeout(r, 5000))
     try {
       const e = await client.getEvent(eventId)
+      apiErrs = 0
       if (EVENT_FAIL.has(e.status)) return false
       if (EVENT_DONE.has(e.status) || e.finished_at) return true
     } catch {
-      return false
+      if (++apiErrs >= 3) return false
     }
   }
   return false
@@ -59,9 +63,21 @@ export async function syncAdditionalDomains(
         redirect: d.redirect ? { enabled: d.redirect.enabled, type: d.redirect.type, destination: d.redirect.destination } : undefined,
       })
       const ok = await pollEvent(client, ev.event_id)
-      if (ok) result.added.push(d.domain)
-      else result.failed.push({ domain: d.domain, error: "the add-domain event failed on SpinupWP" })
-      log?.({ event: "domain-add", destSiteId, domain: d.domain, ok })
+      if (ok) {
+        result.added.push(d.domain)
+        log?.({ event: "domain-add", destSiteId, domain: d.domain, eventId: ev.event_id, ok })
+      } else {
+        // Pull the event's own output so the roster/log say WHY, not just "failed".
+        let out = ""
+        try {
+          out = ((await client.getEvent(ev.event_id)).output ?? "").trim()
+        } catch {
+          /* best-effort */
+        }
+        const error = `add-domain event ${ev.event_id} failed${out ? `: …${out.slice(-200)}` : " on SpinupWP"}`
+        result.failed.push({ domain: d.domain, error })
+        log?.({ event: "domain-add", destSiteId, domain: d.domain, eventId: ev.event_id, ok, output: out })
+      }
     } catch (err) {
       const error = (err as Error).message
       result.failed.push({ domain: d.domain, error })

--- a/src/lib/cloneDomains.ts
+++ b/src/lib/cloneDomains.ts
@@ -1,0 +1,72 @@
+// Carry a site's additional domains onto its clone. A freshly created dest site
+// answers ONLY its primary domain (nginx server_name has nothing else — verified on
+// the test boxes), so without this step the DNS cutover would repoint www/extra
+// hostnames at a server that doesn't serve them. Redirect settings (enabled/type/
+// destination) are copied verbatim from the source. Idempotent: domains already on
+// the dest are skipped, so per-site retries re-run it safely.
+
+import type { SpinupWPClient } from "../api/client.ts"
+import type { AdditionalDomain } from "../api/types.ts"
+
+const EVENT_DONE = new Set(["deployed", "completed", "provisioned", "finished", "success"])
+const EVENT_FAIL = new Set(["failed", "errored", "error"])
+
+async function pollEvent(client: SpinupWPClient, eventId: number, timeoutMs = 120_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 3000))
+    try {
+      const e = await client.getEvent(eventId)
+      if (EVENT_FAIL.has(e.status)) return false
+      if (EVENT_DONE.has(e.status) || e.finished_at) return true
+    } catch {
+      return false
+    }
+  }
+  return false
+}
+
+export interface DomainSyncResult {
+  added: string[]
+  skipped: string[] // already present on the dest (retry path)
+  failed: { domain: string; error: string }[]
+}
+
+export async function syncAdditionalDomains(
+  client: SpinupWPClient,
+  destSiteId: number,
+  sourceDomains: AdditionalDomain[],
+  log?: (entry: Record<string, unknown>) => void,
+): Promise<DomainSyncResult> {
+  const result: DomainSyncResult = { added: [], skipped: [], failed: [] }
+  if (sourceDomains.length === 0) return result
+  // A failed listing falls back to "add everything" — a duplicate add errors
+  // per-domain and lands in `failed` with the API's message rather than hiding.
+  let existing = new Set<string>()
+  try {
+    existing = new Set((await client.listSiteDomains(destSiteId)).map((d) => d.domain))
+  } catch {
+    /* fall through */
+  }
+  for (const d of sourceDomains) {
+    if (existing.has(d.domain)) {
+      result.skipped.push(d.domain)
+      continue
+    }
+    try {
+      const ev = await client.addSiteDomain(destSiteId, {
+        domain: d.domain,
+        redirect: d.redirect ? { enabled: d.redirect.enabled, type: d.redirect.type, destination: d.redirect.destination } : undefined,
+      })
+      const ok = await pollEvent(client, ev.event_id)
+      if (ok) result.added.push(d.domain)
+      else result.failed.push({ domain: d.domain, error: "the add-domain event failed on SpinupWP" })
+      log?.({ event: "domain-add", destSiteId, domain: d.domain, ok })
+    } catch (err) {
+      const error = (err as Error).message
+      result.failed.push({ domain: d.domain, error })
+      log?.({ event: "domain-add", destSiteId, domain: d.domain, ok: false, error })
+    }
+  }
+  return result
+}

--- a/src/lib/cloneLog.ts
+++ b/src/lib/cloneLog.ts
@@ -1,0 +1,52 @@
+// Persistent clone-job logging (born from the 2026-07-02 web2→mercury failure,
+// where all six errors were truncated to 24 chars in the roster and lost when the
+// app closed). One JSONL file per clone job under <configDir>/logs/; every sudo
+// script the pull chains run is recorded with its full stdout/stderr so a failed
+// site can be diagnosed after the fact. Secrets (sudo + generated DB passwords)
+// are redacted before anything touches disk.
+
+import { appendFileSync, mkdirSync } from "node:fs"
+import { join } from "node:path"
+import { configDir } from "../config.ts"
+
+// Big outputs (composer, tar) are capped; keep the TAIL — errors come last.
+const FIELD_CAP = 16_000
+
+export class CloneLogger {
+  readonly path: string
+  private secrets: string[] = []
+
+  constructor(label: string) {
+    const dir = join(configDir(), "logs")
+    try {
+      mkdirSync(dir, { recursive: true })
+    } catch {
+      /* logging is best-effort */
+    }
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19)
+    const slug = label.replace(/[^a-zA-Z0-9.-]+/g, "_").slice(0, 60)
+    this.path = join(dir, `clone-${stamp}-${slug}.jsonl`)
+  }
+
+  // Register strings that must never reach disk (passwords). Call before log().
+  redact(...secrets: (string | undefined)[]): void {
+    for (const s of secrets) if (s && s.length >= 4 && !this.secrets.includes(s)) this.secrets.push(s)
+  }
+
+  private clean(v: unknown): unknown {
+    if (typeof v !== "string") return v
+    let s = v
+    for (const secret of this.secrets) s = s.split(secret).join("[redacted]")
+    return s.length > FIELD_CAP ? `…[${s.length - FIELD_CAP} chars trimmed]…${s.slice(-FIELD_CAP)}` : s
+  }
+
+  log(entry: Record<string, unknown>): void {
+    try {
+      const out: Record<string, unknown> = { ts: new Date().toISOString() }
+      for (const [k, v] of Object.entries(entry)) out[k] = this.clean(v)
+      appendFileSync(this.path, JSON.stringify(out) + "\n")
+    } catch {
+      /* never let logging break a clone */
+    }
+  }
+}

--- a/src/lib/cloneLog.ts
+++ b/src/lib/cloneLog.ts
@@ -5,12 +5,44 @@
 // site can be diagnosed after the fact. Secrets (sudo + generated DB passwords)
 // are redacted before anything touches disk.
 
-import { appendFileSync, mkdirSync } from "node:fs"
+import { appendFileSync, mkdirSync, readdirSync, statSync, unlinkSync } from "node:fs"
 import { join } from "node:path"
 import { configDir } from "../config.ts"
 
 // Big outputs (composer, tar) are capped; keep the TAIL — errors come last.
 const FIELD_CAP = 16_000
+
+// Retention: swept every time a new job's logger is created (the only moment the
+// app touches this dir), so nothing accumulates without a natural purge point. A
+// log survives only while it's BOTH younger than MAX_AGE and among the newest
+// MAX_LOGS. Copy a log elsewhere to keep it past retention.
+const MAX_AGE_DAYS = 30
+const MAX_LOGS = 20
+
+function pruneOldLogs(dir: string): void {
+  try {
+    const cutoff = Date.now() - MAX_AGE_DAYS * 24 * 60 * 60 * 1000
+    const logs = readdirSync(dir)
+      .filter((f) => f.startsWith("clone-") && f.endsWith(".jsonl"))
+      .map((f) => {
+        const path = join(dir, f)
+        return { path, mtime: statSync(path).mtimeMs }
+      })
+      .sort((a, b) => b.mtime - a.mtime)
+    for (const [i, l] of logs.entries()) {
+      // The new job's log is about to join — keep MAX_LOGS-1 existing at most.
+      if (l.mtime < cutoff || i >= MAX_LOGS - 1) {
+        try {
+          unlinkSync(l.path)
+        } catch {
+          /* best-effort */
+        }
+      }
+    }
+  } catch {
+    /* pruning must never break a clone */
+  }
+}
 
 export class CloneLogger {
   readonly path: string
@@ -23,6 +55,7 @@ export class CloneLogger {
     } catch {
       /* logging is best-effort */
     }
+    pruneOldLogs(dir)
     const stamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19)
     const slug = label.replace(/[^a-zA-Z0-9.-]+/g, "_").slice(0, 60)
     this.path = join(dir, `clone-${stamp}-${slug}.jsonl`)

--- a/src/lib/serverClone.ts
+++ b/src/lib/serverClone.ts
@@ -68,6 +68,11 @@ export interface SiteSizeInput {
   siteUser: string
   publicFolder?: string // wp-cli runs from files<public_folder> (files/ when "/")
 }
+export interface SiteSizeEstimate {
+  web: number // webroot bytes (uncompressed du) — the files-transfer soft ceiling
+  db: number
+  total: number
+}
 
 // Estimate each source site's payload (webroot bytes + DB bytes) in ONE round trip.
 // Webroot via `du -sb /sites/<domain>/files`; DB via `wp db size --size_format=b`
@@ -78,7 +83,7 @@ export async function estimateSourceSiteSizes(
   sudoUser: string,
   sudoPassword: string,
   sites: SiteSizeInput[],
-): Promise<Map<number, number>> {
+): Promise<Map<number, SiteSizeEstimate>> {
   if (sites.length === 0) return new Map()
   const lines = sites.map((s) => {
     const root = `/sites/${s.domain}/files`
@@ -90,14 +95,15 @@ export async function estimateSourceSiteSizes(
     ].join("; ")
   })
   const res = await sudoExec(server, sudoUser, sudoPassword, lines.join("\n"), 120_000)
-  const out = new Map<number, number>()
+  const out = new Map<number, SiteSizeEstimate>()
   if (!res.ok) return out
   for (const line of res.stdout.split("\n")) {
     const m = line.trim().match(/^(\d+)\s+(\d+)\s+(\d+)$/)
     if (!m) continue
     const id = Number(m[1])
-    const total = Number(m[2]) + Number(m[3])
-    if (total > 0) out.set(id, total)
+    const web = Number(m[2])
+    const db = Number(m[3])
+    if (web + db > 0) out.set(id, { web, db, total: web + db })
   }
   return out
 }
@@ -141,7 +147,11 @@ export type CloneExecLog = (e: CloneExecRecord) => void
 // over its own SSH session every few seconds — reads exact bytes-so-far without
 // touching the transfer pipeline (progress display must never be able to break a
 // transfer). Best-effort: a failed poll is silently skipped.
-export type CloneTransfer = (stage: CloneStage, bytes: number) => void
+// `target` is the expected final size when known; `exact` distinguishes a true
+// percent (the DB dump is staged+gzipped BEFORE the pull, so its size is a fact)
+// from a soft ceiling (files stream gzip-compressed, so the uncompressed du size
+// only bounds the transfer — a percent against it would lie).
+export type CloneTransfer = (stage: CloneStage, bytes: number, target?: number, exact?: boolean) => void
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
 
@@ -233,6 +243,7 @@ export interface StandardWpPullSpec {
   destDbUser: string
   destDbPassword: string
   publicFolder?: string // source site's public_folder (dest is created with the same)
+  approxFilesBytes?: number // Plan's uncompressed webroot size — soft ceiling for the files meter
 }
 
 // The ephemeral pull key and its authorized_keys marker are PER SITE. They were
@@ -323,7 +334,7 @@ export async function runStandardWpPull(
     // may sit in the webroot OR one level above it, so the assertion accepts either.
     onProgress("files", "start")
     const normalize = plan.normalize ? `${normalizeWebrootScript(root, destWpDir)}; ` : ""
-    const stopFilesPoll = pollTransferSize(dest, `/tmp/clone_${spec.domain}.tgz`, (b) => onTransfer?.("files", b))
+    const stopFilesPoll = pollTransferSize(dest, `/tmp/clone_${spec.domain}.tgz`, (b) => onTransfer?.("files", b, spec.approxFilesBytes, false))
     // wp-config.php may live in the webroot or one level above it (the
     // config-above-webroot convention — see CLAUDE.md); never above files/.
     const cfgDirs = [...new Set([destWpDir, destWpDir.slice(0, destWpDir.lastIndexOf("/")), root])].filter((d) => d.length >= root.length)
@@ -360,11 +371,13 @@ export async function runStandardWpPull(
     const dump = await run(
       "db",
       source,
-      `sudo -u ${shq(su)} -H bash -c "cd ${shq(srcWpDir)} && wp --skip-plugins --skip-themes db export ${shq(home)}/.clone_db.sql 2>/dev/null && gzip -f ${shq(home)}/.clone_db.sql"`,
+      `sudo -u ${shq(su)} -H bash -c "cd ${shq(srcWpDir)} && wp --skip-plugins --skip-themes db export ${shq(home)}/.clone_db.sql 2>/dev/null && gzip -f ${shq(home)}/.clone_db.sql && stat -c %s ${shq(home)}/.clone_db.sql.gz"`,
       900_000,
     )
     if (!dump.ok) return fail("db", dump.stderr.trim() || "source db export failed")
-    const stopDbPoll = pollTransferSize(dest, `/tmp/clone_${spec.domain}.sql.gz`, (b) => onTransfer?.("db", b))
+    // The staged dump's size is exact — the db meter gets a true percent.
+    const dbTarget = Number(dump.stdout.trim().match(/(\d+)\s*$/)?.[1]) || undefined
+    const stopDbPoll = pollTransferSize(dest, `/tmp/clone_${spec.domain}.sql.gz`, (b) => onTransfer?.("db", b, dbTarget, true))
     const imp = await run(
       "db",
       dest,
@@ -522,11 +535,12 @@ export async function runBedrockPull(
     const dump = await run(
       "db",
       source,
-      `sudo -u ${shq(su)} -H bash -c "cd ${shq(root)} && wp --skip-plugins --skip-themes db export ${shq(home)}/.clone_db.sql 2>/dev/null && gzip -f ${shq(home)}/.clone_db.sql"`,
+      `sudo -u ${shq(su)} -H bash -c "cd ${shq(root)} && wp --skip-plugins --skip-themes db export ${shq(home)}/.clone_db.sql 2>/dev/null && gzip -f ${shq(home)}/.clone_db.sql && stat -c %s ${shq(home)}/.clone_db.sql.gz"`,
       900_000,
     )
     if (!dump.ok) return fail("db", dump.stderr.trim() || "source db export failed")
-    const stopDbPoll = pollTransferSize(dest, `${tmp}.sql.gz`, (b) => onTransfer?.("db", b))
+    const dbTarget = Number(dump.stdout.trim().match(/(\d+)\s*$/)?.[1]) || undefined
+    const stopDbPoll = pollTransferSize(dest, `${tmp}.sql.gz`, (b) => onTransfer?.("db", b, dbTarget, true))
     const imp = await run(
       "db",
       dest,

--- a/src/lib/serverClone.ts
+++ b/src/lib/serverClone.ts
@@ -208,8 +208,17 @@ export interface StandardWpPullSpec {
   publicFolder?: string // source site's public_folder (dest is created with the same)
 }
 
-const CLONE_KEY = "/root/.clone_pull"
-const KEY_MARKER = "spinup-clone-pull"
+// The ephemeral pull key and its authorized_keys marker are PER SITE. They were
+// once a single shared /root/.clone_pull — with concurrent sites each auth stage
+// regenerated it and each revoke deleted it, breaking every other in-flight site's
+// SSH mid-chain (proven live 2026-07-02: one site's db pull got Permission denied
+// seconds after another site's auth replaced the key).
+function cloneKeyFor(domain: string): string {
+  return `/root/.clone_pull_${domain}`
+}
+function keyMarkerFor(domain: string): string {
+  return `spinup-clone-pull-${domain}`
+}
 
 function exec(ctx: SudoCtx, script: string, timeoutMs = 600_000) {
   return sudoExec(ctx.server, ctx.sudoUser, ctx.sudoPassword, script, timeoutMs)
@@ -238,7 +247,9 @@ export async function runStandardWpPull(
   const expRel = publicFolderRel(spec.publicFolder) // configured layout — nginx's root on both ends
   const su = spec.sourceSiteUser
   const du = spec.destSiteUser
-  const sshk = `ssh -i ${CLONE_KEY} -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=10`
+  const KEY = cloneKeyFor(spec.domain)
+  const MARKER = keyMarkerFor(spec.domain)
+  const sshk = `ssh -i ${KEY} -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=10`
   const fail = (stage: CloneStage, msg: string) => {
     onProgress(stage, "fail", msg)
     return { ok: false as const, error: `${stage}: ${msg}` }
@@ -265,7 +276,7 @@ export async function runStandardWpPull(
   try {
     // 1. auth — ephemeral key on dest, granted onto the source site user.
     onProgress("auth", "start")
-    const gen = await run("auth", dest, `rm -f ${CLONE_KEY} ${CLONE_KEY}.pub; ssh-keygen -t ed25519 -f ${CLONE_KEY} -N "" -C ${KEY_MARKER} >/dev/null 2>&1 && cat ${CLONE_KEY}.pub`, 30_000)
+    const gen = await run("auth", dest, `rm -f ${KEY} ${KEY}.pub; ssh-keygen -t ed25519 -f ${KEY} -N "" -C ${MARKER} >/dev/null 2>&1 && cat ${KEY}.pub`, 30_000)
     const pub = gen.stdout.trim()
     if (!gen.ok || !pub.startsWith("ssh-")) return fail("auth", gen.stderr.trim() || "couldn't generate pull key")
     const grant = await run(
@@ -288,10 +299,14 @@ export async function runStandardWpPull(
     // config-above-webroot convention — see CLAUDE.md); never above files/.
     const cfgDirs = [...new Set([destWpDir, destWpDir.slice(0, destWpDir.lastIndexOf("/")), root])].filter((d) => d.length >= root.length)
     const cfgAssert = cfgDirs.map((d) => `test -f ${shq(`${d}/wp-config.php`)}`).join(" || ")
+    // tar exit 1 = "some files differ" (a live site touched a file mid-read —
+    // every-minute WP cron + bot traffic make this routine); tolerate it but fail
+    // on >=2 (real tar errors), 124 (timeout), 255 (ssh). No --warning suppression:
+    // the which-file-changed diagnostics belong in the clone log.
     const files = await run(
       "files",
       dest,
-      `set -e; timeout -k 5 900 ${sshk} ${shq(su)}@${srcIp} "tar -C ${shq(root)} --warning=no-file-changed -czf - --exclude=wp-content/cache ." </dev/null > /tmp/clone_${spec.domain}.tgz; tar -C ${shq(root)} -xzf /tmp/clone_${spec.domain}.tgz; rm -f /tmp/clone_${spec.domain}.tgz; ${normalize}chown -R ${shq(du)}:${shq(du)} ${shq(root)}; test -f ${shq(destWpDir)}/wp-settings.php || { echo "no WordPress core at ${destWpDir} after pull" >&2; exit 65; }; ${cfgAssert} || { echo "no wp-config.php in the webroot or one level above it (under ${root})" >&2; exit 65; }`,
+      `set -e; rc=0; timeout -k 5 900 ${sshk} ${shq(su)}@${srcIp} "tar -C ${shq(root)} -czf - --exclude=wp-content/cache ." </dev/null > /tmp/clone_${spec.domain}.tgz || rc=$?; [ "$rc" -le 1 ] || { echo "tar-over-ssh failed with exit $rc" >&2; exit "$rc"; }; tar -C ${shq(root)} -xzf /tmp/clone_${spec.domain}.tgz; rm -f /tmp/clone_${spec.domain}.tgz; ${normalize}chown -R ${shq(du)}:${shq(du)} ${shq(root)}; test -f ${shq(destWpDir)}/wp-settings.php || { echo "no WordPress core at ${destWpDir} after pull" >&2; exit 65; }; ${cfgAssert} || { echo "no wp-config.php in the webroot or one level above it (under ${root})" >&2; exit 65; }`,
       900_000,
     )
     if (!files.ok) return fail("files", files.stderr.trim() || "file pull failed")
@@ -342,8 +357,8 @@ export async function runStandardWpPull(
     // sed (not grep -v): grep returns exit 1 when it filters out the only line, which
     // would skip the rewrite and leave the key behind — exactly the case where the
     // source site user has no other keys.
-    await run("revoke", source, `AK=${shq(home)}/.ssh/authorized_keys; [ -f "$AK" ] && sed -i ${shq(`/${KEY_MARKER}/d`)} "$AK" && chown ${shq(su)}:${shq(su)} "$AK"; rm -f ${shq(home)}/.clone_db.sql.gz`, 30_000).catch(() => {})
-    await run("revoke", dest, `rm -f ${CLONE_KEY} ${CLONE_KEY}.pub /tmp/clone_${spec.domain}.tgz /tmp/clone_${spec.domain}.sql.gz /tmp/clone_${spec.domain}.sql`, 30_000).catch(() => {})
+    await run("revoke", source, `AK=${shq(home)}/.ssh/authorized_keys; [ -f "$AK" ] && sed -i ${shq(`/${MARKER}/d`)} "$AK" && chown ${shq(su)}:${shq(su)} "$AK"; rm -f ${shq(home)}/.clone_db.sql.gz`, 30_000).catch(() => {})
+    await run("revoke", dest, `rm -f ${KEY} ${KEY}.pub /tmp/clone_${spec.domain}.tgz /tmp/clone_${spec.domain}.sql.gz /tmp/clone_${spec.domain}.sql`, 30_000).catch(() => {})
     onProgress("revoke", "ok")
   }
 }
@@ -382,7 +397,9 @@ export async function runBedrockPull(
   const su = spec.sourceSiteUser
   const du = spec.destSiteUser
   const tmp = `/tmp/clone_${spec.domain}`
-  const sshk = `ssh -i ${CLONE_KEY} -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=10`
+  const KEY = cloneKeyFor(spec.domain)
+  const MARKER = keyMarkerFor(spec.domain)
+  const sshk = `ssh -i ${KEY} -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=10`
   const remote = (cmd: string) => `${sshk} ${shq(su)}@${srcIp} ${shq(cmd)} </dev/null`
   const fail = (stage: CloneStage, msg: string) => {
     onProgress(stage, "fail", msg)
@@ -398,7 +415,7 @@ export async function runBedrockPull(
   try {
     // 1. auth — ephemeral key on dest, granted onto the source site user.
     onProgress("auth", "start")
-    const gen = await run("auth", dest, `rm -f ${CLONE_KEY} ${CLONE_KEY}.pub; ssh-keygen -t ed25519 -f ${CLONE_KEY} -N "" -C ${KEY_MARKER} >/dev/null 2>&1 && cat ${CLONE_KEY}.pub`, 30_000)
+    const gen = await run("auth", dest, `rm -f ${KEY} ${KEY}.pub; ssh-keygen -t ed25519 -f ${KEY} -N "" -C ${MARKER} >/dev/null 2>&1 && cat ${KEY}.pub`, 30_000)
     const pub = gen.stdout.trim()
     if (!gen.ok || !pub.startsWith("ssh-")) return fail("auth", gen.stderr.trim() || "couldn't generate pull key")
     const grant = await run(
@@ -493,8 +510,8 @@ export async function runBedrockPull(
   } finally {
     // 7. revoke — drop the pull key (by marker) on source, clean dest temp + staged dump.
     onProgress("revoke", "start")
-    await run("revoke", source, `AK=${shq(home)}/.ssh/authorized_keys; [ -f "$AK" ] && sed -i ${shq(`/${KEY_MARKER}/d`)} "$AK" && chown ${shq(su)}:${shq(su)} "$AK"; rm -f ${shq(home)}/.clone_db.sql.gz`, 30_000).catch(() => {})
-    await run("revoke", dest, `rm -f ${CLONE_KEY} ${CLONE_KEY}.pub ${tmp}_auth.json ${tmp}_up.tgz ${tmp}_env ${tmp}.sql.gz ${tmp}.sql`, 30_000).catch(() => {})
+    await run("revoke", source, `AK=${shq(home)}/.ssh/authorized_keys; [ -f "$AK" ] && sed -i ${shq(`/${MARKER}/d`)} "$AK" && chown ${shq(su)}:${shq(su)} "$AK"; rm -f ${shq(home)}/.clone_db.sql.gz`, 30_000).catch(() => {})
+    await run("revoke", dest, `rm -f ${KEY} ${KEY}.pub ${tmp}_auth.json ${tmp}_up.tgz ${tmp}_env ${tmp}.sql.gz ${tmp}.sql`, 30_000).catch(() => {})
     onProgress("revoke", "ok")
   }
 }

--- a/src/lib/serverClone.ts
+++ b/src/lib/serverClone.ts
@@ -66,12 +66,13 @@ export interface SiteSizeInput {
   siteId: number
   domain: string
   siteUser: string
+  publicFolder?: string // wp-cli runs from files<public_folder> (files/ when "/")
 }
 
 // Estimate each source site's payload (webroot bytes + DB bytes) in ONE round trip.
 // Webroot via `du -sb /sites/<domain>/files`; DB via `wp db size --size_format=b`
-// run as the site user from that dir (wp-cli.yml resolves Bedrock's web/wp path and
-// reads .env). Sites whose probe fails are simply omitted from the map.
+// run as the site user from the site's WP dir (wp-cli.yml resolves Bedrock's web/wp
+// path and reads .env). Sites whose probe fails are simply omitted from the map.
 export async function estimateSourceSiteSizes(
   server: Server,
   sudoUser: string,
@@ -82,9 +83,9 @@ export async function estimateSourceSiteSizes(
   const lines = sites.map((s) => {
     const root = `/sites/${s.domain}/files`
     return [
-      `D=${shq(root)}`,
+      detectWpDirScript(root, s.publicFolder), // sets D (files root) + W (real WP dir, may be empty)
       `wb=$(du -sb "$D" 2>/dev/null | cut -f1)`,
-      `db=$(cd "$D" 2>/dev/null && sudo -u ${shq(s.siteUser)} -H wp db size --size_format=b 2>/dev/null | tr -dc 0-9)`,
+      `db=$(cd "$W" 2>/dev/null && sudo -u ${shq(s.siteUser)} -H wp db size --size_format=b 2>/dev/null | tr -dc 0-9)`,
       `echo "${s.siteId} \${wb:-0} \${db:-0}"`,
     ].join("; ")
   })
@@ -117,8 +118,85 @@ export interface SudoCtx {
   sudoUser: string
   sudoPassword: string
 }
-export type CloneStage = "auth" | "build" | "files" | "config" | "db" | "verify" | "revoke"
+export type CloneStage = "detect" | "auth" | "build" | "files" | "config" | "db" | "verify" | "revoke"
 export type CloneProgress = (stage: CloneStage, status: "start" | "ok" | "fail", detail?: string) => void
+
+// Every sudo script a pull chain runs, reported to the caller for persistent
+// logging (the roster truncates errors; the log keeps the full stdout/stderr).
+export interface CloneExecRecord {
+  domain: string
+  stage: CloneStage
+  host: string // which end ran it (source/dest server name)
+  ok: boolean
+  code: number
+  ms: number
+  script: string
+  stdout: string
+  stderr: string
+}
+export type CloneExecLog = (e: CloneExecRecord) => void
+
+// ---- Webroot: configured vs REAL ------------------------------------------
+//
+// SpinupWP's public_folder is a *setting* (nginx root = files<public_folder>) — the
+// panel never moves files (its UI warns users to move them by hand), so where
+// WordPress ACTUALLY lives is a separate fact. The 2026-07-02 web2→mercury failure
+// taught us not to hardcode files/; trusting the setting alone is the same trap one
+// level up. So the pull chain DETECTS the real WP dir on the source (wp-settings.php
+// is the core marker) and, on the dest, normalizes the tree so the files sit where
+// the configured public folder expects them — completing the move-the-files step
+// SpinupWP leaves to users, instead of cloning a 404.
+
+// "/public/" → "public", "/" or undefined → "" (relative to files/).
+export function publicFolderRel(publicFolder?: string): string {
+  return (publicFolder ?? "/").replace(/^\/+|\/+$/g, "")
+}
+function webrootFor(root: string, publicFolder?: string): string {
+  const pf = publicFolderRel(publicFolder)
+  return pf ? `${root}/${pf}` : root
+}
+
+// Bash fragment: set W to the dir under $D (the files root) that holds
+// wp-settings.php — configured-candidate first, then the root, then a bounded find.
+// Leaves W empty when no WordPress core exists. Exported for the test harness.
+export function detectWpDirScript(root: string, publicFolder?: string): string {
+  const candidate = webrootFor(root, publicFolder)
+  return [
+    `D=${shq(root)}; W=""`,
+    `[ -f ${shq(candidate)}/wp-settings.php ] && W=${shq(candidate)}`,
+    `[ -z "$W" ] && [ -f "$D/wp-settings.php" ] && W="$D"`,
+    `[ -z "$W" ] && { F=$(find "$D" -maxdepth 3 -name wp-settings.php -not -path "*/wp-content/*" -print -quit 2>/dev/null); [ -n "$F" ] && W=$(dirname "$F"); }`,
+  ].join("; ")
+}
+
+// Bash fragment: sweep everything under `root` into `destWpDir` (the configured
+// public folder) — the move-the-files step SpinupWP leaves to users. wp-config.php
+// is then placed ONE LEVEL ABOVE the webroot: WordPress's long-standing config-
+// outside-the-docroot hardening, the whole point of a public/ layout, and a
+// deliberate product stance (see CLAUDE.md "WordPress layout rules"). Root-webroot
+// sites never reach this path — their config stays alongside core. Idempotent: a
+// tree that already has core at destWpDir is left alone. Exported for the test harness.
+export function normalizeWebrootScript(root: string, destWpDir: string): string {
+  const parent = destWpDir.slice(0, destWpDir.lastIndexOf("/"))
+  return `if [ ! -f ${shq(destWpDir)}/wp-settings.php ]; then cd ${shq(root)}; rm -rf .spinup_normalize; mkdir .spinup_normalize; find . -mindepth 1 -maxdepth 1 ! -name .spinup_normalize -exec mv {} .spinup_normalize/ \\; ; mkdir -p ${shq(destWpDir)}; find .spinup_normalize -mindepth 1 -maxdepth 1 -exec mv {} ${shq(destWpDir)}/ \\; ; rmdir .spinup_normalize; if [ -f ${shq(destWpDir)}/wp-config.php ]; then mv ${shq(destWpDir)}/wp-config.php ${shq(parent)}/wp-config.php; fi; fi`
+}
+
+// Decide what the clone does about the webroot, from the DETECTED source layout vs
+// the CONFIGURED public folder (both relative to files/, "" = files root):
+//   • match → clone as-is.
+//   • detected at root, setting deeper → the mid-move SOP state: normalize the dest
+//     (sweep files under the setting) so nginx serves the clone.
+//   • detected deeper, setting at root → a subdirectory install (root index.php
+//     bootstraps core in a subfolder) — a working layout; clone as-is, wp-cli runs
+//     from the core dir.
+//   • two different non-root dirs → too custom to guess; refuse with a clear error.
+// Exported (pure) for the test harness.
+export function planWebroot(detectedRel: string, configuredRel: string): { destRel: string; normalize: boolean } | { error: string } {
+  if (detectedRel === configuredRel) return { destRel: detectedRel, normalize: false }
+  if (detectedRel === "") return { destRel: configuredRel, normalize: true }
+  if (configuredRel === "") return { destRel: detectedRel, normalize: false }
+  return { error: `WordPress lives at files/${detectedRel} on the source but the public folder setting is /${configuredRel}/ — can't auto-normalize; align them in SpinupWP (or move the files) and retry` }
+}
 
 export interface StandardWpPullSpec {
   domain: string
@@ -127,6 +205,7 @@ export interface StandardWpPullSpec {
   destDbName: string
   destDbUser: string
   destDbPassword: string
+  publicFolder?: string // source site's public_folder (dest is created with the same)
 }
 
 const CLONE_KEY = "/root/.clone_pull"
@@ -141,15 +220,22 @@ function exec(ctx: SudoCtx, script: string, timeoutMs = 600_000) {
 // wp-config re-stamped to the dest DB. Verifies `wp core is-installed`; the HTTP
 // `--resolve` check is the caller's (it knows the dest IP). The granted pull key is
 // always revoked (best-effort) before returning.
+//
+// Webroot handling: the REAL source WP dir is detected (stage 0), all source-side
+// wp-cli runs there; planWebroot decides whether the dest tree is normalized to the
+// CONFIGURED public folder (stage 2); all dest-side wp-cli runs from the resulting
+// dir. The result reports both layouts (`sourceWebrootRel`/`destWebrootRel`) for verify.
 export async function runStandardWpPull(
   source: SudoCtx,
   dest: SudoCtx,
   spec: StandardWpPullSpec,
   onProgress: CloneProgress = () => {},
-): Promise<{ ok: boolean; error?: string }> {
+  onExec?: CloneExecLog,
+): Promise<{ ok: boolean; error?: string; sourceWebrootRel?: string; destWebrootRel?: string }> {
   const srcIp = source.server.ip_address ?? ""
   const root = `/sites/${spec.domain}/files`
   const home = `/sites/${spec.domain}`
+  const expRel = publicFolderRel(spec.publicFolder) // configured layout — nginx's root on both ends
   const su = spec.sourceSiteUser
   const du = spec.destSiteUser
   const sshk = `ssh -i ${CLONE_KEY} -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=10`
@@ -157,14 +243,33 @@ export async function runStandardWpPull(
     onProgress(stage, "fail", msg)
     return { ok: false as const, error: `${stage}: ${msg}` }
   }
+  const run = async (stage: CloneStage, ctx: SudoCtx, script: string, timeoutMs?: number) => {
+    const t0 = Date.now()
+    const r = await exec(ctx, script, timeoutMs)
+    onExec?.({ domain: spec.domain, stage, host: ctx.server.name, ok: r.ok, code: r.code, ms: Date.now() - t0, script, stdout: r.stdout, stderr: r.stderr })
+    return r
+  }
+
+  // 0. detect — find the REAL WP dir on the source (setting and reality can
+  // disagree; SpinupWP never moves files). Fails fast before any key is granted.
+  onProgress("detect", "start")
+  const det = await run("detect", source, `${detectWpDirScript(root, spec.publicFolder)}; echo "WPDIR:$W"`, 30_000)
+  const srcWpDir = (det.stdout.match(/^WPDIR:(.*)$/m)?.[1] ?? "").trim()
+  if (!det.ok || !srcWpDir) return fail("detect", det.stderr.trim() || `no WordPress core (wp-settings.php) found under ${root} — is this a WordPress site?`)
+  const srcRel = srcWpDir === root ? "" : srcWpDir.startsWith(`${root}/`) ? srcWpDir.slice(root.length + 1) : ""
+  const plan = planWebroot(srcRel, expRel)
+  if ("error" in plan) return fail("detect", plan.error)
+  const destWpDir = plan.destRel ? `${root}/${plan.destRel}` : root
+  onProgress("detect", "ok", srcRel ? `files/${srcRel}` : "files/")
 
   try {
     // 1. auth — ephemeral key on dest, granted onto the source site user.
     onProgress("auth", "start")
-    const gen = await exec(dest, `rm -f ${CLONE_KEY} ${CLONE_KEY}.pub; ssh-keygen -t ed25519 -f ${CLONE_KEY} -N "" -C ${KEY_MARKER} >/dev/null 2>&1 && cat ${CLONE_KEY}.pub`, 30_000)
+    const gen = await run("auth", dest, `rm -f ${CLONE_KEY} ${CLONE_KEY}.pub; ssh-keygen -t ed25519 -f ${CLONE_KEY} -N "" -C ${KEY_MARKER} >/dev/null 2>&1 && cat ${CLONE_KEY}.pub`, 30_000)
     const pub = gen.stdout.trim()
     if (!gen.ok || !pub.startsWith("ssh-")) return fail("auth", gen.stderr.trim() || "couldn't generate pull key")
-    const grant = await exec(
+    const grant = await run(
+      "auth",
       source,
       `set -e; SSHDIR=${shq(home)}/.ssh; AK=$SSHDIR/authorized_keys; install -d -m 700 -o ${shq(su)} -g ${shq(su)} "$SSHDIR"; touch "$AK"; chown ${shq(su)}:${shq(su)} "$AK"; chmod 600 "$AK"; grep -qxF ${shq(pub)} "$AK" || echo ${shq(pub)} >> "$AK"`,
       30_000,
@@ -172,37 +277,52 @@ export async function runStandardWpPull(
     if (!grant.ok) return fail("auth", grant.stderr.trim() || "couldn't grant pull key on source")
     onProgress("auth", "ok")
 
-    // 2. files — tar-over-ssh pull → extract → chown.
+    // 2. files — tar-over-ssh pull → extract → normalize → chown. When the source
+    // keeps WP at the files root but the public folder setting is deeper (the
+    // mid-move SOP state), the dest tree is swept under the configured folder so
+    // nginx (rooted at files<public_folder>) actually serves the clone. wp-config.php
+    // may sit in the webroot OR one level above it, so the assertion accepts either.
     onProgress("files", "start")
-    const files = await exec(
+    const normalize = plan.normalize ? `${normalizeWebrootScript(root, destWpDir)}; ` : ""
+    // wp-config.php may live in the webroot or one level above it (the
+    // config-above-webroot convention — see CLAUDE.md); never above files/.
+    const cfgDirs = [...new Set([destWpDir, destWpDir.slice(0, destWpDir.lastIndexOf("/")), root])].filter((d) => d.length >= root.length)
+    const cfgAssert = cfgDirs.map((d) => `test -f ${shq(`${d}/wp-config.php`)}`).join(" || ")
+    const files = await run(
+      "files",
       dest,
-      `set -e; timeout -k 5 900 ${sshk} ${shq(su)}@${srcIp} "tar -C ${shq(root)} --warning=no-file-changed -czf - --exclude=wp-content/cache ." </dev/null > /tmp/clone_${spec.domain}.tgz; tar -C ${shq(root)} -xzf /tmp/clone_${spec.domain}.tgz; rm -f /tmp/clone_${spec.domain}.tgz; chown -R ${shq(du)}:${shq(du)} ${shq(root)}; test -f ${shq(root)}/wp-config.php`,
+      `set -e; timeout -k 5 900 ${sshk} ${shq(su)}@${srcIp} "tar -C ${shq(root)} --warning=no-file-changed -czf - --exclude=wp-content/cache ." </dev/null > /tmp/clone_${spec.domain}.tgz; tar -C ${shq(root)} -xzf /tmp/clone_${spec.domain}.tgz; rm -f /tmp/clone_${spec.domain}.tgz; ${normalize}chown -R ${shq(du)}:${shq(du)} ${shq(root)}; test -f ${shq(destWpDir)}/wp-settings.php || { echo "no WordPress core at ${destWpDir} after pull" >&2; exit 65; }; ${cfgAssert} || { echo "no wp-config.php in the webroot or one level above it (under ${root})" >&2; exit 65; }`,
       900_000,
     )
     if (!files.ok) return fail("files", files.stderr.trim() || "file pull failed")
     onProgress("files", "ok")
 
-    // 3. config — re-stamp DB creds to the dest's.
+    // 3. config — re-stamp DB creds to the dest's. Run from the dest WP dir: wp-cli
+    // walks up to find wp-config.php, covering both layouts.
     onProgress("config", "start")
-    const cfg = await exec(
+    const cfg = await run(
+      "config",
       dest,
-      `set -e; cd ${shq(root)}; sudo -u ${shq(du)} -H wp config set DB_NAME ${shq(spec.destDbName)} --type=constant >/dev/null; sudo -u ${shq(du)} -H wp config set DB_USER ${shq(spec.destDbUser)} --type=constant >/dev/null; sudo -u ${shq(du)} -H wp config set DB_PASSWORD ${shq(spec.destDbPassword)} --type=constant >/dev/null; sudo -u ${shq(du)} -H wp db check >/dev/null 2>&1`,
+      `set -e; cd ${shq(destWpDir)}; sudo -u ${shq(du)} -H wp config set DB_NAME ${shq(spec.destDbName)} --type=constant >/dev/null; sudo -u ${shq(du)} -H wp config set DB_USER ${shq(spec.destDbUser)} --type=constant >/dev/null; sudo -u ${shq(du)} -H wp config set DB_PASSWORD ${shq(spec.destDbPassword)} --type=constant >/dev/null; sudo -u ${shq(du)} -H wp db check >/dev/null`,
       60_000,
     )
     if (!cfg.ok) return fail("config", cfg.stderr.trim() || "re-stamp / db check failed")
     onProgress("config", "ok")
 
-    // 4. db — stage on source (clean stream → file), pull, import.
+    // 4. db — stage on source (clean stream → file), pull, import. The dump runs
+    // from the DETECTED source dir; the import from the normalized dest dir.
     onProgress("db", "start")
-    const dump = await exec(
+    const dump = await run(
+      "db",
       source,
-      `sudo -u ${shq(su)} -H bash -c "cd ${shq(root)} && wp --skip-plugins --skip-themes db export ${shq(home)}/.clone_db.sql 2>/dev/null && gzip -f ${shq(home)}/.clone_db.sql"`,
+      `sudo -u ${shq(su)} -H bash -c "cd ${shq(srcWpDir)} && wp --skip-plugins --skip-themes db export ${shq(home)}/.clone_db.sql 2>/dev/null && gzip -f ${shq(home)}/.clone_db.sql"`,
       300_000,
     )
     if (!dump.ok) return fail("db", dump.stderr.trim() || "source db export failed")
-    const imp = await exec(
+    const imp = await run(
+      "db",
       dest,
-      `set -e; timeout -k 5 300 ${sshk} ${shq(su)}@${srcIp} "cat ${shq(home)}/.clone_db.sql.gz" </dev/null > /tmp/clone_${spec.domain}.sql.gz; gunzip -f /tmp/clone_${spec.domain}.sql.gz; chmod 644 /tmp/clone_${spec.domain}.sql; cd ${shq(root)}; sudo -u ${shq(du)} -H wp db import /tmp/clone_${spec.domain}.sql >/dev/null; rm -f /tmp/clone_${spec.domain}.sql`,
+      `set -e; timeout -k 5 300 ${sshk} ${shq(su)}@${srcIp} "cat ${shq(home)}/.clone_db.sql.gz" </dev/null > /tmp/clone_${spec.domain}.sql.gz; gunzip -f /tmp/clone_${spec.domain}.sql.gz; chmod 644 /tmp/clone_${spec.domain}.sql; cd ${shq(destWpDir)}; sudo -u ${shq(du)} -H wp db import /tmp/clone_${spec.domain}.sql >/dev/null; rm -f /tmp/clone_${spec.domain}.sql`,
       300_000,
     )
     if (!imp.ok) return fail("db", imp.stderr.trim() || "db pull/import failed")
@@ -210,11 +330,11 @@ export async function runStandardWpPull(
 
     // 5. verify — wp-cli on the dest (HTTP --resolve is the caller's).
     onProgress("verify", "start")
-    const ver = await exec(dest, `cd ${shq(root)}; sudo -u ${shq(du)} -H wp core is-installed`, 30_000)
+    const ver = await run("verify", dest, `cd ${shq(destWpDir)}; sudo -u ${shq(du)} -H wp core is-installed`, 30_000)
     if (!ver.ok) return fail("verify", "wp core is-installed returned false on the dest")
     onProgress("verify", "ok")
 
-    return { ok: true }
+    return { ok: true, sourceWebrootRel: srcRel, destWebrootRel: plan.destRel }
   } finally {
     // 6. revoke — always: drop the pull key (by marker) on source, remove the
     // ephemeral key + staged dump on dest. Best-effort.
@@ -222,8 +342,8 @@ export async function runStandardWpPull(
     // sed (not grep -v): grep returns exit 1 when it filters out the only line, which
     // would skip the rewrite and leave the key behind — exactly the case where the
     // source site user has no other keys.
-    await exec(source, `AK=${shq(home)}/.ssh/authorized_keys; [ -f "$AK" ] && sed -i ${shq(`/${KEY_MARKER}/d`)} "$AK" && chown ${shq(su)}:${shq(su)} "$AK"; rm -f ${shq(home)}/.clone_db.sql.gz`, 30_000).catch(() => {})
-    await exec(dest, `rm -f ${CLONE_KEY} ${CLONE_KEY}.pub /tmp/clone_${spec.domain}.tgz /tmp/clone_${spec.domain}.sql.gz /tmp/clone_${spec.domain}.sql`, 30_000).catch(() => {})
+    await run("revoke", source, `AK=${shq(home)}/.ssh/authorized_keys; [ -f "$AK" ] && sed -i ${shq(`/${KEY_MARKER}/d`)} "$AK" && chown ${shq(su)}:${shq(su)} "$AK"; rm -f ${shq(home)}/.clone_db.sql.gz`, 30_000).catch(() => {})
+    await run("revoke", dest, `rm -f ${CLONE_KEY} ${CLONE_KEY}.pub /tmp/clone_${spec.domain}.tgz /tmp/clone_${spec.domain}.sql.gz /tmp/clone_${spec.domain}.sql`, 30_000).catch(() => {})
     onProgress("revoke", "ok")
   }
 }
@@ -254,6 +374,7 @@ export async function runBedrockPull(
   dest: SudoCtx,
   spec: BedrockPullSpec,
   onProgress: CloneProgress = () => {},
+  onExec?: CloneExecLog,
 ): Promise<{ ok: boolean; error?: string }> {
   const srcIp = source.server.ip_address ?? ""
   const root = `/sites/${spec.domain}/files` // Bedrock project root (composer.json, web/, .env)
@@ -267,14 +388,21 @@ export async function runBedrockPull(
     onProgress(stage, "fail", msg)
     return { ok: false as const, error: `${stage}: ${msg}` }
   }
+  const run = async (stage: CloneStage, ctx: SudoCtx, script: string, timeoutMs?: number) => {
+    const t0 = Date.now()
+    const r = await exec(ctx, script, timeoutMs)
+    onExec?.({ domain: spec.domain, stage, host: ctx.server.name, ok: r.ok, code: r.code, ms: Date.now() - t0, script, stdout: r.stdout, stderr: r.stderr })
+    return r
+  }
 
   try {
     // 1. auth — ephemeral key on dest, granted onto the source site user.
     onProgress("auth", "start")
-    const gen = await exec(dest, `rm -f ${CLONE_KEY} ${CLONE_KEY}.pub; ssh-keygen -t ed25519 -f ${CLONE_KEY} -N "" -C ${KEY_MARKER} >/dev/null 2>&1 && cat ${CLONE_KEY}.pub`, 30_000)
+    const gen = await run("auth", dest, `rm -f ${CLONE_KEY} ${CLONE_KEY}.pub; ssh-keygen -t ed25519 -f ${CLONE_KEY} -N "" -C ${KEY_MARKER} >/dev/null 2>&1 && cat ${CLONE_KEY}.pub`, 30_000)
     const pub = gen.stdout.trim()
     if (!gen.ok || !pub.startsWith("ssh-")) return fail("auth", gen.stderr.trim() || "couldn't generate pull key")
-    const grant = await exec(
+    const grant = await run(
+      "auth",
       source,
       `set -e; SSHDIR=${shq(home)}/.ssh; AK=$SSHDIR/authorized_keys; install -d -m 700 -o ${shq(su)} -g ${shq(su)} "$SSHDIR"; touch "$AK"; chown ${shq(su)}:${shq(su)} "$AK"; chmod 600 "$AK"; grep -qxF ${shq(pub)} "$AK" || echo ${shq(pub)} >> "$AK"`,
       30_000,
@@ -285,13 +413,15 @@ export async function runBedrockPull(
     // 2. build — pull auth.json first (private composer repos need it), then
     //    `composer install` to build vendor/ + web/wp (git/deploy won't, per findings).
     onProgress("build", "start")
-    const authPull = await exec(
+    const authPull = await run(
+      "build",
       dest,
       `set -e; ${remote(`cat ${shq(`${root}/auth.json`)} 2>/dev/null`)} > ${tmp}_auth.json || true; if [ -s ${tmp}_auth.json ]; then install -m 640 -o ${shq(du)} -g ${shq(du)} ${tmp}_auth.json ${shq(`${root}/auth.json`)}; fi; rm -f ${tmp}_auth.json`,
       120_000,
     )
     if (!authPull.ok) return fail("build", authPull.stderr.trim() || "auth.json pull failed")
-    const composer = await exec(
+    const composer = await run(
+      "build",
       dest,
       `set -e; cd ${shq(root)}; sudo -u ${shq(du)} -H bash -lc 'composer install -o --no-dev --no-interaction' 2>&1; test -d ${shq(`${root}/web/wp`)}`,
       600_000,
@@ -303,7 +433,8 @@ export async function runBedrockPull(
     //    uploads dir yields an empty stream we simply skip.
     onProgress("files", "start")
     if (!spec.excludeUploads) {
-      const up = await exec(
+      const up = await run(
+        "files",
         dest,
         `set -e; timeout -k 5 900 ${remote(`[ -d ${shq(`${root}/web/app/uploads`)} ] && tar -C ${shq(root)} --warning=no-file-changed -czf - web/app/uploads || true`)} > ${tmp}_up.tgz; if [ -s ${tmp}_up.tgz ]; then tar -C ${shq(root)} -xzf ${tmp}_up.tgz && chown -R ${shq(du)}:${shq(du)} ${shq(`${root}/web/app/uploads`)}; fi; rm -f ${tmp}_up.tgz`,
         900_000,
@@ -315,7 +446,8 @@ export async function runBedrockPull(
     // 4. config — pull source .env verbatim, swap DB_* (and any DATABASE_URL) to the
     //    dest creds, keep everything else (salts, WP_HOME, custom vars). Then db check.
     onProgress("config", "start")
-    const cfg = await exec(
+    const cfg = await run(
+      "config",
       dest,
       [
         `set -e`,
@@ -335,13 +467,15 @@ export async function runBedrockPull(
 
     // 5. db — stage on source (clean stream → file), pull, import.
     onProgress("db", "start")
-    const dump = await exec(
+    const dump = await run(
+      "db",
       source,
       `sudo -u ${shq(su)} -H bash -c "cd ${shq(root)} && wp --skip-plugins --skip-themes db export ${shq(home)}/.clone_db.sql 2>/dev/null && gzip -f ${shq(home)}/.clone_db.sql"`,
       300_000,
     )
     if (!dump.ok) return fail("db", dump.stderr.trim() || "source db export failed")
-    const imp = await exec(
+    const imp = await run(
+      "db",
       dest,
       `set -e; timeout -k 5 300 ${remote(`cat ${shq(`${home}/.clone_db.sql.gz`)}`)} > ${tmp}.sql.gz; gunzip -f ${tmp}.sql.gz; chmod 644 ${tmp}.sql; cd ${shq(root)}; sudo -u ${shq(du)} -H wp db import ${tmp}.sql >/dev/null; rm -f ${tmp}.sql`,
       300_000,
@@ -351,7 +485,7 @@ export async function runBedrockPull(
 
     // 6. verify — wp-cli on the dest (HTTP --resolve is the caller's).
     onProgress("verify", "start")
-    const ver = await exec(dest, `cd ${shq(root)}; sudo -u ${shq(du)} -H wp core is-installed`, 30_000)
+    const ver = await run("verify", dest, `cd ${shq(root)}; sudo -u ${shq(du)} -H wp core is-installed`, 30_000)
     if (!ver.ok) return fail("verify", "wp core is-installed returned false on the dest")
     onProgress("verify", "ok")
 
@@ -359,8 +493,8 @@ export async function runBedrockPull(
   } finally {
     // 7. revoke — drop the pull key (by marker) on source, clean dest temp + staged dump.
     onProgress("revoke", "start")
-    await exec(source, `AK=${shq(home)}/.ssh/authorized_keys; [ -f "$AK" ] && sed -i ${shq(`/${KEY_MARKER}/d`)} "$AK" && chown ${shq(su)}:${shq(su)} "$AK"; rm -f ${shq(home)}/.clone_db.sql.gz`, 30_000).catch(() => {})
-    await exec(dest, `rm -f ${CLONE_KEY} ${CLONE_KEY}.pub ${tmp}_auth.json ${tmp}_up.tgz ${tmp}_env ${tmp}.sql.gz ${tmp}.sql`, 30_000).catch(() => {})
+    await run("revoke", source, `AK=${shq(home)}/.ssh/authorized_keys; [ -f "$AK" ] && sed -i ${shq(`/${KEY_MARKER}/d`)} "$AK" && chown ${shq(su)}:${shq(su)} "$AK"; rm -f ${shq(home)}/.clone_db.sql.gz`, 30_000).catch(() => {})
+    await run("revoke", dest, `rm -f ${CLONE_KEY} ${CLONE_KEY}.pub ${tmp}_auth.json ${tmp}_up.tgz ${tmp}_env ${tmp}.sql.gz ${tmp}.sql`, 30_000).catch(() => {})
     onProgress("revoke", "ok")
   }
 }
@@ -389,6 +523,9 @@ export interface VerifySpec {
   sourceSiteUser: string
   destSiteUser: string
   destIp: string
+  publicFolder?: string // configured public folder — fallback when the pull's rels are unknown
+  sourceWebrootRel?: string // DETECTED source layout from the pull ("" = files root)
+  destWebrootRel?: string // the CLONE's WP dir from the pull (post-normalization)
 }
 
 // One round-trip per side: collect labeled wp-cli facts as `key=value` lines.
@@ -431,9 +568,14 @@ async function curlStatus(domain: string, ip: string): Promise<string> {
 
 export async function verifyClone(source: SudoCtx, dest: SudoCtx, spec: VerifySpec): Promise<VerifyResult> {
   const root = `/sites/${spec.domain}/files`
+  // Source facts read from where WP was DETECTED during the pull; clone facts from
+  // the pull's resulting dir — after a normalizing pull these differ.
+  const dirFor = (rel: string | undefined) => (rel != null ? (rel ? `${root}/${rel}` : root) : webrootFor(root, spec.publicFolder))
+  const srcDir = dirFor(spec.sourceWebrootRel)
+  const destDir = dirFor(spec.destWebrootRel)
   const [sf, cf, http] = await Promise.all([
-    wpFacts(source, root, spec.sourceSiteUser),
-    wpFacts(dest, root, spec.destSiteUser),
+    wpFacts(source, srcDir, spec.sourceSiteUser),
+    wpFacts(dest, destDir, spec.destSiteUser),
     curlStatus(spec.domain, spec.destIp),
   ])
   const checks: VerifyCheck[] = []

--- a/src/lib/serverClone.ts
+++ b/src/lib/serverClone.ts
@@ -306,8 +306,8 @@ export async function runStandardWpPull(
     const files = await run(
       "files",
       dest,
-      `set -e; rc=0; timeout -k 5 900 ${sshk} ${shq(su)}@${srcIp} "tar -C ${shq(root)} -czf - --exclude=wp-content/cache ." </dev/null > /tmp/clone_${spec.domain}.tgz || rc=$?; [ "$rc" -le 1 ] || { echo "tar-over-ssh failed with exit $rc" >&2; exit "$rc"; }; tar -C ${shq(root)} -xzf /tmp/clone_${spec.domain}.tgz; rm -f /tmp/clone_${spec.domain}.tgz; ${normalize}chown -R ${shq(du)}:${shq(du)} ${shq(root)}; test -f ${shq(destWpDir)}/wp-settings.php || { echo "no WordPress core at ${destWpDir} after pull" >&2; exit 65; }; ${cfgAssert} || { echo "no wp-config.php in the webroot or one level above it (under ${root})" >&2; exit 65; }`,
-      900_000,
+      `set -e; rc=0; timeout -k 5 3600 ${sshk} ${shq(su)}@${srcIp} "tar -C ${shq(root)} -czf - --exclude=wp-content/cache ." </dev/null > /tmp/clone_${spec.domain}.tgz || rc=$?; [ "$rc" -ne 124 ] || { echo "file transfer timed out after 60 minutes" >&2; exit 124; }; [ "$rc" -le 1 ] || { echo "tar-over-ssh failed with exit $rc" >&2; exit "$rc"; }; tar -C ${shq(root)} -xzf /tmp/clone_${spec.domain}.tgz; rm -f /tmp/clone_${spec.domain}.tgz; ${normalize}chown -R ${shq(du)}:${shq(du)} ${shq(root)}; test -f ${shq(destWpDir)}/wp-settings.php || { echo "no WordPress core at ${destWpDir} after pull" >&2; exit 65; }; ${cfgAssert} || { echo "no wp-config.php in the webroot or one level above it (under ${root})" >&2; exit 65; }`,
+      3_660_000, // outer must exceed the in-script `timeout 3600` so the inner reports a clean 124
     )
     if (!files.ok) return fail("files", files.stderr.trim() || "file pull failed")
     onProgress("files", "ok")
@@ -331,14 +331,14 @@ export async function runStandardWpPull(
       "db",
       source,
       `sudo -u ${shq(su)} -H bash -c "cd ${shq(srcWpDir)} && wp --skip-plugins --skip-themes db export ${shq(home)}/.clone_db.sql 2>/dev/null && gzip -f ${shq(home)}/.clone_db.sql"`,
-      300_000,
+      900_000,
     )
     if (!dump.ok) return fail("db", dump.stderr.trim() || "source db export failed")
     const imp = await run(
       "db",
       dest,
       `set -e; timeout -k 5 300 ${sshk} ${shq(su)}@${srcIp} "cat ${shq(home)}/.clone_db.sql.gz" </dev/null > /tmp/clone_${spec.domain}.sql.gz; gunzip -f /tmp/clone_${spec.domain}.sql.gz; chmod 644 /tmp/clone_${spec.domain}.sql; cd ${shq(destWpDir)}; sudo -u ${shq(du)} -H wp db import /tmp/clone_${spec.domain}.sql >/dev/null; rm -f /tmp/clone_${spec.domain}.sql`,
-      300_000,
+      360_000, // outer must exceed the in-script `timeout 300`
     )
     if (!imp.ok) return fail("db", imp.stderr.trim() || "db pull/import failed")
     onProgress("db", "ok")
@@ -453,8 +453,8 @@ export async function runBedrockPull(
       const up = await run(
         "files",
         dest,
-        `set -e; timeout -k 5 900 ${remote(`[ -d ${shq(`${root}/web/app/uploads`)} ] && tar -C ${shq(root)} --warning=no-file-changed -czf - web/app/uploads || true`)} > ${tmp}_up.tgz; if [ -s ${tmp}_up.tgz ]; then tar -C ${shq(root)} -xzf ${tmp}_up.tgz && chown -R ${shq(du)}:${shq(du)} ${shq(`${root}/web/app/uploads`)}; fi; rm -f ${tmp}_up.tgz`,
-        900_000,
+        `set -e; timeout -k 5 3600 ${remote(`[ -d ${shq(`${root}/web/app/uploads`)} ] && tar -C ${shq(root)} --warning=no-file-changed -czf - web/app/uploads || true`)} > ${tmp}_up.tgz; if [ -s ${tmp}_up.tgz ]; then tar -C ${shq(root)} -xzf ${tmp}_up.tgz && chown -R ${shq(du)}:${shq(du)} ${shq(`${root}/web/app/uploads`)}; fi; rm -f ${tmp}_up.tgz`,
+        3_660_000, // outer must exceed the in-script `timeout 3600` so the inner reports a clean 124
       )
       if (!up.ok) return fail("files", up.stderr.trim() || "uploads pull failed")
     }
@@ -488,14 +488,14 @@ export async function runBedrockPull(
       "db",
       source,
       `sudo -u ${shq(su)} -H bash -c "cd ${shq(root)} && wp --skip-plugins --skip-themes db export ${shq(home)}/.clone_db.sql 2>/dev/null && gzip -f ${shq(home)}/.clone_db.sql"`,
-      300_000,
+      900_000,
     )
     if (!dump.ok) return fail("db", dump.stderr.trim() || "source db export failed")
     const imp = await run(
       "db",
       dest,
       `set -e; timeout -k 5 300 ${remote(`cat ${shq(`${home}/.clone_db.sql.gz`)}`)} > ${tmp}.sql.gz; gunzip -f ${tmp}.sql.gz; chmod 644 ${tmp}.sql; cd ${shq(root)}; sudo -u ${shq(du)} -H wp db import ${tmp}.sql >/dev/null; rm -f ${tmp}.sql`,
-      300_000,
+      360_000, // outer must exceed the in-script `timeout 300`
     )
     if (!imp.ok) return fail("db", imp.stderr.trim() || "db pull/import failed")
     onProgress("db", "ok")

--- a/src/lib/serverClone.ts
+++ b/src/lib/serverClone.ts
@@ -136,6 +136,33 @@ export interface CloneExecRecord {
 }
 export type CloneExecLog = (e: CloneExecRecord) => void
 
+// Byte-level transfer progress: the pull materializes a growing file (the tarball
+// or DB dump being received), so a SIDECAR poll — an independent, read-only `stat`
+// over its own SSH session every few seconds — reads exact bytes-so-far without
+// touching the transfer pipeline (progress display must never be able to break a
+// transfer). Best-effort: a failed poll is silently skipped.
+export type CloneTransfer = (stage: CloneStage, bytes: number) => void
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+// Poll `path` on `ctx` until stopped; report each growing size. Returns a stop().
+export function pollTransferSize(ctx: SudoCtx, path: string, onBytes: (bytes: number) => void): () => void {
+  let live = true
+  void (async () => {
+    await sleep(4000) // let the transfer begin
+    while (live) {
+      const r = await exec(ctx, `stat -c %s ${shq(path)} 2>/dev/null || true`, 15_000)
+      if (!live) break
+      const n = Number(r.stdout.trim())
+      if (r.ok && Number.isFinite(n) && n > 0) onBytes(n)
+      await sleep(5000)
+    }
+  })()
+  return () => {
+    live = false
+  }
+}
+
 // ---- Webroot: configured vs REAL ------------------------------------------
 //
 // SpinupWP's public_folder is a *setting* (nginx root = files<public_folder>) — the
@@ -240,6 +267,7 @@ export async function runStandardWpPull(
   spec: StandardWpPullSpec,
   onProgress: CloneProgress = () => {},
   onExec?: CloneExecLog,
+  onTransfer?: CloneTransfer,
 ): Promise<{ ok: boolean; error?: string; sourceWebrootRel?: string; destWebrootRel?: string }> {
   const srcIp = source.server.ip_address ?? ""
   const root = `/sites/${spec.domain}/files`
@@ -295,6 +323,7 @@ export async function runStandardWpPull(
     // may sit in the webroot OR one level above it, so the assertion accepts either.
     onProgress("files", "start")
     const normalize = plan.normalize ? `${normalizeWebrootScript(root, destWpDir)}; ` : ""
+    const stopFilesPoll = pollTransferSize(dest, `/tmp/clone_${spec.domain}.tgz`, (b) => onTransfer?.("files", b))
     // wp-config.php may live in the webroot or one level above it (the
     // config-above-webroot convention — see CLAUDE.md); never above files/.
     const cfgDirs = [...new Set([destWpDir, destWpDir.slice(0, destWpDir.lastIndexOf("/")), root])].filter((d) => d.length >= root.length)
@@ -309,6 +338,7 @@ export async function runStandardWpPull(
       `set -e; rc=0; timeout -k 5 3600 ${sshk} ${shq(su)}@${srcIp} "tar -C ${shq(root)} -czf - --exclude=wp-content/cache ." </dev/null > /tmp/clone_${spec.domain}.tgz || rc=$?; [ "$rc" -ne 124 ] || { echo "file transfer timed out after 60 minutes" >&2; exit 124; }; [ "$rc" -le 1 ] || { echo "tar-over-ssh failed with exit $rc" >&2; exit "$rc"; }; tar -C ${shq(root)} -xzf /tmp/clone_${spec.domain}.tgz; rm -f /tmp/clone_${spec.domain}.tgz; ${normalize}chown -R ${shq(du)}:${shq(du)} ${shq(root)}; test -f ${shq(destWpDir)}/wp-settings.php || { echo "no WordPress core at ${destWpDir} after pull" >&2; exit 65; }; ${cfgAssert} || { echo "no wp-config.php in the webroot or one level above it (under ${root})" >&2; exit 65; }`,
       3_660_000, // outer must exceed the in-script `timeout 3600` so the inner reports a clean 124
     )
+    stopFilesPoll()
     if (!files.ok) return fail("files", files.stderr.trim() || "file pull failed")
     onProgress("files", "ok")
 
@@ -334,12 +364,14 @@ export async function runStandardWpPull(
       900_000,
     )
     if (!dump.ok) return fail("db", dump.stderr.trim() || "source db export failed")
+    const stopDbPoll = pollTransferSize(dest, `/tmp/clone_${spec.domain}.sql.gz`, (b) => onTransfer?.("db", b))
     const imp = await run(
       "db",
       dest,
       `set -e; timeout -k 5 300 ${sshk} ${shq(su)}@${srcIp} "cat ${shq(home)}/.clone_db.sql.gz" </dev/null > /tmp/clone_${spec.domain}.sql.gz; gunzip -f /tmp/clone_${spec.domain}.sql.gz; chmod 644 /tmp/clone_${spec.domain}.sql; cd ${shq(destWpDir)}; sudo -u ${shq(du)} -H wp db import /tmp/clone_${spec.domain}.sql >/dev/null; rm -f /tmp/clone_${spec.domain}.sql`,
       360_000, // outer must exceed the in-script `timeout 300`
     )
+    stopDbPoll()
     if (!imp.ok) return fail("db", imp.stderr.trim() || "db pull/import failed")
     onProgress("db", "ok")
 
@@ -390,6 +422,7 @@ export async function runBedrockPull(
   spec: BedrockPullSpec,
   onProgress: CloneProgress = () => {},
   onExec?: CloneExecLog,
+  onTransfer?: CloneTransfer,
 ): Promise<{ ok: boolean; error?: string }> {
   const srcIp = source.server.ip_address ?? ""
   const root = `/sites/${spec.domain}/files` // Bedrock project root (composer.json, web/, .env)
@@ -450,12 +483,14 @@ export async function runBedrockPull(
     //    uploads dir yields an empty stream we simply skip.
     onProgress("files", "start")
     if (!spec.excludeUploads) {
+      const stopUpPoll = pollTransferSize(dest, `${tmp}_up.tgz`, (b) => onTransfer?.("files", b))
       const up = await run(
         "files",
         dest,
         `set -e; timeout -k 5 3600 ${remote(`[ -d ${shq(`${root}/web/app/uploads`)} ] && tar -C ${shq(root)} --warning=no-file-changed -czf - web/app/uploads || true`)} > ${tmp}_up.tgz; if [ -s ${tmp}_up.tgz ]; then tar -C ${shq(root)} -xzf ${tmp}_up.tgz && chown -R ${shq(du)}:${shq(du)} ${shq(`${root}/web/app/uploads`)}; fi; rm -f ${tmp}_up.tgz`,
         3_660_000, // outer must exceed the in-script `timeout 3600` so the inner reports a clean 124
       )
+      stopUpPoll()
       if (!up.ok) return fail("files", up.stderr.trim() || "uploads pull failed")
     }
     onProgress("files", "ok")
@@ -491,12 +526,14 @@ export async function runBedrockPull(
       900_000,
     )
     if (!dump.ok) return fail("db", dump.stderr.trim() || "source db export failed")
+    const stopDbPoll = pollTransferSize(dest, `${tmp}.sql.gz`, (b) => onTransfer?.("db", b))
     const imp = await run(
       "db",
       dest,
       `set -e; timeout -k 5 300 ${remote(`cat ${shq(`${home}/.clone_db.sql.gz`)}`)} > ${tmp}.sql.gz; gunzip -f ${tmp}.sql.gz; chmod 644 ${tmp}.sql; cd ${shq(root)}; sudo -u ${shq(du)} -H wp db import ${tmp}.sql >/dev/null; rm -f ${tmp}.sql`,
       360_000, // outer must exceed the in-script `timeout 300`
     )
+    stopDbPoll()
     if (!imp.ok) return fail("db", imp.stderr.trim() || "db pull/import failed")
     onProgress("db", "ok")
 

--- a/src/lib/serverClone.ts
+++ b/src/lib/serverClone.ts
@@ -567,6 +567,112 @@ export async function runBedrockPull(
   }
 }
 
+// ---- Files-only pull chain (non-WP sites: redirect shells, static/PHP sites) --
+//
+// The same hardened transport as the Standard-WP files stage (per-site key,
+// tolerant tar, 60-min budget, sidecar byte meter) with everything WordPress
+// removed: no detect, no wp-config re-stamp, no database. The dest site is
+// created blank with NO database block (the caller's job). Verification is
+// file-count/size + HTTP, not wp-cli — see verifyFilesClone.
+
+export interface FilesOnlyPullSpec {
+  domain: string
+  sourceSiteUser: string
+  destSiteUser: string
+  approxFilesBytes?: number // Plan's uncompressed size — soft ceiling for the meter
+}
+
+export async function runFilesOnlyPull(
+  source: SudoCtx,
+  dest: SudoCtx,
+  spec: FilesOnlyPullSpec,
+  onProgress: CloneProgress = () => {},
+  onExec?: CloneExecLog,
+  onTransfer?: CloneTransfer,
+): Promise<{ ok: boolean; error?: string }> {
+  const srcIp = source.server.ip_address ?? ""
+  const root = `/sites/${spec.domain}/files`
+  const home = `/sites/${spec.domain}`
+  const su = spec.sourceSiteUser
+  const du = spec.destSiteUser
+  const KEY = cloneKeyFor(spec.domain)
+  const MARKER = keyMarkerFor(spec.domain)
+  const sshk = `ssh -i ${KEY} -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=10`
+  const fail = (stage: CloneStage, msg: string) => {
+    onProgress(stage, "fail", msg)
+    return { ok: false as const, error: `${stage}: ${msg}` }
+  }
+  const run = async (stage: CloneStage, ctx: SudoCtx, script: string, timeoutMs?: number) => {
+    const t0 = Date.now()
+    const r = await exec(ctx, script, timeoutMs)
+    onExec?.({ domain: spec.domain, stage, host: ctx.server.name, ok: r.ok, code: r.code, ms: Date.now() - t0, script, stdout: r.stdout, stderr: r.stderr })
+    return r
+  }
+
+  try {
+    // 1. auth — ephemeral per-site key on dest, granted onto the source site user.
+    onProgress("auth", "start")
+    const gen = await run("auth", dest, `rm -f ${KEY} ${KEY}.pub; ssh-keygen -t ed25519 -f ${KEY} -N "" -C ${MARKER} >/dev/null 2>&1 && cat ${KEY}.pub`, 30_000)
+    const pub = gen.stdout.trim()
+    if (!gen.ok || !pub.startsWith("ssh-")) return fail("auth", gen.stderr.trim() || "couldn't generate pull key")
+    const grant = await run(
+      "auth",
+      source,
+      `set -e; SSHDIR=${shq(home)}/.ssh; AK=$SSHDIR/authorized_keys; install -d -m 700 -o ${shq(su)} -g ${shq(su)} "$SSHDIR"; touch "$AK"; chown ${shq(su)}:${shq(su)} "$AK"; chmod 600 "$AK"; grep -qxF ${shq(pub)} "$AK" || echo ${shq(pub)} >> "$AK"`,
+      30_000,
+    )
+    if (!grant.ok) return fail("auth", grant.stderr.trim() || "couldn't grant pull key on source")
+    onProgress("auth", "ok")
+
+    // 2. files — the whole files/ tree, verbatim (whatever layout the site uses).
+    onProgress("files", "start")
+    const stopPoll = pollTransferSize(dest, `/tmp/clone_${spec.domain}.tgz`, (b) => onTransfer?.("files", b, spec.approxFilesBytes, false))
+    const files = await run(
+      "files",
+      dest,
+      `set -e; rc=0; timeout -k 5 3600 ${sshk} ${shq(su)}@${srcIp} "tar -C ${shq(root)} -czf - ." </dev/null > /tmp/clone_${spec.domain}.tgz || rc=$?; [ "$rc" -ne 124 ] || { echo "file transfer timed out after 60 minutes" >&2; exit 124; }; [ "$rc" -le 1 ] || { echo "tar-over-ssh failed with exit $rc" >&2; exit "$rc"; }; tar -C ${shq(root)} -xzf /tmp/clone_${spec.domain}.tgz; rm -f /tmp/clone_${spec.domain}.tgz; chown -R ${shq(du)}:${shq(du)} ${shq(root)}; [ -n "$(ls -A ${shq(root)} 2>/dev/null)" ] || { echo "files/ is empty after pull" >&2; exit 65; }`,
+      3_660_000, // outer must exceed the in-script `timeout 3600`
+    )
+    stopPoll()
+    if (!files.ok) return fail("files", files.stderr.trim() || "file pull failed")
+    onProgress("files", "ok")
+
+    return { ok: true }
+  } finally {
+    onProgress("revoke", "start")
+    await run("revoke", source, `AK=${shq(home)}/.ssh/authorized_keys; [ -f "$AK" ] && sed -i ${shq(`/${MARKER}/d`)} "$AK" && chown ${shq(su)}:${shq(su)} "$AK"`, 30_000).catch(() => {})
+    await run("revoke", dest, `rm -f ${KEY} ${KEY}.pub /tmp/clone_${spec.domain}.tgz`, 30_000).catch(() => {})
+    onProgress("revoke", "ok")
+  }
+}
+
+// Verify a files-only clone: file count + total bytes on each side, plus the HTTP
+// check via the dest IP. Counts must match exactly; bytes get a small tolerance
+// (a growing log on the live source shouldn't flunk the clone).
+export async function verifyFilesClone(source: SudoCtx, dest: SudoCtx, spec: { domain: string; destIp: string }): Promise<VerifyResult> {
+  const root = `/sites/${spec.domain}/files`
+  const script = `echo "files=$(find ${shq(root)} -type f 2>/dev/null | wc -l)"; echo "bytes=$(du -sb ${shq(root)} 2>/dev/null | cut -f1)"`
+  const parse = (out: string): Record<string, string> => {
+    const o: Record<string, string> = {}
+    for (const line of out.split("\n")) {
+      const m = line.match(/^(\w+)=(.*)$/)
+      if (m) o[m[1]!] = (m[2] ?? "").trim()
+    }
+    return o
+  }
+  const [sr, dr, http] = await Promise.all([exec(source, script, 60_000), exec(dest, script, 60_000), curlStatus(spec.domain, spec.destIp)])
+  const sf = parse(sr.stdout)
+  const cf = parse(dr.stdout)
+  const checks: VerifyCheck[] = []
+  checks.push({ key: "http", label: "Clone serves (HTTP)", source: "—", clone: http, ok: /^[23]\d\d$/.test(http) })
+  checks.push({ key: "files", label: "Files", source: sf.files ?? "—", clone: cf.files ?? "—", ok: !!sf.files && sf.files === cf.files })
+  const sb = Number(sf.bytes)
+  const cb = Number(cf.bytes)
+  const bytesOk = Number.isFinite(sb) && Number.isFinite(cb) && sb > 0 && Math.abs(sb - cb) <= Math.max(4096, sb * 0.01)
+  checks.push({ key: "bytes", label: "Total size", source: sf.bytes ?? "—", clone: cf.bytes ?? "—", ok: bytesOk })
+  return { ok: checks.every((c) => c.ok), checks }
+}
+
 // ---- Verify a cloned site (slice 5) ---------------------------------------
 //
 // Read-only confirmation that the clone matches the source: compare a handful of

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -41,7 +41,7 @@ import { recordProviderFor, type DnsRecord, type RecordResult } from "../lib/dns
 import { deriveSiteUser, seedVanityIndex, aRecordResolves } from "../lib/vanitySite.ts"
 import type { StoredProviders } from "../config.ts"
 import { fetchRebootInfo, grantSiteSshKey, revokeSiteSshKey, verifySudo, ensureSpinupKey, listPersonalKeys, keyBody, type RebootInfo } from "../lib/ssh.ts"
-import { estimateSourceSiteSizes, runStandardWpPull, runBedrockPull, verifyClone, type SudoCtx, type CloneStage, type CloneExecRecord, type VerifyResult as CloneVerifyResult } from "../lib/serverClone.ts"
+import { estimateSourceSiteSizes, runStandardWpPull, runBedrockPull, runFilesOnlyPull, verifyClone, verifyFilesClone, type SudoCtx, type CloneStage, type CloneExecRecord, type VerifyResult as CloneVerifyResult } from "../lib/serverClone.ts"
 import { CloneLogger } from "../lib/cloneLog.ts"
 import { syncAdditionalDomains } from "../lib/cloneDomains.ts"
 import { parseRepo, deployKeysSettingsUrl, ghAvailable, ghDeployKeyPresent, ghAddDeployKey, type RepoHost } from "../lib/gitDeployKey.ts"
@@ -203,7 +203,7 @@ export interface CloneSiteState {
   isWordPress: boolean // API is_wordpress — false (non-git) = redirect/static site the WP chain can't clone
   sizeBytes?: number // webroot + DB estimate (sizing + progress); undefined until sized
   sizeWebBytes?: number // webroot-only bytes (uncompressed) — the files-transfer soft ceiling
-  stack: "wp" | "bedrock" // from source git.repo → drives blank-vs-git create
+  stack: "wp" | "bedrock" | "files" // git repo → bedrock; is_wordpress → wp; else files-only (redirect shells, static/PHP sites)
   gitRepo?: string // source git.repo (Bedrock) — the dest is created as a `git` site of it
   gitBranch?: string // source git.branch
   additionalDomains?: string[] // extra domains served by the site → extra cutover records
@@ -282,12 +282,7 @@ export interface CloneJob {
   startedAt: number
   logPath?: string // per-job JSONL log (full stage output; the roster only shows truncated errors)
 }
-// A site the WP pull chain can work on: WordPress, or a git site (is_wordpress is
-// unreliable for git sites — see the API findings doc). is_wordpress:false non-git
-// sites (redirect shells, static placeholders) have no wp-config/DB to clone.
-export function cloneSiteSupported(s: CloneSiteState): boolean {
-  return s.isWordPress || s.stack === "bedrock"
-}
+
 // The gitaccess step is only needed when a selected site is Bedrock (a git repo whose
 // dest the new server must be authorized to clone).
 export function cloneNeedsGitAccess(j: CloneJob): boolean {
@@ -296,10 +291,11 @@ export function cloneNeedsGitAccess(j: CloneJob): boolean {
 export function isCloneInFlight(j: CloneJob | null | undefined): boolean {
   return j != null && j.step !== "done" && j.step !== "error"
 }
-// Detect a site's stack the way the clone branches: a git repo → Bedrock, else
-// Standard WP (is_wordpress is unreliable for git sites — see the API findings doc).
-export function cloneStackFor(site: Site): "wp" | "bedrock" {
-  return site.git?.repo ? "bedrock" : "wp"
+// Detect a site's stack the way the clone branches: a git repo → Bedrock
+// (is_wordpress is unreliable for git sites — see the API findings doc);
+// is_wordpress → Standard WP; anything else → files-only (no DB, no wp-cli).
+export function cloneStackFor(site: Site): "wp" | "bedrock" | "files" {
+  return site.git?.repo ? "bedrock" : site.is_wordpress ? "wp" : "files"
 }
 // Alphanumeric token for generated dest DB passwords (never printed/persisted).
 function randomToken(n: number): string {
@@ -2683,9 +2679,9 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           sourceSiteId: s.id,
           domain: s.domain,
           siteUser: s.site_user ?? "",
-          // Non-WP, non-git sites (redirect shells, placeholders) can't be cloned by
-          // the WP chain — excluded up front rather than failing mid-pull.
-          selected: isWordPress || stack === "bedrock",
+          // files-only sites (redirect shells, placeholders) are cloneable but opt-in —
+          // they're often vanity/placeholder sites nobody wants copied.
+          selected: stack !== "files",
           isWordPress,
           stack,
           gitRepo: s.git?.repo ?? undefined,
@@ -2726,9 +2722,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const toggleCloneSite = useCallback(
-    // Unsupported sites (not WordPress, no git repo) stay deselected — selecting one
-    // would only re-run the 2026-07-02 failure mode.
-    (id: number) => mutateCloneSite(id, (s) => (cloneSiteSupported(s) ? { ...s, selected: !s.selected } : s)),
+    (id: number) => mutateCloneSite(id, (s) => ({ ...s, selected: !s.selected })),
     [mutateCloneSite],
   )
   const toggleCloneSiteUploads = useCallback(
@@ -2885,13 +2879,14 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       }
       try {
         if (site.stack === "bedrock" && !site.gitRepo) return fail("create", "the source Bedrock site has no git repo to clone from.")
-        // create — Bedrock → `git` site (SpinupWP clones the repo); Standard WP → blank.
+        // create — Bedrock → `git` site (SpinupWP clones the repo); Standard WP →
+        // blank + database; files-only → blank with NO database (nothing to import).
         set((s) => ({ ...s, step: "create", error: undefined, failedStep: undefined, detail: undefined, stageStartedAt: Date.now() }))
         const dbName = site.destDbName ?? site.siteUser
         const dbPw = site.destDbPassword ?? randomToken(28)
-        logger?.redact(dbPw)
+        if (site.stack !== "files") logger?.redact(dbPw)
         logger?.log({ event: "site-start", domain: site.domain, stack: site.stack, publicFolder: site.publicFolder, tablePrefix: site.tablePrefix, reusedDestSiteId: site.destSiteId })
-        set((s) => ({ ...s, destDbName: dbName, destDbPassword: dbPw }))
+        if (site.stack !== "files") set((s) => ({ ...s, destDbName: dbName, destDbPassword: dbPw }))
         // Reuse only within THIS job (destSiteId already captured = retry/resume).
         // We deliberately do NOT adopt a pre-existing dest site found by domain: its
         // DB password can't be recovered to re-stamp wp-config, so a leftover from a
@@ -2916,15 +2911,24 @@ export function StoreProvider({ children }: { children: ReactNode }) {
                     deploy_script: "composer install -o --no-dev",
                     git: { repo: site.gitRepo!, branch: site.gitBranch ?? "main", push_to_deploy: true },
                   }
-                : {
-                    server_id: destServerId,
-                    domain: site.domain,
-                    site_user: site.siteUser,
-                    installation_method: "blank",
-                    php_version: site.phpVersion,
-                    public_folder: site.publicFolder,
-                    database: { name: dbName, username: dbName, password: dbPw, table_prefix: site.tablePrefix || "wp_" },
-                  }
+                : site.stack === "files"
+                  ? {
+                      server_id: destServerId,
+                      domain: site.domain,
+                      site_user: site.siteUser,
+                      installation_method: "blank",
+                      php_version: site.phpVersion,
+                      public_folder: site.publicFolder,
+                    }
+                  : {
+                      server_id: destServerId,
+                      domain: site.domain,
+                      site_user: site.siteUser,
+                      installation_method: "blank",
+                      php_version: site.phpVersion,
+                      public_folder: site.publicFolder,
+                      database: { name: dbName, username: dbName, password: dbPw, table_prefix: site.tablePrefix || "wp_" },
+                    }
             ev = await client.createSite(payload)
             logger?.log({ event: "create-requested", domain: site.domain, eventId: ev?.event_id })
           } catch (err) {
@@ -2991,7 +2995,9 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         const res =
           site.stack === "bedrock"
             ? await runBedrockPull(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, destDbName: dbName, destDbUser: dbName, destDbPassword: dbPw, excludeUploads: site.excludeUploads }, onProgress, onExec, onTransfer)
-            : await runStandardWpPull(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, destDbName: dbName, destDbUser: dbName, destDbPassword: dbPw, publicFolder: site.publicFolder, approxFilesBytes: site.sizeWebBytes }, onProgress, onExec, onTransfer)
+            : site.stack === "files"
+              ? await runFilesOnlyPull(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, approxFilesBytes: site.sizeWebBytes }, onProgress, onExec, onTransfer)
+              : await runStandardWpPull(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, destDbName: dbName, destDbUser: dbName, destDbPassword: dbPw, publicFolder: site.publicFolder, approxFilesBytes: site.sizeWebBytes }, onProgress, onExec, onTransfer)
         if (!res.ok) {
           const stage = (res.error?.split(":")[0] ?? "pull") as CloneStage
           return fail(stageToStep(stage), res.error ?? "pull failed")
@@ -3062,7 +3068,9 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       setCloneSite(siteId, (s) => ({ ...s, verifying: true, verifyError: undefined }))
       void (async () => {
         try {
-          const res = await verifyClone(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, destIp, publicFolder: site.stack === "wp" ? site.publicFolder : undefined, sourceWebrootRel: site.stack === "wp" ? site.sourceWebrootRel : undefined, destWebrootRel: site.stack === "wp" ? site.destWebrootRel : undefined })
+          const res = site.stack === "files"
+            ? await verifyFilesClone(source, dest, { domain: site.domain, destIp })
+            : await verifyClone(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, destIp, publicFolder: site.stack === "wp" ? site.publicFolder : undefined, sourceWebrootRel: site.stack === "wp" ? site.sourceWebrootRel : undefined, destWebrootRel: site.stack === "wp" ? site.destWebrootRel : undefined })
           setCloneSite(siteId, (s) => ({ ...s, verifying: false, verify: res }))
         } catch (err) {
           setCloneSite(siteId, (s) => ({ ...s, verifying: false, verifyError: (err as Error).message }))

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -219,6 +219,8 @@ export interface CloneSiteState {
   step: CloneSiteStep
   detail?: string // current sub-activity (the pull stage), for the roster
   stageStartedAt?: number // when the current step/stage began — drives the roster's elapsed timer
+  transferBytes?: number // bytes received so far in the current transfer (sidecar stat poll)
+  transferRate?: number // smoothed bytes/sec derived from successive polls
   failedStep?: CloneSiteStep
   error?: string
   verifying?: boolean // slice 5: verify drill-down in flight
@@ -2970,13 +2972,23 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           stage === "build" ? "deploy" : stage === "config" ? "config" : stage === "verify" ? "verify" : "pull"
         const onProgress = (stage: CloneStage, status: "start" | "ok" | "fail") => {
           if (status !== "start") return
-          set((s) => ({ ...s, step: stageToStep(stage), detail: stage, stageStartedAt: Date.now() }))
+          set((s) => ({ ...s, step: stageToStep(stage), detail: stage, stageStartedAt: Date.now(), transferBytes: undefined, transferRate: undefined }))
+        }
+        // Sidecar byte progress: rate from successive samples (poll cadence ~5s).
+        const transferAtRef = { at: 0 }
+        const onTransfer = (_stage: CloneStage, bytes: number) => {
+          const at = Date.now()
+          set((s) => {
+            const rate = s.transferBytes != null && bytes > s.transferBytes && transferAtRef.at > 0 ? ((bytes - s.transferBytes) / (at - transferAtRef.at)) * 1000 : s.transferRate
+            return { ...s, transferBytes: bytes, transferRate: rate }
+          })
+          transferAtRef.at = at
         }
         const onExec = logger ? (e: CloneExecRecord) => logger.log({ event: "exec", ...e }) : undefined
         const res =
           site.stack === "bedrock"
-            ? await runBedrockPull(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, destDbName: dbName, destDbUser: dbName, destDbPassword: dbPw, excludeUploads: site.excludeUploads }, onProgress, onExec)
-            : await runStandardWpPull(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, destDbName: dbName, destDbUser: dbName, destDbPassword: dbPw, publicFolder: site.publicFolder }, onProgress, onExec)
+            ? await runBedrockPull(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, destDbName: dbName, destDbUser: dbName, destDbPassword: dbPw, excludeUploads: site.excludeUploads }, onProgress, onExec, onTransfer)
+            : await runStandardWpPull(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, destDbName: dbName, destDbUser: dbName, destDbPassword: dbPw, publicFolder: site.publicFolder }, onProgress, onExec, onTransfer)
         if (!res.ok) {
           const stage = (res.error?.split(":")[0] ?? "pull") as CloneStage
           return fail(stageToStep(stage), res.error ?? "pull failed")

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -485,6 +485,7 @@ interface StoreValue extends DataState {
   cloneSizeSites: () => Promise<void> // measure source sites' webroot+DB over source sudo → sizeBytes
   startClone: () => void // run the fan-out (worker pool, cap = concurrency) over selected sites
   cloneRetrySite: (siteId: number) => void // re-run one failed site
+  cloneContinueToCutover: () => void // explicit user continue: settled roster → DNS cutover
   verifyCloneSite: (siteId: number) => void // slice 5: verify one cloned site (source-vs-clone)
   cutoverCheck: () => Promise<void> // slice 6: read + classify each site's DNS record
   startCutover: () => void // slice 6: flip every "ready" record to the new IP (batched)
@@ -2917,19 +2918,24 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           } catch (err) {
             return fail("create", err instanceof ApiError ? err.message : (err as Error).message)
           }
-          // poll the create event
+          // poll the create event. 5s cadence (3 workers share the API window) and
+          // up to 3 consecutive API errors tolerated — a transient failure to READ
+          // the event is not the event failing (the 2026-07-02 run misreported a
+          // successful create as failed off one rate-limited poll).
           const ok = await new Promise<boolean>((resolve) => {
+            let apiErrs = 0
             const poll = async () => {
               try {
                 const e = await client.getEvent(ev!.event_id)
+                apiErrs = 0
                 if (SERVER_FAIL.has(e.status)) return resolve(false)
                 if (SERVER_DONE.has(e.status) || e.finished_at) return resolve(true)
-                setTimeout(() => void poll(), 3000)
               } catch {
-                resolve(false)
+                if (++apiErrs >= 3) return resolve(false)
               }
+              setTimeout(() => void poll(), 5000)
             }
-            setTimeout(() => void poll(), 3000)
+            setTimeout(() => void poll(), 5000)
           })
           if (!ok) return fail("create", "The dest site create failed on SpinupWP.")
           try {
@@ -3044,16 +3050,30 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     [cloneJob, sudoCtxFor, setCloneSite],
   )
 
-  // When every selected site has settled, advance: any successful clone → DNS cutover
-  // (the next journey step); all-failed → straight to the done summary.
+  // When every selected site has settled: all-failed → the done summary. With ANY
+  // success the wizard STAYS on the roster — DNS cutover moves live traffic, so
+  // advancing requires the user's explicit continue (c → cloneContinueToCutover);
+  // the user always gets to eyeball the roster's final state first (2026-07-02).
   useEffect(() => {
     if (!cloneJob || cloneJob.step !== "clone") return
     const sel = cloneJob.sites.filter((s) => s.selected)
     if (sel.length > 0 && sel.every((s) => s.step === "done" || s.step === "error")) {
       const anyDone = sel.some((s) => s.step === "done")
-      setCloneJob((j) => (j && j.step === "clone" ? { ...j, step: anyDone ? "cutover" : "done" } : j))
+      if (!anyDone) setCloneJob((j) => (j && j.step === "clone" ? { ...j, step: "done" } : j))
     }
   }, [cloneJob])
+
+  // The explicit continue: only valid once every selected site has settled and at
+  // least one clone succeeded.
+  const cloneContinueToCutover = useCallback(() => {
+    setCloneJob((j) => {
+      if (!j || j.step !== "clone") return j
+      const sel = j.sites.filter((s) => s.selected)
+      const settled = sel.length > 0 && sel.every((s) => s.step === "done" || s.step === "error")
+      const anyDone = sel.some((s) => s.step === "done")
+      return settled && anyDone ? { ...j, step: "cutover" } : j
+    })
+  }, [])
 
   // ---- DNS cutover (slice 6) ------------------------------------------------
   const destIpOf = useCallback(
@@ -3306,6 +3326,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     cloneSizeSites,
     startClone,
     cloneRetrySite,
+    cloneContinueToCutover,
     verifyCloneSite,
     cutoverCheck,
     startCutover,

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -28,6 +28,8 @@ import {
   nameserversMatch,
   PROVIDER_CONSOLE,
   PROVIDER_REGISTRY,
+  consoleForHost,
+  DEFAULT_WEB_ACCESS_NOTE,
   ALL_PROVIDERS,
   type Connection,
   type ConnProvider,
@@ -216,6 +218,7 @@ export interface CloneSiteState {
   destDbPassword?: string
   step: CloneSiteStep
   detail?: string // current sub-activity (the pull stage), for the roster
+  stageStartedAt?: number // when the current step/stage began — drives the roster's elapsed timer
   failedStep?: CloneSiteStep
   error?: string
   verifying?: boolean // slice 5: verify drill-down in flight
@@ -236,6 +239,9 @@ export interface CutoverRecord {
   targetValue?: string // the new server IP
   reason?: string // when manual: why it can't be auto-flipped
   error?: string
+  apex?: string // the zone apex (for the registrar web handoff + note lookup)
+  hostKey?: string // the DNS host key (drives consoleForHost)
+  excluded?: boolean // ready record the user deselected (space) — c skips it
 }
 export interface CloneCutoverState {
   status: CloneCutoverStatus // aggregate over records (rail badge + summary)
@@ -486,6 +492,7 @@ interface StoreValue extends DataState {
   startClone: () => void // run the fan-out (worker pool, cap = concurrency) over selected sites
   cloneRetrySite: (siteId: number) => void // re-run one failed site
   cloneContinueToCutover: () => void // explicit user continue: settled roster → DNS cutover
+  toggleCutoverExclude: (siteId: number, name: string) => void // space: include/exclude a ready cutover record
   verifyCloneSite: (siteId: number) => void // slice 5: verify one cloned site (source-vs-clone)
   cutoverCheck: () => Promise<void> // slice 6: read + classify each site's DNS record
   startCutover: () => void // slice 6: flip every "ready" record to the new IP (batched)
@@ -2276,7 +2283,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   // checked just now)" — re-verify can't cure a zone that genuinely isn't live yet; the
   // user must finish NS delegation. See memory dns-zone-resolution-staleness.
   const resolveZoneConn = useCallback(
-    async (hostname: string): Promise<{ zone: ZoneHost; conn: Connection } | { error: string }> => {
+    async (hostname: string): Promise<{ zone: ZoneHost; conn: Connection } | { error: string; zone?: ZoneHost }> => {
       const zone = await resolveZone(hostname)
       if (!zone) return { error: `Couldn't find the DNS zone for ${hostname}.` }
       // Match against the cache ref (not the providerZones state) so a re-verify
@@ -2290,14 +2297,14 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         const prov = apiProviderFor(zone.providerKey)
         const accounts = prov ? allConnections.filter((c) => c.provider === prov) : []
         if (accounts.length === 0) {
-          return { error: `No ${zone.providerLabel} account is connected for ${zone.apex} — add one in the DNS view (N) first.` }
+          return { error: `No ${zone.providerLabel} account is connected for ${zone.apex} — add one in the DNS view (N) first.`, zone }
         }
         // An account is connected but its cached zones don't list this zone — most
         // likely a stale cache (zone added since the last verify). Re-verify + retry.
         await Promise.all(accounts.map((c) => verifyAndCache(c)))
         conn = find()
         if (!conn) {
-          return { error: `Your ${zone.providerLabel} account doesn't serve ${zone.apex} (re-checked just now) — confirm the zone exists in that account.` }
+          return { error: `Your ${zone.providerLabel} account doesn't serve ${zone.apex} (re-checked just now) — confirm the zone exists in that account.`, zone }
         }
       }
       return { zone, conn }
@@ -2874,7 +2881,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       try {
         if (site.stack === "bedrock" && !site.gitRepo) return fail("create", "the source Bedrock site has no git repo to clone from.")
         // create — Bedrock → `git` site (SpinupWP clones the repo); Standard WP → blank.
-        set((s) => ({ ...s, step: "create", error: undefined, failedStep: undefined, detail: undefined }))
+        set((s) => ({ ...s, step: "create", error: undefined, failedStep: undefined, detail: undefined, stageStartedAt: Date.now() }))
         const dbName = site.destDbName ?? site.siteUser
         const dbPw = site.destDbPassword ?? randomToken(28)
         logger?.redact(dbPw)
@@ -2963,7 +2970,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           stage === "build" ? "deploy" : stage === "config" ? "config" : stage === "verify" ? "verify" : "pull"
         const onProgress = (stage: CloneStage, status: "start" | "ok" | "fail") => {
           if (status !== "start") return
-          set((s) => ({ ...s, step: stageToStep(stage), detail: stage }))
+          set((s) => ({ ...s, step: stageToStep(stage), detail: stage, stageStartedAt: Date.now() }))
         }
         const onExec = logger ? (e: CloneExecRecord) => logger.log({ event: "exec", ...e }) : undefined
         const res =
@@ -3063,6 +3070,21 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     }
   }, [cloneJob])
 
+  // Space on a ready cutover row: include/exclude it from the batch flip.
+  const toggleCutoverExclude = useCallback((siteId: number, name: string) => {
+    setCloneJob((j) => {
+      if (!j) return j
+      return {
+        ...j,
+        sites: j.sites.map((s) =>
+          s.sourceSiteId === siteId && s.cutover
+            ? { ...s, cutover: { ...s.cutover, records: s.cutover.records.map((r) => (r.name === name && r.status === "ready" ? { ...r, excluded: !r.excluded } : r)) } }
+            : s,
+        ),
+      }
+    })
+  }, [])
+
   // The explicit continue: only valid once every selected site has settled and at
   // least one clone succeeded.
   const cloneContinueToCutover = useCallback(() => {
@@ -3111,18 +3133,26 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           try {
             const rc = await resolveZoneConn(name)
             if ("error" in rc) {
-              records.push({ name, status: "manual", targetValue: targetIp, reason: rc.error })
+              // A web-handoff host (GoDaddy delegate access, Namecheap, …) is a
+              // deliberate way of working, not a misconfiguration — its manual
+              // reason is the user's access note (per-zone override, else the
+              // global default), not a "connect an account" scold. API-connectable
+              // hosts (Cloudflare/Route 53) keep the actionable error.
+              const zi = rc.zone
+              const web = zi ? consoleForHost(zi.providerKey) : null
+              const reason = web ? zoneAccessNotes.get(zi!.apex) || DEFAULT_WEB_ACCESS_NOTE : rc.error
+              records.push({ name, status: "manual", targetValue: targetIp, reason, apex: zi?.apex, hostKey: zi?.providerKey })
               continue
             }
             const res = await getZoneRecord(rc.conn.id, rc.zone.apex, name, "A")
             if (!res.ok || !res.record) {
               // No A record here — typically a www CNAME that follows the apex, or
               // absent. Skip silently; only flag a missing PRIMARY domain A.
-              if (name === site.domain) records.push({ name, status: "manual", targetValue: targetIp, reason: res.error ?? "no A record" })
+              if (name === site.domain) records.push({ name, status: "manual", targetValue: targetIp, reason: res.error ?? "no A record", apex: rc.zone.apex, hostKey: rc.zone.providerKey })
               continue
             }
             const cur = res.record.values[0] ?? ""
-            const base = { name, currentValue: cur, targetValue: targetIp }
+            const base = { name, currentValue: cur, targetValue: targetIp, apex: rc.zone.apex, hostKey: rc.zone.providerKey }
             // Cutover repoints the VALUE, not the TTL — a Cloudflare proxied
             // record can't have its TTL edited but its origin IS still
             // PATCHable, so this checks valueEditable (falls back to editable
@@ -3138,7 +3168,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         setCloneSite(site.sourceSiteId, (s) => ({ ...s, cutover: { status: aggregateCutover(records), records } }))
       }),
     )
-  }, [cloneJob, destIpOf, resolveZoneConn, getZoneRecord, setCloneSite])
+  }, [cloneJob, destIpOf, resolveZoneConn, getZoneRecord, setCloneSite, zoneAccessNotes])
 
   // Flip every "ready" A record to the new IP, together (batched, across all sites).
   // Re-resolves zone+record at flip time (no creds held in state), repoints via
@@ -3149,7 +3179,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     const targetIp = destIpOf(j)
     if (!targetIp) return
     for (const site of j.sites.filter((s) => s.selected && s.cutover)) {
-      for (const rec of site.cutover!.records.filter((r) => r.status === "ready")) {
+      for (const rec of site.cutover!.records.filter((r) => r.status === "ready" && !r.excluded)) {
         const name = rec.name
         const upd = (fn: (r: CutoverRecord) => CutoverRecord) => setCutoverRecord(site.sourceSiteId, name, fn)
         upd((r) => ({ ...r, status: "flipping", error: undefined }))
@@ -3327,6 +3357,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     startClone,
     cloneRetrySite,
     cloneContinueToCutover,
+    toggleCutoverExclude,
     verifyCloneSite,
     cutoverCheck,
     startCutover,

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -39,7 +39,8 @@ import { recordProviderFor, type DnsRecord, type RecordResult } from "../lib/dns
 import { deriveSiteUser, seedVanityIndex, aRecordResolves } from "../lib/vanitySite.ts"
 import type { StoredProviders } from "../config.ts"
 import { fetchRebootInfo, grantSiteSshKey, revokeSiteSshKey, verifySudo, ensureSpinupKey, listPersonalKeys, keyBody, type RebootInfo } from "../lib/ssh.ts"
-import { estimateSourceSiteSizes, runStandardWpPull, runBedrockPull, verifyClone, type SudoCtx, type CloneStage, type VerifyResult as CloneVerifyResult } from "../lib/serverClone.ts"
+import { estimateSourceSiteSizes, runStandardWpPull, runBedrockPull, verifyClone, type SudoCtx, type CloneStage, type CloneExecRecord, type VerifyResult as CloneVerifyResult } from "../lib/serverClone.ts"
+import { CloneLogger } from "../lib/cloneLog.ts"
 import { parseRepo, deployKeysSettingsUrl, ghAvailable, ghDeployKeyPresent, ghAddDeployKey, type RepoHost } from "../lib/gitDeployKey.ts"
 import { keychainAvailable, setSudoPassword, getSudoPassword, deleteSudoPassword } from "../lib/keychain.ts"
 import { StackCache, siteSignature, type CachedProbe } from "../lib/stackCache.ts"
@@ -196,6 +197,7 @@ export interface CloneSiteState {
   domain: string
   siteUser: string // source site_user — reused on the dest + for the source-side pull
   selected: boolean // unchecked in Plan → skipped entirely
+  isWordPress: boolean // API is_wordpress — false (non-git) = redirect/static site the WP chain can't clone
   sizeBytes?: number // webroot + DB estimate (sizing + progress); undefined until sized
   stack: "wp" | "bedrock" // from source git.repo → drives blank-vs-git create
   gitRepo?: string // source git.repo (Bedrock) — the dest is created as a `git` site of it
@@ -203,7 +205,10 @@ export interface CloneSiteState {
   additionalDomains?: string[] // extra domains served by the site → extra cutover records
   excludeUploads: boolean // per-site opt-out (default false = sync uploads/)
   phpVersion?: string // matched from source for the dest create
-  publicFolder?: string // matched from source for the dest create
+  publicFolder?: string // matched from source for the dest create + where WP lives under files/
+  tablePrefix?: string // source DB table_prefix — the dest DB is created to match
+  sourceWebrootRel?: string // DETECTED source WP dir rel to files/ ("" = files root), from the pull
+  destWebrootRel?: string // the clone's WP dir rel to files/ (post-normalization), from the pull
   destSiteId?: number
   destDbName?: string // dest DB creds (generated at create; reused on retry)
   destDbPassword?: string
@@ -262,6 +267,13 @@ export interface CloneJob {
   repoKeys?: RepoKeyState[] // deploy-key onboarding (Bedrock dests; gitaccess step)
   fanoutStarted?: boolean // startClone ran — survives the wizard being backgrounded/reopened
   startedAt: number
+  logPath?: string // per-job JSONL log (full stage output; the roster only shows truncated errors)
+}
+// A site the WP pull chain can work on: WordPress, or a git site (is_wordpress is
+// unreliable for git sites — see the API findings doc). is_wordpress:false non-git
+// sites (redirect shells, static placeholders) have no wp-config/DB to clone.
+export function cloneSiteSupported(s: CloneSiteState): boolean {
+  return s.isWordPress || s.stack === "bedrock"
 }
 // The gitaccess step is only needed when a selected site is Bedrock (a git repo whose
 // dest the new server must be authorized to clone).
@@ -831,6 +843,8 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   // Plan draft (and, in later slices, the running fan-out).
   const [cloneServer, setCloneServer] = useState<Server | null>(null)
   const [cloneJob, setCloneJob] = useState<CloneJob | null>(null)
+  // Per-job clone log (survives backgrounding/retries; a new job gets a new file).
+  const cloneLogRef = useRef<CloneLogger | null>(null)
   const [providerMetadata, setProviderMetadata] = useState<Map<string, ProviderMetadata>>(new Map())
   const [providerMetadataLoading, setProviderMetadataLoading] = useState<Set<string>>(new Set())
   const [providerMetadataError, setProviderMetadataError] = useState<Map<string, string>>(new Map())
@@ -2647,20 +2661,28 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         return
       }
       const srcSites = sitesForServer(server.id)
-      const sites: CloneSiteState[] = srcSites.map((s) => ({
-        sourceSiteId: s.id,
-        domain: s.domain,
-        siteUser: s.site_user ?? "",
-        selected: true,
-        stack: cloneStackFor(s),
-        gitRepo: s.git?.repo ?? undefined,
-        gitBranch: s.git?.branch ?? undefined,
-        additionalDomains: (s.additional_domains ?? []).map((d) => d.domain),
-        excludeUploads: false,
-        phpVersion: s.php_version ?? undefined,
-        publicFolder: s.public_folder ?? undefined,
-        step: "queued",
-      }))
+      const sites: CloneSiteState[] = srcSites.map((s) => {
+        const stack = cloneStackFor(s)
+        const isWordPress = s.is_wordpress
+        return {
+          sourceSiteId: s.id,
+          domain: s.domain,
+          siteUser: s.site_user ?? "",
+          // Non-WP, non-git sites (redirect shells, placeholders) can't be cloned by
+          // the WP chain — excluded up front rather than failing mid-pull.
+          selected: isWordPress || stack === "bedrock",
+          isWordPress,
+          stack,
+          gitRepo: s.git?.repo ?? undefined,
+          gitBranch: s.git?.branch ?? undefined,
+          additionalDomains: (s.additional_domains ?? []).map((d) => d.domain),
+          excludeUploads: false,
+          phpVersion: s.php_version ?? undefined,
+          publicFolder: s.public_folder ?? undefined,
+          tablePrefix: s.database?.table_prefix ?? undefined,
+          step: "queued" as CloneSiteStep,
+        }
+      })
       const draft: CloneJob = {
         sourceServerId: server.id,
         sourceServerName: server.name,
@@ -2688,7 +2710,9 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const toggleCloneSite = useCallback(
-    (id: number) => mutateCloneSite(id, (s) => ({ ...s, selected: !s.selected })),
+    // Unsupported sites (not WordPress, no git repo) stay deselected — selecting one
+    // would only re-run the 2026-07-02 failure mode.
+    (id: number) => mutateCloneSite(id, (s) => (cloneSiteSupported(s) ? { ...s, selected: !s.selected } : s)),
     [mutateCloneSite],
   )
   const toggleCloneSiteUploads = useCallback(
@@ -2804,7 +2828,9 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     const sudoUser = srv ? sudoUsers.get(srv.id) : undefined
     const pw = srv ? sudoPwRef.current.get(srv.id) : undefined
     if (!srv || !sudoUser || pw == null) return
-    const inputs = j.sites.map((s) => ({ siteId: s.sourceSiteId, domain: s.domain, siteUser: s.siteUser }))
+    // publicFolder only for Standard WP: Bedrock's wp-cli runs from the project root
+    // (files/, via wp-cli.yml), not from its /web/ public folder.
+    const inputs = j.sites.map((s) => ({ siteId: s.sourceSiteId, domain: s.domain, siteUser: s.siteUser, publicFolder: s.stack === "wp" ? s.publicFolder : undefined }))
     const sizes = await estimateSourceSiteSizes(srv, sudoUser, pw, inputs)
     if (sizes.size === 0) return
     setCloneJob((cur) =>
@@ -2836,13 +2862,19 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const driveCloneSite = useCallback(
     async (site: CloneSiteState, source: SudoCtx, dest: SudoCtx, destServerId: number) => {
       const set = (fn: (s: CloneSiteState) => CloneSiteState) => setCloneSite(site.sourceSiteId, fn)
-      const fail = (failedStep: CloneSiteStep, error: string) => set((s) => ({ ...s, step: "error", failedStep, error, detail: undefined }))
+      const logger = cloneLogRef.current
+      const fail = (failedStep: CloneSiteStep, error: string) => {
+        logger?.log({ event: "site-failed", domain: site.domain, failedStep, error })
+        set((s) => ({ ...s, step: "error", failedStep, error, detail: undefined }))
+      }
       try {
         if (site.stack === "bedrock" && !site.gitRepo) return fail("create", "the source Bedrock site has no git repo to clone from.")
         // create — Bedrock → `git` site (SpinupWP clones the repo); Standard WP → blank.
         set((s) => ({ ...s, step: "create", error: undefined, failedStep: undefined, detail: undefined }))
         const dbName = site.destDbName ?? site.siteUser
         const dbPw = site.destDbPassword ?? randomToken(28)
+        logger?.redact(dbPw)
+        logger?.log({ event: "site-start", domain: site.domain, stack: site.stack, publicFolder: site.publicFolder, tablePrefix: site.tablePrefix, reusedDestSiteId: site.destSiteId })
         set((s) => ({ ...s, destDbName: dbName, destDbPassword: dbPw }))
         // Reuse only within THIS job (destSiteId already captured = retry/resume).
         // We deliberately do NOT adopt a pre-existing dest site found by domain: its
@@ -2861,7 +2893,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
                     installation_method: "git",
                     php_version: site.phpVersion,
                     public_folder: site.publicFolder ?? "/web/",
-                    database: { name: dbName, username: dbName, password: dbPw, table_prefix: "wp_" },
+                    database: { name: dbName, username: dbName, password: dbPw, table_prefix: site.tablePrefix || "wp_" },
                     // deploy_script is TOP-LEVEL; we send the corrected canonical (the
                     // source's stored value has a known typo) for future push-to-deploy —
                     // we composer install over SSH regardless (git/deploy won't run it).
@@ -2875,9 +2907,10 @@ export function StoreProvider({ children }: { children: ReactNode }) {
                     installation_method: "blank",
                     php_version: site.phpVersion,
                     public_folder: site.publicFolder,
-                    database: { name: dbName, username: dbName, password: dbPw, table_prefix: "wp_" },
+                    database: { name: dbName, username: dbName, password: dbPw, table_prefix: site.tablePrefix || "wp_" },
                   }
             ev = await client.createSite(payload)
+            logger?.log({ event: "create-requested", domain: site.domain, eventId: ev?.event_id })
           } catch (err) {
             return fail("create", err instanceof ApiError ? err.message : (err as Error).message)
           }
@@ -2911,15 +2944,18 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           if (status !== "start") return
           set((s) => ({ ...s, step: stageToStep(stage), detail: stage }))
         }
+        const onExec = logger ? (e: CloneExecRecord) => logger.log({ event: "exec", ...e }) : undefined
         const res =
           site.stack === "bedrock"
-            ? await runBedrockPull(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, destDbName: dbName, destDbUser: dbName, destDbPassword: dbPw, excludeUploads: site.excludeUploads }, onProgress)
-            : await runStandardWpPull(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, destDbName: dbName, destDbUser: dbName, destDbPassword: dbPw }, onProgress)
+            ? await runBedrockPull(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, destDbName: dbName, destDbUser: dbName, destDbPassword: dbPw, excludeUploads: site.excludeUploads }, onProgress, onExec)
+            : await runStandardWpPull(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, destDbName: dbName, destDbUser: dbName, destDbPassword: dbPw, publicFolder: site.publicFolder }, onProgress, onExec)
         if (!res.ok) {
           const stage = (res.error?.split(":")[0] ?? "pull") as CloneStage
           return fail(stageToStep(stage), res.error ?? "pull failed")
         }
-        set((s) => ({ ...s, step: "done", detail: undefined, error: undefined, failedStep: undefined }))
+        const { sourceWebrootRel, destWebrootRel } = res as { sourceWebrootRel?: string; destWebrootRel?: string }
+        logger?.log({ event: "site-done", domain: site.domain, sourceWebrootRel, destWebrootRel })
+        set((s) => ({ ...s, step: "done", detail: undefined, error: undefined, failedStep: undefined, sourceWebrootRel, destWebrootRel }))
       } catch (err) {
         fail(site.step, (err as Error).message)
       }
@@ -2937,7 +2973,12 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     const dest = sudoCtxFor(j.destServerId)
     if (!source || !dest) return // both ends must be sudo-connected (trust step ensured)
     const destServerId = j.destServerId
-    setCloneJob((cur) => (cur ? { ...cur, step: "clone", fanoutStarted: true, sites: cur.sites.map((s) => (s.selected ? { ...s, step: "queued" as CloneSiteStep, error: undefined, failedStep: undefined } : s)) } : cur))
+    // One log file per job; sudo passwords registered for redaction up front.
+    const logger = new CloneLogger(`${j.sourceServerName}-to-${j.destServerName || String(destServerId)}`)
+    logger.redact(source.sudoPassword, dest.sudoPassword)
+    logger.log({ event: "job-start", source: j.sourceServerName, dest: j.destServerName, destServerId, sites: j.sites.filter((s) => s.selected).map((s) => s.domain), concurrency: j.concurrency })
+    cloneLogRef.current = logger
+    setCloneJob((cur) => (cur ? { ...cur, step: "clone", fanoutStarted: true, logPath: logger.path, sites: cur.sites.map((s) => (s.selected ? { ...s, step: "queued" as CloneSiteStep, error: undefined, failedStep: undefined } : s)) } : cur))
     const queue = j.sites.filter((s) => s.selected)
     let cursor = 0
     const worker = async () => {
@@ -2958,6 +2999,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       const source = sudoCtxFor(j.sourceServerId)
       const dest = sudoCtxFor(j.destServerId)
       if (!site || !source || !dest) return
+      cloneLogRef.current?.log({ event: "site-retry", domain: site.domain })
       void driveCloneSite(site, source, dest, j.destServerId)
     },
     [cloneJob, sudoCtxFor, driveCloneSite],
@@ -2977,7 +3019,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       setCloneSite(siteId, (s) => ({ ...s, verifying: true, verifyError: undefined }))
       void (async () => {
         try {
-          const res = await verifyClone(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, destIp })
+          const res = await verifyClone(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, destIp, publicFolder: site.stack === "wp" ? site.publicFolder : undefined, sourceWebrootRel: site.stack === "wp" ? site.sourceWebrootRel : undefined, destWebrootRel: site.stack === "wp" ? site.destWebrootRel : undefined })
           setCloneSite(siteId, (s) => ({ ...s, verifying: false, verify: res }))
         } catch (err) {
           setCloneSite(siteId, (s) => ({ ...s, verifying: false, verifyError: (err as Error).message }))

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -202,6 +202,7 @@ export interface CloneSiteState {
   selected: boolean // unchecked in Plan → skipped entirely
   isWordPress: boolean // API is_wordpress — false (non-git) = redirect/static site the WP chain can't clone
   sizeBytes?: number // webroot + DB estimate (sizing + progress); undefined until sized
+  sizeWebBytes?: number // webroot-only bytes (uncompressed) — the files-transfer soft ceiling
   stack: "wp" | "bedrock" // from source git.repo → drives blank-vs-git create
   gitRepo?: string // source git.repo (Bedrock) — the dest is created as a `git` site of it
   gitBranch?: string // source git.branch
@@ -221,6 +222,8 @@ export interface CloneSiteState {
   stageStartedAt?: number // when the current step/stage began — drives the roster's elapsed timer
   transferBytes?: number // bytes received so far in the current transfer (sidecar stat poll)
   transferRate?: number // smoothed bytes/sec derived from successive polls
+  transferTarget?: number // expected final size when known
+  transferExact?: boolean // true = target is a fact (staged DB dump) → real percent; false = soft ceiling
   failedStep?: CloneSiteStep
   error?: string
   verifying?: boolean // slice 5: verify drill-down in flight
@@ -2847,7 +2850,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     const sizes = await estimateSourceSiteSizes(srv, sudoUser, pw, inputs)
     if (sizes.size === 0) return
     setCloneJob((cur) =>
-      cur ? { ...cur, sites: cur.sites.map((s) => (sizes.has(s.sourceSiteId) ? { ...s, sizeBytes: sizes.get(s.sourceSiteId) } : s)) } : cur,
+      cur ? { ...cur, sites: cur.sites.map((s) => { const e = sizes.get(s.sourceSiteId); return e ? { ...s, sizeBytes: e.total, sizeWebBytes: e.web } : s }) } : cur,
     )
   }, [cloneJob, servers, sudoUsers])
 
@@ -2972,15 +2975,15 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           stage === "build" ? "deploy" : stage === "config" ? "config" : stage === "verify" ? "verify" : "pull"
         const onProgress = (stage: CloneStage, status: "start" | "ok" | "fail") => {
           if (status !== "start") return
-          set((s) => ({ ...s, step: stageToStep(stage), detail: stage, stageStartedAt: Date.now(), transferBytes: undefined, transferRate: undefined }))
+          set((s) => ({ ...s, step: stageToStep(stage), detail: stage, stageStartedAt: Date.now(), transferBytes: undefined, transferRate: undefined, transferTarget: undefined, transferExact: undefined }))
         }
         // Sidecar byte progress: rate from successive samples (poll cadence ~5s).
         const transferAtRef = { at: 0 }
-        const onTransfer = (_stage: CloneStage, bytes: number) => {
+        const onTransfer = (_stage: CloneStage, bytes: number, target?: number, exact?: boolean) => {
           const at = Date.now()
           set((s) => {
             const rate = s.transferBytes != null && bytes > s.transferBytes && transferAtRef.at > 0 ? ((bytes - s.transferBytes) / (at - transferAtRef.at)) * 1000 : s.transferRate
-            return { ...s, transferBytes: bytes, transferRate: rate }
+            return { ...s, transferBytes: bytes, transferRate: rate, transferTarget: target, transferExact: exact }
           })
           transferAtRef.at = at
         }
@@ -2988,7 +2991,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         const res =
           site.stack === "bedrock"
             ? await runBedrockPull(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, destDbName: dbName, destDbUser: dbName, destDbPassword: dbPw, excludeUploads: site.excludeUploads }, onProgress, onExec, onTransfer)
-            : await runStandardWpPull(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, destDbName: dbName, destDbUser: dbName, destDbPassword: dbPw, publicFolder: site.publicFolder }, onProgress, onExec, onTransfer)
+            : await runStandardWpPull(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, destDbName: dbName, destDbUser: dbName, destDbPassword: dbPw, publicFolder: site.publicFolder, approxFilesBytes: site.sizeWebBytes }, onProgress, onExec, onTransfer)
         if (!res.ok) {
           const stage = (res.error?.split(":")[0] ?? "pull") as CloneStage
           return fail(stageToStep(stage), res.error ?? "pull failed")

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -8,7 +8,7 @@
 import { createContext, useContext, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
 import { toast } from "@opentui-ui/toast"
 import { SpinupWPClient, ApiError, type ServerService } from "../api/client.ts"
-import type { Server, Site, Event, ProviderMetadata, CreateServerPayload, CreateSitePayload } from "../api/types.ts"
+import type { Server, Site, Event, ProviderMetadata, CreateServerPayload, CreateSitePayload, AdditionalDomain } from "../api/types.ts"
 import { loadConfig, saveConfig, type ServerProviderRef } from "../config.ts"
 import { saveJob, removeJob } from "../lib/jobs.ts"
 import { APP_VERSION } from "../version.ts"
@@ -41,6 +41,7 @@ import type { StoredProviders } from "../config.ts"
 import { fetchRebootInfo, grantSiteSshKey, revokeSiteSshKey, verifySudo, ensureSpinupKey, listPersonalKeys, keyBody, type RebootInfo } from "../lib/ssh.ts"
 import { estimateSourceSiteSizes, runStandardWpPull, runBedrockPull, verifyClone, type SudoCtx, type CloneStage, type CloneExecRecord, type VerifyResult as CloneVerifyResult } from "../lib/serverClone.ts"
 import { CloneLogger } from "../lib/cloneLog.ts"
+import { syncAdditionalDomains } from "../lib/cloneDomains.ts"
 import { parseRepo, deployKeysSettingsUrl, ghAvailable, ghDeployKeyPresent, ghAddDeployKey, type RepoHost } from "../lib/gitDeployKey.ts"
 import { keychainAvailable, setSudoPassword, getSudoPassword, deleteSudoPassword } from "../lib/keychain.ts"
 import { StackCache, siteSignature, type CachedProbe } from "../lib/stackCache.ts"
@@ -203,6 +204,7 @@ export interface CloneSiteState {
   gitRepo?: string // source git.repo (Bedrock) — the dest is created as a `git` site of it
   gitBranch?: string // source git.branch
   additionalDomains?: string[] // extra domains served by the site → extra cutover records
+  additionalDomainConfigs?: AdditionalDomain[] // full source configs (redirects) — re-created on the dest
   excludeUploads: boolean // per-site opt-out (default false = sync uploads/)
   phpVersion?: string // matched from source for the dest create
   publicFolder?: string // matched from source for the dest create + where WP lives under files/
@@ -2676,6 +2678,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           gitRepo: s.git?.repo ?? undefined,
           gitBranch: s.git?.branch ?? undefined,
           additionalDomains: (s.additional_domains ?? []).map((d) => d.domain),
+          additionalDomainConfigs: s.additional_domains ?? [],
           excludeUploads: false,
           phpVersion: s.php_version ?? undefined,
           publicFolder: s.public_folder ?? undefined,
@@ -2936,6 +2939,18 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           }
         }
         set((s) => ({ ...s, destSiteId }))
+        // additional domains — a fresh dest site answers ONLY its primary domain;
+        // re-create the source's set (with redirect settings) or the later DNS
+        // cutover would repoint hostnames the dest doesn't serve. Idempotent on retry.
+        const extraDomains = site.additionalDomainConfigs ?? []
+        if (destSiteId != null && extraDomains.length > 0) {
+          set((s) => ({ ...s, detail: "domains" }))
+          const dres = await syncAdditionalDomains(client, destSiteId, extraDomains, logger ? (e) => logger.log(e) : undefined)
+          if (dres.failed.length > 0) {
+            const f = dres.failed[0]!
+            return fail("create", `couldn't add ${dres.failed.length === 1 ? `domain ${f.domain}` : `${dres.failed.length} domains (${dres.failed.map((x) => x.domain).join(", ")})`}: ${f.error}`)
+          }
+        }
         // pull chain — stack-appropriate runner. Map its stage → roster step.
         set((s) => ({ ...s, step: "pull", detail: "starting" }))
         const stageToStep = (stage: CloneStage): CloneSiteStep =>

--- a/src/ui/views/Browser.tsx
+++ b/src/ui/views/Browser.tsx
@@ -225,6 +225,7 @@ export function Browser({ rows }: { rows: number }) {
           { key: "u", label: "change PHP" },
           { key: "K", label: "grant key" },
           { key: "o", label: "open" },
+          { key: "w", label: "SpinupWP" },
           { key: "s", label: "ssh" },
           { key: "h", label: "health" },
         ]

--- a/src/ui/views/CloneWizard.tsx
+++ b/src/ui/views/CloneWizard.tsx
@@ -16,7 +16,7 @@ import { Panel, Spinner } from "../components.tsx"
 import { StatusBar } from "../StatusBar.tsx"
 import { openUrl } from "../../lib/open.ts"
 import { serverWebUrl } from "../../lib/spinupweb.ts"
-import { useStore, cloneNeedsGitAccess, type CloneStep, type CloneSiteStep, type RepoKeyState } from "../store.tsx"
+import { useStore, cloneNeedsGitAccess, cloneSiteSupported, type CloneStep, type CloneSiteStep, type RepoKeyState } from "../store.tsx"
 import type { VerifyCheck } from "../../lib/serverClone.ts"
 
 // Choosing an existing server as the dest is a first-class feature now (the `d` picker
@@ -258,9 +258,15 @@ export function CloneWizard() {
 
     if (job.step === "clone" || job.step === "done") {
       const sel = job.sites.filter((s) => s.selected)
-      // While drilled into a verify view, only re-run (v) and ←/Esc(handled above) apply.
+      // While drilled into a verify/failure view: v re-runs verify (done sites),
+      // r retries the drilled FAILED site, ←/Esc(handled above) goes back.
       if (verifyOpen != null) {
-        if (name === "v") return verifyCloneSite(verifyOpen)
+        const drilled = job.sites.find((s) => s.sourceSiteId === verifyOpen)
+        if (name === "r" && drilled?.step === "error") {
+          setVerifyOpen(null)
+          return cloneRetrySite(verifyOpen)
+        }
+        if (name === "v" && drilled?.step === "done") return verifyCloneSite(verifyOpen)
         if (name === "left" || name === "h") return setVerifyOpen(null)
         return
       }
@@ -272,6 +278,11 @@ export function CloneWizard() {
       if ((name === "v" || name === "return") && cur && cur.step === "done") {
         setVerifyOpen(cur.sourceSiteId)
         verifyCloneSite(cur.sourceSiteId)
+        return
+      }
+      // Enter on a FAILED site — drill into the full (untruncated) error.
+      if (name === "return" && cur && cur.step === "error") {
+        setVerifyOpen(cur.sourceSiteId)
         return
       }
       // r — retry every failed site.
@@ -352,7 +363,10 @@ export function CloneWizard() {
     if (job!.step === "server") return serverPane()
     if (job!.step === "trust") return trustPane()
     if (job!.step === "gitaccess") return gitAccessPane()
-    if ((job!.step === "clone" || job!.step === "done") && verifyOpen != null) return verifyPane(verifyOpen)
+    if ((job!.step === "clone" || job!.step === "done") && verifyOpen != null) {
+      const drilled = job!.sites.find((s) => s.sourceSiteId === verifyOpen)
+      return drilled?.step === "error" ? failurePane(verifyOpen) : verifyPane(verifyOpen)
+    }
     if (job!.step === "clone" || job!.step === "done") return clonePane()
     if (job!.step === "cutover") return cutoverPane()
     // error — scaffolding for now.
@@ -543,8 +557,9 @@ export function CloneWizard() {
             const mark = s.selected ? "◉" : "◯"
             const markColor = s.selected ? theme.good : theme.textFaint
             const size = s.sizeBytes != null ? formatBytes(s.sizeBytes) : "—"
-            const tag = s.stack === "bedrock" ? "bedrock" : ""
-            const note = !s.selected ? " (skipped)" : s.excludeUploads ? " (no uploads)" : ""
+            const supported = cloneSiteSupported(s)
+            const tag = s.stack === "bedrock" ? "bedrock" : !supported ? "not WP" : ""
+            const note = !supported ? " (nothing to clone)" : !s.selected ? " (skipped)" : s.excludeUploads ? " (no uploads)" : ""
             return (
               <box key={s.sourceSiteId} style={{ flexDirection: "row", height: 1, backgroundColor: sel ? theme.bgAlt : undefined }}>
                 <text content={` ${mark} `} fg={markColor} style={{ flexShrink: 0 }} />
@@ -657,6 +672,7 @@ export function CloneWizard() {
           <box style={{ flexGrow: 1 }} />
           <text content={`✓ ${done} done · ⠹ ${running} running · ${queued} queued${errored ? ` · ✕ ${errored} failed` : ""}`} fg={theme.textDim} wrapMode="none" />
           {done > 0 ? <text content="↑↓ select · v verify a done site" fg={theme.textFaint} wrapMode="none" /> : null}
+          {errored > 0 ? <text content={`⏎ on a failed site — full error${job!.logPath ? ` · log: ${job!.logPath}` : ""}`} fg={theme.textFaint} wrapMode="none" /> : null}
           {job!.step === "clone" ? (
             <text content={errored > 0 ? "r retry failed · esc — clone keeps running in the background" : "esc — clone keeps running in the background (reopen with C)"} fg={theme.textFaint} wrapMode="none" />
           ) : (
@@ -713,6 +729,28 @@ export function CloneWizard() {
     )
   }
 
+  // Failure drill-down — the FULL error for one failed site (the roster truncates it),
+  // plus where the complete stage-by-stage log lives on disk.
+  function failurePane(siteId: number) {
+    const site = job!.sites.find((s) => s.sourceSiteId === siteId)
+    if (!site) return null
+    return (
+      <Panel title={` Failed · ${site.domain} `} active>
+        <box style={{ flexDirection: "column", flexGrow: 1, paddingTop: 1 }}>
+          <box style={{ flexDirection: "row", height: 1 }}>
+            <text content="✕ failed at: " fg={theme.bad} style={{ flexShrink: 0 }} />
+            <text content={site.failedStep ?? "?"} fg={theme.text} wrapMode="none" style={{ flexShrink: 1 }} />
+          </box>
+          <box style={{ height: 1 }} />
+          <text content={site.error ?? "no error captured"} fg={theme.text} />
+          <box style={{ flexGrow: 1 }} />
+          {job!.logPath ? <text content={`Full stage-by-stage output: ${job!.logPath}`} fg={theme.textFaint} /> : null}
+          <text content="r retry this site · ← back to roster" fg={theme.textFaint} wrapMode="none" />
+        </box>
+      </Panel>
+    )
+  }
+
   function hints() {
     if (job!.step === "plan") {
       return [
@@ -740,7 +778,11 @@ export function CloneWizard() {
       ]
     }
     if (job!.step === "clone" || job!.step === "done") {
-      if (verifyOpen != null) return [{ key: "v", label: "re-run" }, { key: "←", label: "back" }, { key: "esc", label: "close" }]
+      if (verifyOpen != null) {
+        const drilled = job!.sites.find((s) => s.sourceSiteId === verifyOpen)
+        if (drilled?.step === "error") return [{ key: "r", label: "retry site" }, { key: "←", label: "back" }, { key: "esc", label: "close" }]
+        return [{ key: "v", label: "re-run" }, { key: "←", label: "back" }, { key: "esc", label: "close" }]
+      }
       const done = selected.filter((s) => s.step === "done").length
       const errored = selected.filter((s) => s.step === "error").length
       return [

--- a/src/ui/views/CloneWizard.tsx
+++ b/src/ui/views/CloneWizard.tsx
@@ -17,7 +17,7 @@ import { StatusBar } from "../StatusBar.tsx"
 import { openUrl, copyToClipboard } from "../../lib/open.ts"
 import { consoleForHost } from "../../lib/providers.ts"
 import { serverWebUrl } from "../../lib/spinupweb.ts"
-import { useStore, cloneNeedsGitAccess, cloneSiteSupported, type CloneStep, type CloneSiteStep, type RepoKeyState } from "../store.tsx"
+import { useStore, cloneNeedsGitAccess, type CloneStep, type CloneSiteStep, type RepoKeyState } from "../store.tsx"
 import type { VerifyCheck } from "../../lib/serverClone.ts"
 
 // Choosing an existing server as the dest is a first-class feature now (the `d` picker
@@ -598,9 +598,8 @@ export function CloneWizard() {
             const mark = s.selected ? "◉" : "◯"
             const markColor = s.selected ? theme.good : theme.textFaint
             const size = s.sizeBytes != null ? formatBytes(s.sizeBytes) : "—"
-            const supported = cloneSiteSupported(s)
-            const tag = s.stack === "bedrock" ? "bedrock" : !supported ? "not WP" : ""
-            const note = !supported ? " (nothing to clone)" : !s.selected ? " (skipped)" : s.excludeUploads ? " (no uploads)" : ""
+            const tag = s.stack === "bedrock" ? "bedrock" : s.stack === "files" ? "files only" : ""
+            const note = !s.selected ? " (skipped)" : s.excludeUploads ? " (no uploads)" : ""
             return (
               <box key={s.sourceSiteId} style={{ flexDirection: "row", height: 1, backgroundColor: sel ? theme.bgAlt : undefined }}>
                 <text content={` ${mark} `} fg={markColor} style={{ flexShrink: 0 }} />

--- a/src/ui/views/CloneWizard.tsx
+++ b/src/ui/views/CloneWizard.tsx
@@ -694,8 +694,10 @@ export function CloneWizard() {
     const running = selected.filter((s) => !["queued", "done", "error"].includes(s.step)).length
     const errored = selected.filter((s) => s.step === "error").length
     const queued = selected.filter((s) => s.step === "queued").length
+    // "· 3 at a time" only earns its place when there's actually a queue.
+    const title = selected.length === 1 ? " Clone site " : selected.length > job!.concurrency ? ` Clone sites · up to ${job!.concurrency} at a time ` : " Clone sites "
     return (
-      <Panel title={` Clone sites · ${job!.concurrency} at a time `} active>
+      <Panel title={title} active>
         <box style={{ flexDirection: "column", flexGrow: 1, paddingTop: 1 }}>
           {selected.map((s, i) => {
             const active = !["queued", "done", "error"].includes(s.step)

--- a/src/ui/views/CloneWizard.tsx
+++ b/src/ui/views/CloneWizard.tsx
@@ -707,7 +707,7 @@ export function CloneWizard() {
                 <text content={` ${s.domain}`} fg={cur || s.step === "error" || s.step === "done" ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 1 }} />
                 <box style={{ flexGrow: 1 }} />
                 <text
-                  content={(s.step === "error" ? truncate(s.error ?? "failed", 24) : s.step === "done" ? "done" : s.step === "queued" ? "queued" : `${s.step}${s.detail ? " · " + s.detail : ""}${s.transferBytes != null ? ` · ${formatBytes(s.transferBytes)}${s.transferRate ? ` · ${formatBytes(s.transferRate)}/s` : ""}` : ""}${s.stageStartedAt ? " · " + fmtElapsed(now - s.stageStartedAt) : ""}`) + vmark}
+                  content={(s.step === "error" ? truncate(s.error ?? "failed", 24) : s.step === "done" ? "done" : s.step === "queued" ? "queued" : `${s.step}${s.detail ? " · " + s.detail : ""}${s.transferBytes != null ? ` · ${formatBytes(s.transferBytes)}${s.transferTarget ? ` of ${s.transferExact ? "" : "~"}${formatBytes(s.transferTarget)}` : ""}${s.transferExact && s.transferTarget ? ` (${Math.min(100, Math.round((s.transferBytes / s.transferTarget) * 100))}%)` : ""}${s.transferRate ? ` · ${formatBytes(s.transferRate)}/s` : ""}` : ""}${s.stageStartedAt ? " · " + fmtElapsed(now - s.stageStartedAt) : ""}`) + vmark}
                   fg={s.step === "error" || (s.verify && !s.verify.ok) ? theme.bad : s.verify?.ok ? theme.good : s.step === "done" ? theme.good : theme.textFaint}
                   wrapMode="none"
                   style={{ flexShrink: 0 }}

--- a/src/ui/views/CloneWizard.tsx
+++ b/src/ui/views/CloneWizard.tsx
@@ -59,6 +59,7 @@ export function CloneWizard() {
     cloneSizeSites,
     startClone,
     cloneRetrySite,
+    cloneContinueToCutover,
     verifyCloneSite,
     cutoverCheck,
     startCutover,
@@ -289,6 +290,12 @@ export function CloneWizard() {
       if (name === "r") {
         for (const s of job.sites) if (s.selected && s.step === "error") cloneRetrySite(s.sourceSiteId)
         return
+      }
+      // c — the explicit continue to DNS cutover (only once the roster settled
+      // with at least one success; cutover moves live traffic).
+      if (name === "c" && job.step === "clone") {
+        const settled = sel.length > 0 && sel.every((s) => s.step === "done" || s.step === "error")
+        if (settled && sel.some((s) => s.step === "done")) return cloneContinueToCutover()
       }
     }
 
@@ -645,6 +652,7 @@ export function CloneWizard() {
   // Live clone roster — one row per selected site, sub-step + spinner/✓/✕.
   function clonePane() {
     const done = selected.filter((s) => s.step === "done").length
+    const settled = selected.length > 0 && selected.every((s) => s.step === "done" || s.step === "error")
     const running = selected.filter((s) => !["queued", "done", "error"].includes(s.step)).length
     const errored = selected.filter((s) => s.step === "error").length
     const queued = selected.filter((s) => s.step === "queued").length
@@ -673,6 +681,9 @@ export function CloneWizard() {
           <text content={`✓ ${done} done · ⠹ ${running} running · ${queued} queued${errored ? ` · ✕ ${errored} failed` : ""}`} fg={theme.textDim} wrapMode="none" />
           {done > 0 ? <text content="↑↓ select · v verify a done site" fg={theme.textFaint} wrapMode="none" /> : null}
           {errored > 0 ? <text content={`⏎ on a failed site — full error${job!.logPath ? ` · log: ${job!.logPath}` : ""}`} fg={theme.textFaint} wrapMode="none" /> : null}
+          {settled && done > 0 && job!.step === "clone" ? (
+            <text content={`❯ c — continue to DNS cutover (${done} of ${selected.length} cloned; cutover moves LIVE traffic)`} fg={theme.brand} wrapMode="none" />
+          ) : null}
           {job!.step === "clone" ? (
             <text content={errored > 0 ? "r retry failed · esc — clone keeps running in the background" : "esc — clone keeps running in the background (reopen with C)"} fg={theme.textFaint} wrapMode="none" />
           ) : (
@@ -785,7 +796,9 @@ export function CloneWizard() {
       }
       const done = selected.filter((s) => s.step === "done").length
       const errored = selected.filter((s) => s.step === "error").length
+      const settled = selected.length > 0 && selected.every((s) => s.step === "done" || s.step === "error")
       return [
+        ...(settled && done > 0 && job!.step === "clone" ? [{ key: "c", label: "DNS cutover" }] : []),
         ...(done > 0 ? [{ key: "↑↓", label: "select" }, { key: "v", label: "verify" }] : []),
         ...(errored > 0 ? [{ key: "r", label: "retry failed" }] : []),
         { key: "esc", label: job!.step === "clone" ? "background" : "close" },

--- a/src/ui/views/CloneWizard.tsx
+++ b/src/ui/views/CloneWizard.tsx
@@ -14,7 +14,8 @@ import { useKeyboard } from "@opentui/react"
 import { theme } from "../../lib/theme.ts"
 import { Panel, Spinner } from "../components.tsx"
 import { StatusBar } from "../StatusBar.tsx"
-import { openUrl } from "../../lib/open.ts"
+import { openUrl, copyToClipboard } from "../../lib/open.ts"
+import { consoleForHost } from "../../lib/providers.ts"
 import { serverWebUrl } from "../../lib/spinupweb.ts"
 import { useStore, cloneNeedsGitAccess, cloneSiteSupported, type CloneStep, type CloneSiteStep, type RepoKeyState } from "../store.tsx"
 import type { VerifyCheck } from "../../lib/serverClone.ts"
@@ -60,6 +61,7 @@ export function CloneWizard() {
     startClone,
     cloneRetrySite,
     cloneContinueToCutover,
+    toggleCutoverExclude,
     verifyCloneSite,
     cutoverCheck,
     startCutover,
@@ -102,6 +104,21 @@ export function CloneWizard() {
       void cloneDetectRepoKeys()
     }
   }, [job?.step, cloneDetectRepoKeys])
+
+  // The cutover roster gets its own cursor run — reset it when we land there.
+  useEffect(() => {
+    if (job?.step === "cutover") setIdx(0)
+  }, [job?.step])
+
+  // Tick once a second while any selected site is mid-stage so the roster's
+  // elapsed readout counts up (long file pulls otherwise look frozen).
+  const [now, setNow] = useState(Date.now())
+  useEffect(() => {
+    if (job?.step !== "clone") return
+    if (!job.sites.some((s) => s.selected && !["queued", "done", "error"].includes(s.step))) return
+    const t = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(t)
+  }, [job?.step, job?.sites])
 
   // Read + classify each site's DNS record when we land on the cutover step — but
   // only if it hasn't been checked yet (so reopening a backgrounded wizard doesn't
@@ -300,10 +317,27 @@ export function CloneWizard() {
     }
 
     if (job.step === "cutover") {
-      // c — flip every "ready" record to the new server (the live-traffic write).
+      const recs = job.sites.filter((s) => s.selected && s.step === "done").flatMap((s) => (s.cutover?.records ?? []).map((r) => ({ r, siteId: s.sourceSiteId })))
+      const n = recs.length
+      if (n > 0 && (name === "up" || name === "k")) return setIdx((i) => (i - 1 + n) % n)
+      if (n > 0 && (name === "down" || name === "j")) return setIdx((i) => (i + 1) % n)
+      const cur = recs[Math.min(idx, Math.max(0, n - 1))]
+      // space — include/exclude a ready record from the batch flip.
+      if (name === "space" && cur && cur.r.status === "ready") return toggleCutoverExclude(cur.siteId, cur.r.name)
+      // ⏎ — open the zone's registrar/web console (zone copied for the
+      // delegate-access paste), for the manual rows the API can't flip.
+      if (name === "return" && cur) {
+        const con = cur.r.hostKey ? consoleForHost(cur.r.hostKey) : null
+        if (con) {
+          copyToClipboard(cur.r.apex ?? cur.r.name)
+          openUrl(con.url)
+        }
+        return
+      }
+      // c — flip every included "ready" record to the new server (the live-traffic write).
       if (name === "c") return startCutover()
       if (name === "r") return void cutoverCheck()
-      if (name === "return") return cloneCutoverFinish()
+      if (name === "f") return cloneCutoverFinish()
     }
   })
 
@@ -601,28 +635,32 @@ export function CloneWizard() {
     const cloned = selected.filter((s) => s.step === "done")
     const recs = cloned.flatMap((s) => (s.cutover?.records ?? []).map((r) => ({ r, siteId: s.sourceSiteId })))
     const count = (st: string) => recs.filter((x) => x.r.status === st).length
-    const ready = count("ready")
+    const ready = recs.filter((x) => x.r.status === "ready" && !x.r.excluded).length
+    const skipped = recs.filter((x) => x.r.status === "ready" && x.r.excluded).length
     const working = count("checking") + count("flipping")
     const cutDone = count("done")
     const manual = count("manual")
     const errored = count("error")
     const targetIp = job!.destServerIp || (job!.destServerId != null ? servers.find((s) => s.id === job!.destServerId)?.ip_address ?? "" : "") || "the new server"
-    const rowFor = ({ r, siteId }: (typeof recs)[number]) => {
+    const rowFor = ({ r, siteId }: (typeof recs)[number], i: number) => {
       const st = r.status
+      const cur = i === idx
       const busy = st === "checking" || st === "flipping"
-      const glyph = st === "done" ? "✓" : st === "manual" ? "!" : st === "error" ? "✕" : st === "ready" ? "○" : "·"
-      const gcolor = st === "done" ? theme.good : st === "manual" ? theme.warn : st === "error" ? theme.bad : st === "ready" ? theme.brand : theme.textFaint
+      // Ready rows read as include/exclude toggles (◉/◯, like Plan); the rest keep
+      // their status glyphs.
+      const glyph = st === "done" ? "✓" : st === "manual" ? "!" : st === "error" ? "✕" : st === "ready" ? (r.excluded ? "◯" : "◉") : "·"
+      const gcolor = st === "done" ? theme.good : st === "manual" ? theme.warn : st === "error" ? theme.bad : st === "ready" ? (r.excluded ? theme.textFaint : theme.brand) : theme.textFaint
       const detail =
         st === "checking" ? "reading DNS…"
         : st === "flipping" ? "updating…"
         : st === "done" ? `now → ${r.targetValue ?? targetIp}`
-        : st === "ready" ? `${r.currentValue ?? "?"} → ${r.targetValue ?? targetIp}`
+        : st === "ready" ? `${r.currentValue ?? "?"} → ${r.targetValue ?? targetIp}${r.excluded ? "  (skipped)" : ""}`
         : st === "manual" ? `manual: ${r.reason ?? "edit by hand"}`
         : st === "error" ? truncate(r.error ?? "failed", 28)
         : "pending"
-      const dcolor = st === "error" ? theme.bad : st === "done" ? theme.good : st === "manual" ? theme.warn : theme.textFaint
+      const dcolor = st === "error" ? theme.bad : st === "done" ? theme.good : st === "manual" ? theme.warn : cur ? theme.text : theme.textFaint
       return (
-        <box key={`${siteId}|${r.name}`} style={{ flexDirection: "row", height: 1 }}>
+        <box key={`${siteId}|${r.name}`} style={{ flexDirection: "row", height: 1, backgroundColor: cur ? theme.bgAlt : undefined }}>
           {busy ? <Spinner color={theme.brand} /> : <text content={glyph} fg={gcolor} style={{ flexShrink: 0 }} />}
           <text content={` ${r.name}`} fg={theme.text} wrapMode="none" style={{ flexShrink: 1 }} />
           <box style={{ flexGrow: 1 }} />
@@ -637,12 +675,12 @@ export function CloneWizard() {
           <box style={{ height: 1 }} />
           {recs.length === 0 ? <text content="Reading DNS…" fg={theme.textDim} wrapMode="none" /> : recs.map(rowFor)}
           <box style={{ flexGrow: 1 }} />
-          <text content={`✓ ${cutDone} cut over · ○ ${ready} ready · ⠹ ${working} working${manual ? ` · ! ${manual} manual` : ""}${errored ? ` · ✕ ${errored} failed` : ""}`} fg={theme.textDim} wrapMode="none" />
-          {manual > 0 ? <text content="Manual records can't be API-edited — repoint them in your DNS host." fg={theme.textFaint} wrapMode="none" /> : null}
+          <text content={`✓ ${cutDone} cut over · ◉ ${ready} ready${skipped ? ` · ◯ ${skipped} skipped` : ""} · ⠹ ${working} working${manual ? ` · ! ${manual} manual` : ""}${errored ? ` · ✕ ${errored} failed` : ""}`} fg={theme.textDim} wrapMode="none" />
+          {manual > 0 ? <text content="Manual records can't be API-edited — ⏎ opens that zone's registrar (zone name copied for the delegate-access paste)." fg={theme.textFaint} wrapMode="none" /> : null}
           {ready > 0 ? (
             <text content={`❯ c — cut over ${ready} record${ready === 1 ? "" : "s"} to the new server (live traffic)`} fg={theme.brand} wrapMode="none" />
           ) : (
-            <text content="⏎ — finish" fg={theme.textFaint} wrapMode="none" />
+            <text content="f — finish" fg={theme.textFaint} wrapMode="none" />
           )}
         </box>
       </Panel>
@@ -669,7 +707,7 @@ export function CloneWizard() {
                 <text content={` ${s.domain}`} fg={cur || s.step === "error" || s.step === "done" ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 1 }} />
                 <box style={{ flexGrow: 1 }} />
                 <text
-                  content={(s.step === "error" ? truncate(s.error ?? "failed", 24) : s.step === "done" ? "done" : s.step === "queued" ? "queued" : `${s.step}${s.detail ? " · " + s.detail : ""}`) + vmark}
+                  content={(s.step === "error" ? truncate(s.error ?? "failed", 24) : s.step === "done" ? "done" : s.step === "queued" ? "queued" : `${s.step}${s.detail ? " · " + s.detail : ""}${s.stageStartedAt ? " · " + fmtElapsed(now - s.stageStartedAt) : ""}`) + vmark}
                   fg={s.step === "error" || (s.verify && !s.verify.ok) ? theme.bad : s.verify?.ok ? theme.good : s.step === "done" ? theme.good : theme.textFaint}
                   wrapMode="none"
                   style={{ flexShrink: 0 }}
@@ -805,11 +843,16 @@ export function CloneWizard() {
       ]
     }
     if (job!.step === "cutover") {
-      const ready = selected.filter((s) => s.step === "done").flatMap((s) => s.cutover?.records ?? []).filter((r) => r.status === "ready").length
+      const recs = selected.filter((s) => s.step === "done").flatMap((s) => s.cutover?.records ?? [])
+      const ready = recs.filter((r) => r.status === "ready" && !r.excluded).length
+      const anyConsole = recs.some((r) => r.hostKey && consoleForHost(r.hostKey))
       return [
+        { key: "↑↓", label: "select" },
+        ...(recs.some((r) => r.status === "ready") ? [{ key: "space", label: "skip/include" }] : []),
+        ...(anyConsole ? [{ key: "⏎", label: "registrar" }] : []),
         ...(ready > 0 ? [{ key: "c", label: "cut over" }] : []),
         { key: "r", label: "re-check" },
-        { key: "⏎", label: "finish" },
+        { key: "f", label: "finish" },
         { key: "esc", label: "background" },
       ]
     }
@@ -846,6 +889,10 @@ export function CloneWizard() {
   }
 }
 
+function fmtElapsed(ms: number): string {
+  const sec = Math.max(0, Math.floor(ms / 1000))
+  return sec < 60 ? `${sec}s` : `${Math.floor(sec / 60)}m${String(sec % 60).padStart(2, "0")}s`
+}
 function truncate(s: string, n: number): string {
   return s.length <= n ? s : s.slice(0, Math.max(0, n - 1)) + "…"
 }

--- a/src/ui/views/CloneWizard.tsx
+++ b/src/ui/views/CloneWizard.tsx
@@ -707,7 +707,7 @@ export function CloneWizard() {
                 <text content={` ${s.domain}`} fg={cur || s.step === "error" || s.step === "done" ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 1 }} />
                 <box style={{ flexGrow: 1 }} />
                 <text
-                  content={(s.step === "error" ? truncate(s.error ?? "failed", 24) : s.step === "done" ? "done" : s.step === "queued" ? "queued" : `${s.step}${s.detail ? " · " + s.detail : ""}${s.stageStartedAt ? " · " + fmtElapsed(now - s.stageStartedAt) : ""}`) + vmark}
+                  content={(s.step === "error" ? truncate(s.error ?? "failed", 24) : s.step === "done" ? "done" : s.step === "queued" ? "queued" : `${s.step}${s.detail ? " · " + s.detail : ""}${s.transferBytes != null ? ` · ${formatBytes(s.transferBytes)}${s.transferRate ? ` · ${formatBytes(s.transferRate)}/s` : ""}` : ""}${s.stageStartedAt ? " · " + fmtElapsed(now - s.stageStartedAt) : ""}`) + vmark}
                   fg={s.step === "error" || (s.verify && !s.verify.ok) ? theme.bad : s.verify?.ok ? theme.good : s.step === "done" ? theme.good : theme.textFaint}
                   wrapMode="none"
                   style={{ flexShrink: 0 }}


### PR DESCRIPTION
Everything learned from the first real production server migration (6 clone rounds, each failure diagnosed from the new per-job logs), plus the features that came out of it.

## Fixed
- **Webroot detection instead of assumptions** — the pull finds where WordPress actually lives (`public_folder` is a setting, not a fact) and normalizes mid-move layouts on the dest, placing `wp-config.php` one level above the webroot per the config-outside-the-docroot convention (deliberate product stance, see CLAUDE.md).
- **Per-site SSH pull keys** — the shared key let concurrent sites clobber each other's auth mid-chain (at most one site per run could survive).
- **tar "file changed as we read it" tolerated** (exit 1 = warning; live sites touch files mid-read) with the culprit file logged instead of suppressed.
- **60-minute transfer budget** with outer>inner timeouts and an honest timeout message (a ~16-minute pull was killed by stacked 900s caps).
- **Rate-limit-aware API client** — paces off `X-RateLimit-Remaining`, absorbs 429s with Retry-After; resilient event polling (a failed read is not a failed event — three "failures" in one run were phantoms).
- Dest DBs keep the source table prefix; additional domains carried over with redirect settings (a fresh site only serves its primary domain).

## Added
- **Files-only clone mode** for non-WP sites (redirect shells, static/PHP): blank create with no DB, whole-tree pull, file-count/size/HTTP verify.
- **Per-job JSONL clone logs** (full stage output, passwords redacted, self-pruning 30d/20-file retention) + failed-site drill-down with per-site retry.
- **Live transfer progress**: bytes, rate, soft ceiling for files, true percent for DB pulls, per-stage elapsed.
- **Cutover controls**: explicit continue gate before the live-traffic step, record cursor + include/exclude, registrar deep-link handoff, access-note reasons for manual records.

All validated live on the dedicated test boxes and in the production migration itself; typecheck green throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSktjZBwrHhQyM7gxrDohj