### PR TITLE
DNS record repoint, clone-wizard back navigation, vanity sites on busy servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,56 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+### Added
+- **A vanity site can now be added to a server that already has sites.** `V` was
+  only offered on empty servers (its original "connect a fresh box" role), so a
+  busy server had no way to get its hostname page + key-holding site user. The
+  gate is now "does the server have a site at its own hostname yet" — and when
+  it doesn't, a `V — Vanity site at hostname` row appears under Manage in the
+  server's Details panel (or "Resume vanity-site build" for an unfinished one).
+- **The DNS view can now repoint a record — press `p` to choose where it points.**
+  Alongside the TTL editor, the `N` view's single-record editor gains a "Point
+  at…" mode: pick from a list of your SpinupWP servers (name + IP, with the
+  current one tagged) — pointing a record at one of your own boxes is what this
+  is for — or enter a custom IP. Same confirm-before-firing flow as every other
+  live write, and the change keeps applying in the background (Route 53 polls to
+  INSYNC) if you close the editor. The inventory's VALUE column shows the
+  in-flight repoint (`→ new IP`) and the settled value, mirroring the TTL cell.
+  Guardrails carried over from the cutover work: a CNAME row explains it follows
+  its target instead of opening, a Cloudflare *proxied* record repoints its
+  origin (with a note that visitors keep resolving Cloudflare's IPs), a
+  multi-value record warns it'll be collapsed to the one new value, and the
+  NS-mismatch pre-flight blocks edits through a stale duplicate zone.
+- **The clone wizard can now go back a screen with `←` (or `h`).** The setup
+  steps (Plan ↔ Destination ↔ Connect dest ↔ Git access) step back freely —
+  nothing has executed yet, so re-picking sites or the destination is safe.
+  Once the per-site fan-out has fired, the one back edge is **DNS cutover →
+  the clone roster**, so a verify can be re-run or a failed site retried
+  before flipping live traffic. Cutover state survives the round trip: rows
+  already checked, flipped, or mid-flight are never reset, and a site that
+  becomes done via retry gets its DNS records read on re-entry.
+
+### Fixed
+- **The DNS view's `◀ here` marker is now always relative to the server you're
+  viewing.** The "points here" flag was baked into each hostname's cached
+  resolution at lookup time, relative to whichever server's inventory triggered
+  it — so after checking DNS on the new server post-migration, reopening the
+  view on the OLD server showed records that point at the new box flagged
+  `◀ here` (with the wrong "N point here" tally). The cache now stores the
+  resolved IPs neutrally and computes "here" at render against the current
+  server; a just-repointed record also reads correctly immediately, before any
+  refresh.
+- **Clone verification no longer reports a cut-off read as a mismatch.** The
+  source-vs-clone facts run as one wp-cli script per side; if it was
+  interrupted partway (a timeout, or a plugin stalling on an outbound call),
+  the missing tail rendered as `–` mismatch rows — reading as "the clone
+  differs" when nothing had been compared. Verification now runs wp-cli with
+  `--skip-plugins --skip-themes` (no plugin code stalls the read, and both
+  sides use identical flags so every count stays comparable), allows the
+  facts read twice the time, and a read that still comes back incomplete
+  fails loudly as a verify error naming the side, instead of masquerading as
+  differences.
+
 ## [0.12.0] - 2026-07-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -65,8 +65,10 @@ Once you're in, the dashboard looks like this:
   records that move a site to another server: each site's hostnames with their type,
   TTL (in seconds), and a `◀ here` flag when they point at this server. Connect a
   provider (AWS Route 53 / Cloudflare) and press `⏎` to **edit a record's TTL** — the
-  prep step for a low-risk cutover. It only ever touches a site's own hosting records,
-  never your MX/TXT/other records. (See "DNS hosts, access & editing" below.)
+  prep step for a low-risk cutover — or `p` to **repoint the record**: pick another
+  of your SpinupWP servers from a list (or enter an IP) and move the traffic. It only
+  ever touches a site's own hosting records, never your MX/TXT/other records. (See
+  "DNS hosts, access & editing" below.)
 - **Database backup & sync** — on a linked WordPress site (Search tab), press `d`
   to download a gzipped production database backup into the copy's `sql/` folder
   (**read-only on production**), or — opt-in — press `p` to pull production into
@@ -97,8 +99,9 @@ Once you're in, the dashboard looks like this:
   kernel/security packages). (See "Server actions" below.)
 - **Create & connect a server** — press `c` on the Servers tab to provision a new
   server (DigitalOcean / Vultr / Linode / Hetzner), priced from the provider catalog
-  and pre-filled to match a selected server. Then press `V` on a server with **no
-  sites** to connect it end to end: Spinup writes the DNS A record, creates a
+  and pre-filled to match a selected server. Then press `V` on any server that
+  doesn't yet have a **site at its own hostname** to connect it end to end: Spinup
+  writes the DNS A record, creates a
   placeholder "vanity" site, enables HTTPS, hands you off to add your SSH key, and
   publishes a status page — turning a bare server into one you can actually work
   with. Long builds run in the background and survive a restart. (See "Creating &
@@ -252,7 +255,7 @@ These can be set in `config.json` or via an environment variable:
 | `m` | Production media fallback: serve missing-locally images from production (Search; WordPress + linked) |
 | `L` | Link / edit a site's local working copy |
 | `t` / `v` | Open the linked copy in a terminal / its local URL in your browser |
-| `n` | DNS migration view for a site — its records + TTLs (`⏎` edits a TTL; `a` shows the whole server) |
+| `n` | DNS migration view for a site — its records + TTLs (`⏎` edits a TTL; `p` repoints the record; `a` shows the whole server) |
 | `N` | DNS migration view for the whole server |
 | `h` | Live server health (CPU/mem/disk over SSH) |
 | `d` | Detect a site's stack via SSH (Servers / Stacks tabs) |
@@ -264,7 +267,7 @@ These can be set in `config.json` or via an environment variable:
 | `P` | Purge a site's page cache + object cache (Servers / Stacks / Search; needs a Read/Write token) |
 | `a` | Server actions: reboot / restart a service (Servers / Search; needs a Read/Write token) |
 | `c` | Create a new server (Servers tab; needs a Read/Write token) |
-| `V` | Connect a 0-site server with a vanity site — DNS + site + HTTPS + SSH-key handoff (Servers tab; needs a Read/Write token) |
+| `V` | Add a vanity site at the server's own hostname — DNS + site + HTTPS + SSH-key handoff (Servers tab; offered when no hostname site exists; needs a Read/Write token) |
 | `C` | Clone a server's sites to a new/existing destination (Servers tab; needs a Read/Write token + sudo) |
 | `S` | Connect sudo on a server for privileged writes — optionally remembered in the macOS Keychain (Servers tab) |
 | `K` | Grant / revoke an SSH key on a site, or every site on the server (needs sudo connected) |
@@ -390,8 +393,11 @@ build fires `POST /servers` and tracks the ~10-minute provision in the backgroun
 
 **Connect it with a vanity site (`V`).** A brand-new server has **no site**, so
 there's nothing to attach an SSH key to and no way for Spinup to reach it — empty
-servers are flagged in **amber** in the Servers list. Press `V` on one to build a
-small placeholder ("vanity") site at the server's own hostname, end to end:
+servers are flagged in **amber** in the Servers list. A busy server benefits from
+the same thing (a status page at its own hostname + a site user to hold your key),
+so `V` is offered on **any server that doesn't yet have a site at its own
+hostname** — it also appears under **Manage** in the server's Details panel. It
+builds the small placeholder ("vanity") site end to end:
 
 1. **DNS** — writes an `A` record for the hostname → the server IP (AWS Route 53),
    using the connection from the DNS module.
@@ -489,7 +495,9 @@ over SSH). The steps:
 
 The clone runs in the **background** — pressing `Esc` doesn't abandon it; a header
 badge (`⠹ Cloning … — press C`) surfaces the in-flight job and `C` reopens the live
-roster. **Every job writes a full log** (`~/.config/spinupwp-tui/logs/`, passwords
+roster. `←` (or `h`) steps **back a screen**: the setup steps go back freely, and
+once cloning has started the one back edge is DNS cutover → the clone roster — so
+you can re-verify or retry a site before flipping live traffic. **Every job writes a full log** (`~/.config/spinupwp-tui/logs/`, passwords
 redacted, self-pruning) — `⏎` on a failed site shows the complete error and `r`
 retries just that site. Pairs naturally with the DNS module: **lower the TTLs**
 (`n`/`N` → `⏎`) a day or two ahead so the cutover propagates fast.
@@ -620,10 +628,18 @@ never shown or changed. Moving a site can't take down its email.
   check re-reads the live nameservers and **blocks** the change if the connected
   account's zone isn't the one actually serving the domain. Route 53 changes are
   followed to completion; the record shows an "updating" status that keeps ticking
-  even if you leave the view. Only the **TTL** is editable here — a record's target
-  is repointed separately, during the clone wizard's DNS cutover (see "Cloning a
-  server" below). Cloudflare **proxied** records keep their TTL fixed to automatic
-  (so it's not editable here), but their origin IP still repoints fine at cutover.
+  even if you leave the view. Cloudflare **proxied** records keep their TTL fixed
+  to automatic, so it's not editable here — repointing still works (next).
+- **Repoint a record (`p`).** The same focused editor, on the record's **value** —
+  where it points. The picker leads with **your SpinupWP servers** (name + IP, the
+  record's current home tagged), because pointing a record at one of your own boxes
+  is what this is for; a custom IP is the fallback. The same confirm and NS
+  pre-flight gate apply, the write is followed to completion in the background, and
+  the inventory row shows `→ new IP` while it applies. A Cloudflare **proxied**
+  record repoints its **origin** behind the proxy (visitors keep resolving
+  Cloudflare's IPs). CNAMEs aren't repointed — they follow their target, which is
+  the record to edit. This is the standalone version of the clone wizard's DNS
+  cutover: migrate a single site, finish a cutover by hand, or fix a stale record.
 - **Connect a provider (`c`).** Manage credentials for the selected zone's
   provider — **AWS Route 53** (an IAM access key), **Cloudflare** (a scoped token),
   or **GoDaddy** (a Production API key). Multiple accounts per provider are
@@ -632,8 +648,8 @@ never shown or changed. Moving a site can't take down its email.
   environment variables are honored (`CLOUDFLARE_API_TOKEN`, `AWS_ACCESS_KEY_ID` /
   `AWS_SECRET_ACCESS_KEY`, `GODADDY_API_KEY` / `GODADDY_API_SECRET`). Secrets are
   masked as you type. Listing hosts needs only read access (Cloudflare `Zone:Read`);
-  **editing a TTL** needs write access — Route 53 record writes, or a Cloudflare
-  `Zone.DNS:Edit` token.
+  **editing (a TTL or a repoint)** needs write access — Route 53 record writes, or a
+  Cloudflare `Zone.DNS:Edit` token.
 - **Web-only hosts (GoDaddy, Namecheap, Network Solutions, …).** A registrar with
   no usable API shows `↗`; press `w` (in the inventory or the connect overlay) to
   open its web console — for GoDaddy specifically, your Clients hub, with the

--- a/src/lib/serverClone.ts
+++ b/src/lib/serverClone.ts
@@ -703,10 +703,14 @@ export interface VerifySpec {
 }
 
 // One round-trip per side: collect labeled wp-cli facts as `key=value` lines.
+// --skip-plugins/--skip-themes: no plugin code runs per invocation (a plugin making a
+// stalled outbound call once ate the whole budget and cut the facts off mid-script) —
+// and the flags are identical on both sides, so every count stays comparable. The
+// trailing `eof` sentinel is how verifyClone tells "read got cut off" from "differs".
 async function wpFacts(ctx: SudoCtx, root: string, user: string): Promise<Record<string, string>> {
   const script = [
     `cd ${shq(root)} 2>/dev/null || exit 0`,
-    `u() { sudo -u ${shq(user)} -H wp "$@" 2>/dev/null; }`,
+    `u() { sudo -u ${shq(user)} -H wp --skip-plugins --skip-themes "$@" 2>/dev/null; }`,
     `echo "core=$(u core version)"`,
     `echo "posts=$(u post list --post_type=any --format=count)"`,
     `echo "pages=$(u post list --post_type=page --format=count)"`,
@@ -714,8 +718,9 @@ async function wpFacts(ctx: SudoCtx, root: string, user: string): Promise<Record
     `echo "plugins=$(u plugin list --status=active --format=count)"`,
     `echo "siteurl=$(u option get siteurl)"`,
     `echo "home=$(u option get home)"`,
+    `echo "eof=1"`,
   ].join("\n")
-  const res = await exec(ctx, script, 60_000)
+  const res = await exec(ctx, script, 120_000)
   const out: Record<string, string> = {}
   for (const line of res.stdout.split("\n")) {
     const m = line.match(/^(\w+)=(.*)$/)
@@ -752,6 +757,13 @@ export async function verifyClone(source: SudoCtx, dest: SudoCtx, spec: VerifySp
     wpFacts(dest, destDir, spec.destSiteUser),
     curlStatus(spec.domain, spec.destIp),
   ])
+  // A missing tail sentinel means the facts script was cut off partway (timeout, a
+  // stalled command) — fail the verify loudly instead of rendering the missing tail
+  // as misleading ✕ "–" mismatch rows (which read as "the clone differs").
+  if (sf.eof !== "1" || cf.eof !== "1") {
+    const side = sf.eof !== "1" ? "source" : "clone"
+    throw new Error(`couldn't read the ${side}'s WordPress facts (the wp-cli read was cut off) — press v to re-run`)
+  }
   const checks: VerifyCheck[] = []
   checks.push({ key: "http", label: "Clone serves (HTTP)", source: "—", clone: http, ok: /^[23]\d\d$/.test(http) })
   const cmp = (key: string, label: string) => {

--- a/src/ui/Details.tsx
+++ b/src/ui/Details.tsx
@@ -13,7 +13,7 @@ import { useStore, isUpgradeInFlight, isServerOpInFlight, isHttpsToggleInFlight,
 import type { Server, Site } from "../api/types.ts"
 
 export function ServerDetail({ server, siteCount, showControl = false }: { server: Server; siteCount: number; showControl?: boolean }) {
-  const { rebootInfo, serverOps, isServerOsEol } = useStore()
+  const { rebootInfo, serverOps, isServerOsEol, sitesForServer, vanityJob } = useStore()
   const ds = server.disk_space
   const pct = diskUsedPct(ds?.used, ds?.total)
   const op = serverOps.get(server.id)
@@ -81,11 +81,23 @@ export function ServerDetail({ server, siteCount, showControl = false }: { serve
       {showControl ? (
         <>
           <box style={{ height: 1 }} />
-          <ControlPanel heading="Server Control" groups={SERVER_CONTROL} />
+          <ControlPanel heading="Server Control" groups={serverControlGroups()} />
         </>
       ) : null}
     </box>
   )
+
+  // The static groups, plus a Manage "V" row whenever the V key would actually do
+  // something: the server has no site at its own hostname yet (busy servers
+  // benefit from a vanity site just like empty ones), or an unfinished build for
+  // this server can be reopened.
+  function serverControlGroups(): ActionGroup[] {
+    const resumable = vanityJob != null && vanityJob.step !== "done" && vanityJob.serverId === server.id
+    const hasVanity = sitesForServer(server.id).some((s) => s.domain.toLowerCase() === server.name.toLowerCase())
+    if (!resumable && hasVanity) return SERVER_CONTROL
+    const vanityItem: [string, string] = ["V", resumable ? "Resume vanity-site build" : "Vanity site at hostname"]
+    return SERVER_CONTROL.map((g) => (g.title === "Manage" ? { ...g, items: [...g.items, vanityItem] } : g))
+  }
 }
 
 export const SERVER_CONTROL: ActionGroup[] = [

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -347,24 +347,31 @@ export function isKeyGrantInFlight(p: KeyGrantProgress | undefined): boolean {
   return p != null && p.status !== "done" && p.status !== "error"
 }
 
-// A record TTL change (Phase 3), tracked in the store (same model as the other
+// Which single field of a hosting record an edit targets: its TTL, or its VALUE
+// (where the record points — the migration repoint). One editor, two modes.
+export type RecordEditKind = "ttl" | "value"
+
+// A record change (Phase 3), tracked in the store (same model as the other
 // writes) so it survives the records overlay being closed and a Route 53 change
 // can keep polling to INSYNC in the background. Keyed by the record's stable key.
 // `status`: queued → pending (Route 53 propagating) → done | failed. Cloudflare
-// applies synchronously, so it jumps straight to done.
-export interface TtlWriteProgress {
-  ttl: number
+// applies synchronously, so it jumps straight to done. `kind` says which field
+// changed; `ttl`/`value` carry the target for that kind.
+export interface RecordWriteProgress {
+  kind: RecordEditKind
+  ttl?: number
+  value?: string
   status: string
   error?: string
   host: string // record hostname (lowercased) — lets the inventory match a write to a row
   type: string // record type (A / AAAA / CNAME …)
 }
-const TTL_DONE = "done"
-const TTL_FAIL = "failed"
-const TTL_POLL_MS = 3000
+const WRITE_DONE = "done"
+const WRITE_FAIL = "failed"
+const WRITE_POLL_MS = 3000
 
-export function isTtlWriteInFlight(p: TtlWriteProgress | undefined): boolean {
-  return p != null && p.status !== TTL_DONE && p.status !== TTL_FAIL
+export function isRecordWriteInFlight(p: RecordWriteProgress | undefined): boolean {
+  return p != null && p.status !== WRITE_DONE && p.status !== WRITE_FAIL
 }
 
 // A resolved website-hosting record for one hostname (apex / www / additional
@@ -376,7 +383,12 @@ export interface HostRecord {
   type: string // A | AAAA | CNAME | none
   ttl: number | null // configured TTL (from the authoritative answer)
   value: string // record value (IP or CNAME target)
-  pointsHere: boolean // resolves (following CNAMEs) to this server's IP
+  // Every A value in the authoritative answer (following CNAME chains). Kept
+  // server-NEUTRAL on purpose: the cache is keyed by hostname and shared across
+  // servers, so "points at this server" is computed at render time against the
+  // server being viewed — a baked-in boolean went stale the moment the same
+  // hostname was viewed from a different server's inventory.
+  resolvedIps: string[]
   checkedAt: number
 }
 
@@ -495,9 +507,10 @@ interface StoreValue extends DataState {
   startClone: () => void // run the fan-out (worker pool, cap = concurrency) over selected sites
   cloneRetrySite: (siteId: number) => void // re-run one failed site
   cloneContinueToCutover: () => void // explicit user continue: settled roster → DNS cutover
+  cloneGoBack: () => void // ← one screen back (config steps freely; post-fan-out only cutover → roster)
   toggleCutoverExclude: (siteId: number, name: string) => void // space: include/exclude a ready cutover record
   verifyCloneSite: (siteId: number) => void // slice 5: verify one cloned site (source-vs-clone)
-  cutoverCheck: () => Promise<void> // slice 6: read + classify each site's DNS record
+  cutoverCheck: (siteIds?: number[]) => Promise<void> // slice 6: read + classify each site's DNS records (optionally only the given sites)
   startCutover: () => void // slice 6: flip every "ready" record to the new IP (batched)
   cloneCutoverFinish: () => void // slice 6: cutover → done summary
   backgroundClone: () => void // hide the wizard, keep the in-flight clone running (reopen with C)
@@ -707,21 +720,24 @@ interface StoreValue extends DataState {
   // The zone whose provider-connect overlay is open (apex + its host key), or null.
   connectZoneTarget: { apex: string; hostKey: string } | null
   setConnectZoneTarget: (t: { apex: string; hostKey: string } | null) => void
-  // The zone whose DNS-records overlay is open (Phase 3: view records + edit TTL),
-  // with the connection id we'll authenticate the record calls with. `record` is the
-  // single hosting record to edit (migration lens — never a whole zone). null = closed.
-  dnsRecordsTarget: { apex: string; hostKey: string; connId: string; record: { name: string; type: string } } | null
-  setDnsRecordsTarget: (t: { apex: string; hostKey: string; connId: string; record: { name: string; type: string } } | null) => void
-  // In-flight (and just-settled) record TTL changes, keyed by the record key.
-  // Tracked in the store so a Route 53 change keeps polling after the overlay closes.
-  ttlWrites: Map<string, TtlWriteProgress>
+  // The zone whose DNS-records overlay is open (Phase 3: edit TTL, or repoint the
+  // value), with the connection id we'll authenticate the record calls with.
+  // `record` is the single hosting record to edit (migration lens — never a whole
+  // zone); `edit` picks which field the editor targets. null = closed.
+  dnsRecordsTarget: { apex: string; hostKey: string; connId: string; record: { name: string; type: string }; edit: RecordEditKind } | null
+  setDnsRecordsTarget: (t: { apex: string; hostKey: string; connId: string; record: { name: string; type: string }; edit: RecordEditKind } | null) => void
+  // In-flight (and just-settled) record changes (TTL + value), keyed by the record
+  // key. Tracked in the store so a Route 53 change keeps polling after the overlay closes.
+  recordWrites: Map<string, RecordWriteProgress>
   // Read ONE hosting record via the serving connection (scoped; on demand).
   getZoneRecord: (connId: string, apex: string, name: string, type: string) => Promise<RecordResult>
-  // The latest TTL write for a hostname+type (drives the inventory's updating status).
-  ttlWriteForHost: (host: string, type: string) => TtlWriteProgress | undefined
+  // The latest write of a kind for a hostname+type (drives the inventory's updating status).
+  recordWriteForHost: (host: string, type: string, kind: RecordEditKind) => RecordWriteProgress | undefined
   // Change a record's TTL via the host's API and follow it to completion.
   startTtlChange: (connId: string, zoneId: string, record: DnsRecord, ttl: number) => void
-  clearTtlWrite: (key: string) => void
+  // Repoint a record's value (where it points) and follow it to completion.
+  startValueChange: (connId: string, zoneId: string, record: DnsRecord, value: string) => void
+  clearRecordWrite: (key: string) => void
   // Whether a PHP version is past end-of-life (real dates vs today, refreshed).
   isPhpEol: (version: string | null | undefined) => boolean
   // PHP versions to offer in the upgrade picker (dynamic; current always included).
@@ -969,8 +985,8 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const [connections, setConnections] = useState<Record<ConnProvider, Connection[]>>(() => cfgRef.current.providerConnections)
   const [providerZones, setProviderZones] = useState<Map<string, VerifiedConn>>(() => providersCacheRef.current!.snapshot())
   const [connectZoneTarget, setConnectZoneTarget] = useState<{ apex: string; hostKey: string } | null>(null)
-  const [dnsRecordsTarget, setDnsRecordsTarget] = useState<{ apex: string; hostKey: string; connId: string; record: { name: string; type: string } } | null>(null)
-  const [ttlWrites, setTtlWrites] = useState<Map<string, TtlWriteProgress>>(new Map())
+  const [dnsRecordsTarget, setDnsRecordsTarget] = useState<{ apex: string; hostKey: string; connId: string; record: { name: string; type: string }; edit: RecordEditKind } | null>(null)
+  const [recordWrites, setRecordWrites] = useState<Map<string, RecordWriteProgress>>(new Map())
 
   // PHP EOL dates: embedded defaults overlaid with the last cached fetch; a
   // background refresh (endoflife.date) updates them when the cache is stale.
@@ -2089,17 +2105,17 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   // Resolve one hostname's record at its zone's authoritative NS. Records "none"
   // when the hostname has no record (so it isn't retried); a network miss also
   // caches none until a forced refresh.
-  const resolveHostingOne = useCallback(async (host: string, apex: string, ns: string[], serverIp: string | null) => {
+  const resolveHostingOne = useCallback(async (host: string, apex: string, ns: string[]) => {
     if (hostingInFlight.current.has(host)) return
     hostingInFlight.current.add(host)
     setHostingResolving((prev) => new Set(prev).add(host))
     try {
       const ans = await queryAuthoritative(host, "A", ns)
       const own = ans?.find((a) => a.name.toLowerCase() === host)
-      const here = !!(serverIp && ans?.some((a) => a.type === "A" && a.value === serverIp))
+      const ips = ans?.filter((a) => a.type === "A").map((a) => a.value) ?? []
       const rec: HostRecord = own
-        ? { host, apex, type: own.type, ttl: own.ttl, value: own.value, pointsHere: here, checkedAt: Date.now() }
-        : { host, apex, type: "none", ttl: null, value: "", pointsHere: false, checkedAt: Date.now() }
+        ? { host, apex, type: own.type, ttl: own.ttl, value: own.value, resolvedIps: ips, checkedAt: Date.now() }
+        : { host, apex, type: "none", ttl: null, value: "", resolvedIps: [], checkedAt: Date.now() }
       setHostingRecords((prev) => new Map(prev).set(host, rec))
     } finally {
       hostingInFlight.current.delete(host)
@@ -2113,7 +2129,6 @@ export function StoreProvider({ children }: { children: ReactNode }) {
 
   const resolveServerHosting = useCallback(
     (server: Server, force = false) => {
-      const serverIp = server.ip_address ?? null
       const hosts = new Set<string>()
       for (const s of sites) if (s.server_id === server.id) for (const h of candidateHostnames(domainsForSite(s))) hosts.add(h)
       // Only resolve hostnames whose zone NS we already know (needed to query the
@@ -2135,7 +2150,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       const worker = async () => {
         while (cursor < pool.length) {
           const { host, apex, ns } = pool[cursor++]
-          await resolveHostingOne(host, apex, ns, serverIp)
+          await resolveHostingOne(host, apex, ns)
         }
       }
       for (let i = 0; i < Math.min(CONCURRENCY, pool.length); i++) void worker()
@@ -2315,7 +2330,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     [allConnections, verifyAndCache],
   )
 
-  // ---- DNS record TTL change (Phase 3, first write) -------------------------
+  // ---- DNS record changes (Phase 3: TTL, then value/repoint) ----------------
 
   const getZoneRecord = useCallback(
     async (connId: string, apex: string, name: string, type: string): Promise<RecordResult> => {
@@ -2327,23 +2342,23 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     [allConnections],
   )
 
-  const setTtlWrite = (key: string, progress: TtlWriteProgress) =>
-    setTtlWrites((prev) => new Map(prev).set(key, progress))
+  const setRecordWrite = (key: string, progress: RecordWriteProgress) =>
+    setRecordWrites((prev) => new Map(prev).set(key, progress))
 
-  // The latest TTL write for a given hostname+type, if any — so the inventory can
-  // show an "updating"/just-changed status on the matching record row.
-  const ttlWriteForHost = useCallback(
-    (host: string, type: string): TtlWriteProgress | undefined => {
+  // The latest write of a kind for a given hostname+type, if any — so the inventory
+  // can show an "updating"/just-changed status on the matching record cell.
+  const recordWriteForHost = useCallback(
+    (host: string, type: string, kind: RecordEditKind): RecordWriteProgress | undefined => {
       const h = host.toLowerCase()
-      for (const p of ttlWrites.values()) if (p.host === h && p.type === type) return p
+      for (const p of recordWrites.values()) if (p.kind === kind && p.host === h && p.type === type) return p
       return undefined
     },
-    [ttlWrites],
+    [recordWrites],
   )
 
-  const clearTtlWrite = useCallback(
+  const clearRecordWrite = useCallback(
     (key: string) =>
-      setTtlWrites((prev) => {
+      setRecordWrites((prev) => {
         if (!prev.has(key)) return prev
         const next = new Map(prev)
         next.delete(key)
@@ -2352,20 +2367,22 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     [],
   )
 
-  const startTtlChange = useCallback(
-    (connId: string, zoneId: string, record: DnsRecord, ttl: number) => {
-      const existing = ttlWrites.get(record.key)
-      if (existing && isTtlWriteInFlight(existing)) return // one change per record at a time
+  // Shared runner for both single-field record writes (TTL + value): fire the
+  // provider call, then follow an async change (Route 53) to INSYNC. Progress is
+  // stamped with the record's host/type so the inventory can match an in-flight
+  // write back to its row after the editor closes.
+  const runRecordChange = useCallback(
+    (connId: string, record: DnsRecord, base: { kind: RecordEditKind; ttl?: number; value?: string }, exec: (provider: NonNullable<ReturnType<typeof recordProviderFor>>, creds: Record<string, string>) => Promise<{ ok: boolean; pollId?: string; error?: string }>) => {
+      const existing = recordWrites.get(record.key)
+      if (existing && isRecordWriteInFlight(existing)) return // one change per record at a time
 
-      // Stamp every progress update with the record's host/type so the inventory can
-      // match an in-flight write back to its row after the editor closes.
       const put = (status: string, error?: string) =>
-        setTtlWrite(record.key, { ttl, status, host: record.name.toLowerCase(), type: record.type, ...(error ? { error } : {}) })
+        setRecordWrite(record.key, { ...base, status, host: record.name.toLowerCase(), type: record.type, ...(error ? { error } : {}) })
 
       const conn = allConnections.find((c) => c.id === connId)
       const provider = conn ? recordProviderFor(conn.provider) : null
       if (!conn || !provider) {
-        put(TTL_FAIL, "Lost the provider connection — reopen the records view.")
+        put(WRITE_FAIL, "Lost the provider connection — reopen the records view.")
         return
       }
 
@@ -2373,18 +2390,18 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         put("queued")
         let res
         try {
-          res = await provider.setTtl(conn.creds, zoneId, record, ttl)
+          res = await exec(provider, conn.creds)
         } catch (err) {
-          put(TTL_FAIL, (err as Error).message)
+          put(WRITE_FAIL, (err as Error).message)
           return
         }
         if (!res.ok) {
-          put(TTL_FAIL, res.error || "The provider rejected the change.")
+          put(WRITE_FAIL, res.error || "The provider rejected the change.")
           return
         }
         // No poll id (Cloudflare) → already applied. Otherwise poll to INSYNC.
         if (!res.pollId || !provider.pollChange) {
-          put(TTL_DONE)
+          put(WRITE_DONE)
           return
         }
         const pollId = res.pollId
@@ -2392,18 +2409,35 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         const poll = async () => {
           try {
             const status = await provider.pollChange!(conn.creds, pollId)
-            if (status === "done") put(TTL_DONE)
-            else if (status === "failed") put(TTL_FAIL, "The change failed to propagate.")
-            else setTimeout(() => void poll(), TTL_POLL_MS)
+            if (status === "done") put(WRITE_DONE)
+            else if (status === "failed") put(WRITE_FAIL, "The change failed to propagate.")
+            else setTimeout(() => void poll(), WRITE_POLL_MS)
           } catch (err) {
-            put(TTL_FAIL, (err as Error).message)
+            put(WRITE_FAIL, (err as Error).message)
           }
         }
-        setTimeout(() => void poll(), TTL_POLL_MS)
+        setTimeout(() => void poll(), WRITE_POLL_MS)
       }
       void run()
     },
-    [allConnections, ttlWrites],
+    [allConnections, recordWrites],
+  )
+
+  const startTtlChange = useCallback(
+    (connId: string, zoneId: string, record: DnsRecord, ttl: number) =>
+      runRecordChange(connId, record, { kind: "ttl", ttl }, (provider, creds) => provider.setTtl(creds, zoneId, record, ttl)),
+    [runRecordChange],
+  )
+
+  // The repoint write. setValue is optional on a provider (GoDaddy has none), but
+  // any zone reachable here came through an API-editable connection — the guard is
+  // just belt-and-braces.
+  const startValueChange = useCallback(
+    (connId: string, zoneId: string, record: DnsRecord, value: string) =>
+      runRecordChange(connId, record, { kind: "value", value }, (provider, creds) =>
+        provider.setValue ? provider.setValue(creds, zoneId, record, value) : Promise.resolve({ ok: false, error: "This provider can't repoint records via its API." }),
+      ),
+    [runRecordChange],
   )
 
   // ---- Vanity site (connect a fresh, empty server) ----------------------
@@ -3122,6 +3156,24 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     })
   }, [])
 
+  // ← back one screen. The config steps (plan → server → trust → gitaccess) step back
+  // freely — nothing has executed yet, so re-picking sites or the dest is safe. Once
+  // the fan-out has fired (sites created on the dest = prod writes), re-opening the
+  // config screens would invite editing a plan that's already executing, so the ONLY
+  // post-fan-out back edge is cutover → the clone roster (re-verify / retry a site
+  // before flipping DNS). Cutover state is per-site and survives the round trip.
+  const cloneGoBack = useCallback(() => {
+    setCloneJob((j) => {
+      if (!j) return j
+      if (j.step === "cutover") return { ...j, step: "clone" }
+      if (j.fanoutStarted) return j
+      if (j.step === "server") return { ...j, step: "plan" }
+      if (j.step === "trust") return { ...j, step: "server" }
+      if (j.step === "gitaccess") return { ...j, step: "trust" }
+      return j
+    })
+  }, [])
+
   // ---- DNS cutover (slice 6) ------------------------------------------------
   const destIpOf = useCallback(
     (j: CloneJob) => j.destServerIp ?? (j.destServerId != null ? servers.find((s) => s.id === j.destServerId)?.ip_address ?? "" : ""),
@@ -3143,12 +3195,13 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   // classify it (already-on-new = done; editable-on-old = ready; not-API-editable =
   // manual), and stash the plan in site.cutover. A hostname with no A record (a www
   // CNAME → apex, or absent) is skipped — only a missing PRIMARY A is flagged.
-  // Read-only; the flip is a separate explicit action.
-  const cutoverCheck = useCallback(async () => {
+  // Read-only; the flip is a separate explicit action. `siteIds` scopes the check
+  // (the wizard passes just-arrived sites so a re-entry never resets in-flight rows).
+  const cutoverCheck = useCallback(async (siteIds?: number[]) => {
     const j = cloneJob
     if (!j) return
     const targetIp = destIpOf(j)
-    const dones = j.sites.filter((s) => s.selected && s.step === "done")
+    const dones = j.sites.filter((s) => s.selected && s.step === "done" && (siteIds == null || siteIds.includes(s.sourceSiteId)))
     await Promise.all(
       dones.map(async (site) => {
         const hostnames = [site.domain, ...(site.additionalDomains ?? [])]
@@ -3382,6 +3435,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     startClone,
     cloneRetrySite,
     cloneContinueToCutover,
+    cloneGoBack,
     toggleCutoverExclude,
     verifyCloneSite,
     cutoverCheck,
@@ -3502,11 +3556,12 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     setConnectZoneTarget,
     dnsRecordsTarget,
     setDnsRecordsTarget,
-    ttlWrites,
+    recordWrites,
     getZoneRecord,
-    ttlWriteForHost,
+    recordWriteForHost,
     startTtlChange,
-    clearTtlWrite,
+    startValueChange,
+    clearRecordWrite,
     isPhpEol,
     offeredPhpVersions,
     isServerOsEol,

--- a/src/ui/views/Browser.tsx
+++ b/src/ui/views/Browser.tsx
@@ -175,12 +175,15 @@ export function Browser({ rows }: { rows: number }) {
         }
         return
       case "V":
-        // Connect an empty server: create a vanity site at its hostname. Also
-        // reopens an unfinished build for this server (in-flight, parked at the
-        // SSH-key step, or errored — all after the site may already exist).
-        // Otherwise only for 0-site servers.
-        if (server && ((vanityJob && vanityJob.step !== "done" && vanityJob.serverId === server.id) || sitesForServer(server.id).length === 0)) {
-          setVanityServer(server)
+        // Create the vanity site at the server's own hostname. Offered whenever
+        // the server doesn't already HAVE a site there — a busy server benefits
+        // just as much as an empty one (the hostname page + a key-holding site
+        // user). Also reopens an unfinished build for this server (in-flight,
+        // parked at the SSH-key step, or errored — all after the site may exist).
+        if (server) {
+          const resumable = vanityJob && vanityJob.step !== "done" && vanityJob.serverId === server.id
+          const hasVanity = sitesForServer(server.id).some((s) => s.domain.toLowerCase() === server.name.toLowerCase())
+          if (resumable || !hasVanity) setVanityServer(server)
         }
         return
       case "h":

--- a/src/ui/views/CloneWizard.tsx
+++ b/src/ui/views/CloneWizard.tsx
@@ -61,6 +61,7 @@ export function CloneWizard() {
     startClone,
     cloneRetrySite,
     cloneContinueToCutover,
+    cloneGoBack,
     toggleCutoverExclude,
     verifyCloneSite,
     cutoverCheck,
@@ -105,9 +106,11 @@ export function CloneWizard() {
     }
   }, [job?.step, cloneDetectRepoKeys])
 
-  // The cutover roster gets its own cursor run — reset it when we land there.
+  // Every screen owns its own cursor run — reset it whenever the step changes
+  // (forward or back), so a cursor position from a longer roster never lands
+  // out-of-range on the next screen.
   useEffect(() => {
-    if (job?.step === "cutover") setIdx(0)
+    setIdx(0)
   }, [job?.step])
 
   // Tick once a second while any selected site is mid-stage so the roster's
@@ -120,13 +123,14 @@ export function CloneWizard() {
     return () => clearInterval(t)
   }, [job?.step, job?.sites])
 
-  // Read + classify each site's DNS record when we land on the cutover step — but
-  // only if it hasn't been checked yet (so reopening a backgrounded wizard doesn't
-  // reset in-progress flips). The check itself is read-only.
+  // Read + classify each site's DNS records when we land on the cutover step — but
+  // per-site, only the ones never checked, so reopening a backgrounded wizard (or
+  // returning after ← back → retry) never resets in-progress flips, and a site that
+  // became "done" via retry after backing out still gets its records read.
   useEffect(() => {
     if (job?.step !== "cutover") return
-    const cloned = job.sites.filter((s) => s.selected && s.step === "done")
-    if (cloned.length > 0 && cloned.every((s) => !s.cutover)) void cutoverCheck()
+    const unchecked = job.sites.filter((s) => s.selected && s.step === "done" && !s.cutover)
+    if (unchecked.length > 0) void cutoverCheck(unchecked.map((s) => s.sourceSiteId))
   }, [job?.step, job?.sites, cutoverCheck])
 
   // Dev-only auto-sudo (both ends) from .env so the flow is testable headlessly.
@@ -192,6 +196,15 @@ export function CloneWizard() {
       // reopen with C on the source server. Before launch / at the summary, esc cancels.
       if (job.step === "clone" || job.step === "cutover") return backgroundClone()
       return close()
+    }
+
+    // ← / h — back one screen (layered views close first, matching esc). The config
+    // steps go back freely; after the fan-out has fired, the only back edge is
+    // cutover → the clone roster (re-verify / retry) — cloneGoBack enforces this.
+    if (name === "left" || name === "h") {
+      if (verifyOpen != null) return setVerifyOpen(null)
+      if (pickExisting) return setPickExisting(false)
+      return cloneGoBack()
     }
 
     if (job.step === "plan") {
@@ -277,7 +290,7 @@ export function CloneWizard() {
     if (job.step === "clone" || job.step === "done") {
       const sel = job.sites.filter((s) => s.selected)
       // While drilled into a verify/failure view: v re-runs verify (done sites),
-      // r retries the drilled FAILED site, ←/Esc(handled above) goes back.
+      // r retries the drilled FAILED site, ←/h/Esc (handled above) goes back.
       if (verifyOpen != null) {
         const drilled = job.sites.find((s) => s.sourceSiteId === verifyOpen)
         if (name === "r" && drilled?.step === "error") {
@@ -285,7 +298,6 @@ export function CloneWizard() {
           return cloneRetrySite(verifyOpen)
         }
         if (name === "v" && drilled?.step === "done") return verifyCloneSite(verifyOpen)
-        if (name === "left" || name === "h") return setVerifyOpen(null)
         return
       }
       const n = sel.length
@@ -814,7 +826,7 @@ export function CloneWizard() {
     }
     if (job!.step === "server") {
       if (pickExisting) return [{ key: "↑↓", label: "select" }, { key: "⏎", label: "use server" }, { key: "esc", label: "back" }]
-      return [{ key: "⏎", label: "provision new" }, ...(eligibleDests.length > 0 ? [{ key: "d", label: "use existing" }] : []), { key: "esc", label: "close" }]
+      return [{ key: "⏎", label: "provision new" }, ...(eligibleDests.length > 0 ? [{ key: "d", label: "use existing" }] : []), { key: "←", label: "back" }, { key: "esc", label: "close" }]
     }
     if (job!.step === "trust") {
       const destServer = job!.destServerId != null ? servers.find((s) => s.id === job!.destServerId) ?? null : null
@@ -824,6 +836,7 @@ export function CloneWizard() {
         { key: "G", label: "sudo source" },
         { key: "w", label: "SpinupWP" },
         ...(both ? [{ key: "⏎", label: "continue" }] : []),
+        { key: "←", label: "back" },
         { key: "esc", label: "close" },
       ]
     }
@@ -853,6 +866,7 @@ export function CloneWizard() {
         ...(anyConsole ? [{ key: "⏎", label: "registrar" }] : []),
         ...(ready > 0 ? [{ key: "c", label: "cut over" }] : []),
         { key: "r", label: "re-check" },
+        { key: "←", label: "clone roster" },
         { key: "f", label: "finish" },
         { key: "esc", label: "background" },
       ]
@@ -867,6 +881,7 @@ export function CloneWizard() {
         ...(hasManual ? [{ key: "o", label: "open settings" }] : []),
         { key: "r", label: "re-check" },
         ...(!blocked ? [{ key: "⏎", label: "continue" }] : []),
+        { key: "←", label: "back" },
         { key: "esc", label: "close" },
       ]
     }

--- a/src/ui/views/DnsInventory.tsx
+++ b/src/ui/views/DnsInventory.tsx
@@ -19,7 +19,7 @@ import { openUrl, copyToClipboard } from "../../lib/open.ts"
 import { List, moveSelection } from "../List.tsx"
 import { StatusBar } from "../StatusBar.tsx"
 import { Spinner } from "../components.tsx"
-import { useStore, isTtlWriteInFlight } from "../store.tsx"
+import { useStore, isRecordWriteInFlight, type RecordEditKind } from "../store.tsx"
 import type { Site } from "../../api/types.ts"
 
 // Fixed column widths (chars) so columns align on every row; VALUE flexes.
@@ -123,7 +123,7 @@ export function DnsInventory() {
     resolveServerHosting,
     hostingFor,
     isHostingResolving,
-    ttlWriteForHost,
+    recordWriteForHost,
     zoneAccessNotes,
   } = useStore()
   const allConnections = useMemo(() => Object.values(connections).flat(), [connections])
@@ -164,6 +164,19 @@ export function DnsInventory() {
     let zoneCount = 0
     let hereCount = 0
     let resolving = false
+
+    // Does this hostname point at THE SERVER BEING VIEWED? Computed here, at
+    // render, against the current server's IP — the cached HostRecord is shared
+    // across servers, so a stored flag would be stale from another server's view.
+    // A settled repoint (recordWrites) wins over the cached resolution until the
+    // next refresh, so a just-flipped row reads correctly right away.
+    const serverIp = server?.ip_address ?? ""
+    const hereFor = (name: string, rec: { type: string; resolvedIps: string[] } | undefined): boolean => {
+      if (!serverIp || !rec) return false
+      const vw = recordWriteForHost(name, rec.type, "value")
+      const ips = vw?.status === "done" && vw.value ? [vw.value] : rec.resolvedIps
+      return ips.includes(serverIp)
+    }
 
     for (const site of sites) {
       const entries = [
@@ -230,7 +243,8 @@ export function DnsInventory() {
         const wwwRec = headHost.startsWith("www.") ? undefined : hostingFor(wwwName)
         const wwwTarget = wwwRec?.type === "CNAME" ? norm(wwwRec.value) : ""
         const wwwFollows = wwwTarget !== "" && (wwwTarget === headHost || wwwTarget === g.apex)
-        if (hasRecord && headRec!.pointsHere) hereCount++
+        const headHere = hasRecord && hereFor(headHost, headRec)
+        if (headHere) hereCount++
         if (headResolving) resolving = true
 
         out.push({
@@ -253,7 +267,7 @@ export function DnsInventory() {
           recordType: headRec?.type ?? "",
           ttl: headRec?.ttl ?? null,
           value: headRec?.value ?? "",
-          pointsHere: headRec?.pointsHere ?? false,
+          pointsHere: headHere,
           resolving: headResolving,
           wwwFollows,
         })
@@ -265,7 +279,8 @@ export function DnsInventory() {
           const hr = hostingFor(name)
           if (hr && hr.type === "none") continue // no record for this hostname — nothing to migrate
           const isResolving = isHostingResolving(name) || (!hr && cached?.zone != null)
-          if (hr?.pointsHere) hereCount++
+          const hrHere = hereFor(name, hr)
+          if (hrHere) hereCount++
           if (!hr && isResolving) resolving = true
           const cnameTarget = hr?.type === "CNAME" ? hr.value.toLowerCase().replace(/\.$/, "") : ""
           const followsApex = cnameTarget !== "" && cnameTarget === g.apex
@@ -279,7 +294,7 @@ export function DnsInventory() {
             recordType: hr?.type ?? "",
             ttl: hr?.ttl ?? null,
             value: hr?.value ?? "",
-            pointsHere: hr?.pointsHere ?? false,
+            pointsHere: hrHere,
             followsApex,
             resolving: !hr,
             indent: isPrimaryZone ? 1 : 2,
@@ -290,12 +305,12 @@ export function DnsInventory() {
 
     const summary = `${zoneCount} zone${zoneCount === 1 ? "" : "s"}${hereCount ? ` · ${hereCount} point${hereCount === 1 ? "s" : ""} here` : ""}`
     return { rows: out, summary, pending: resolving }
-  }, [sites, dnsZones, dnsResolving, zoneForDomain, accessForZone, accountForZone, hostingFor, isHostingResolving])
+  }, [sites, server, dnsZones, dnsResolving, zoneForDomain, accessForZone, accountForZone, hostingFor, isHostingResolving, recordWriteForHost])
 
   const safeIndex = Math.min(index, Math.max(0, rows.length - 1))
   const close = () => setDnsInventoryServer(null)
 
-  function openDrill(r: InvRow) {
+  function openDrill(r: InvRow, edit: RecordEditKind) {
     if (r.access === "web") return openWeb(r)
     if (r.access !== "editable") return showFlash("Connect API access first — press c")
     const conn = connForZone(r.apex, r.hostKey, r.liveNs)
@@ -313,7 +328,12 @@ export function DnsInventory() {
       if (!r.hasRecord || !r.recordType) return showFlash("No record to edit on this line.")
       rec = { name: r.recordName, type: r.recordType }
     }
-    setDnsRecordsTarget({ apex: r.apex, hostKey: r.hostKey, connId: conn.id, record: rec })
+    // Repointing is an A/AAAA concern — a CNAME already points at a NAME and moves
+    // with it, so the thing to repoint is the record it targets.
+    if (edit === "value" && rec.type !== "A" && rec.type !== "AAAA") {
+      return showFlash(`A ${rec.type} record follows its target — repoint the A record it points to.`)
+    }
+    setDnsRecordsTarget({ apex: r.apex, hostKey: r.hostKey, connId: conn.id, record: rec, edit })
   }
 
   function openWeb(r: InvRow) {
@@ -358,7 +378,12 @@ export function DnsInventory() {
       case "right":
       case "l":
       case "t":
-        if (r) openDrill(r)
+        if (r) openDrill(r, "ttl")
+        return
+      case "p":
+        // Point the record somewhere else (the migration repoint) — a picker of
+        // the account's servers, since that's where a record almost always goes.
+        if (r) openDrill(r, "value")
         return
       case "c":
         if (!r) return
@@ -427,6 +452,7 @@ export function DnsInventory() {
         hints={[
           { key: "↑↓/jk", label: "select" },
           { key: "⏎", label: "edit TTL" },
+          { key: "p", label: "point at…" },
           { key: "c", label: "manage access" },
           ...(focusSite ? [{ key: "a", label: "all sites" }] : []),
           { key: "r", label: "refresh" },
@@ -451,8 +477,8 @@ export function DnsInventory() {
         </box>
       )
     }
-    const wp = ttlWriteForHost(name, type)
-    if (isTtlWriteInFlight(wp)) {
+    const wp = recordWriteForHost(name, type, "ttl")
+    if (isRecordWriteInFlight(wp)) {
       return (
         <box style={{ flexDirection: "row", width: TTL_W, flexShrink: 0 }}>
           <Spinner color={selected ? theme.text : theme.brand} interval={120} />
@@ -460,10 +486,27 @@ export function DnsInventory() {
         </box>
       )
     }
-    const effTtl = wp?.status === "done" ? wp.ttl : ttl
+    const effTtl = wp?.status === "done" ? (wp.ttl ?? ttl) : ttl
     const txt = effTtl == null ? "—" : String(effTtl)
     const fg = selected ? theme.text : faint ? theme.textFaint : theme.accent
     return <text content={txt.padEnd(TTL_W)} fg={fg} wrapMode="none" style={{ flexShrink: 0 }} />
+  }
+
+  // The VALUE cell, write-aware like the TTL cell: a spinner + "→ip" while a
+  // repoint is in flight, the settled new value once done (the authoritative host
+  // has it), else the resolved value.
+  function valueCell(name: string, type: string, value: string, selected: boolean) {
+    const wp = recordWriteForHost(name, type, "value")
+    if (isRecordWriteInFlight(wp)) {
+      return (
+        <box style={{ flexDirection: "row", flexShrink: 1 }}>
+          <Spinner color={selected ? theme.text : theme.brand} interval={120} />
+          <text content={` →${truncate(wp!.value ?? "", 36)}`} fg={selected ? theme.text : theme.warn} wrapMode="none" />
+        </box>
+      )
+    }
+    const eff = wp?.status === "done" && wp.value ? wp.value : value
+    return <text content={truncate(eff, 38)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 1 }} />
   }
 
   // host + access glyph — a right-side cluster on zone lines.
@@ -505,7 +548,7 @@ export function DnsInventory() {
             <text content={"".padEnd(TTL_W)} wrapMode="none" style={{ flexShrink: 0 }} />
           </>
         )}
-        <text content={truncate(r.value, 38)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 1 }} />
+        {valueCell(r.recordName, r.recordType, r.value, selected)}
         {r.pointsHere ? <text content=" ◀ here" fg={selected ? theme.text : theme.good} wrapMode="none" style={{ flexShrink: 0 }} /> : null}
         {r.wwwFollows ? <text content=" +www" fg={selected ? theme.text : theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} /> : null}
         {r.note ? <text content={"  " + r.note} fg={selected ? theme.text : r.noteColor} wrapMode="none" style={{ flexShrink: 0 }} /> : null}
@@ -524,7 +567,7 @@ export function DnsInventory() {
         <text content={indentedName(r.name, r.indent)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} />
         <text content={(r.resolving ? "" : r.recordType).padEnd(TYPE_W)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} />
         {ttlCell(r.name, r.recordType, r.ttl, r.resolving, r.followsApex, selected)}
-        <text content={truncate(r.value, 38)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 1 }} />
+        {valueCell(r.name, r.recordType, r.value, selected)}
         {r.followsApex ? (
           <text content=" follows apex" fg={selected ? theme.text : theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
         ) : r.pointsHere ? (

--- a/src/ui/views/DnsRecords.tsx
+++ b/src/ui/views/DnsRecords.tsx
@@ -1,17 +1,22 @@
-// Focused TTL editor — Phase 3, the migration record manager's first write.
+// Focused single-record editor — Phase 3, the migration record manager's writes.
 //
-// Opened with Enter on a hosting record in the DNS inventory (one whose host we
-// hold a verified API key for). This is NOT a zone editor: it reads and edits the
-// ONE record it was handed (no zone listing), so the only records reachable here
-// are a site's own hosting records — MX/TXT/DKIM/etc. are never even fetched. You
-// change a single field — the TTL — through the same confirm-before-firing flow as
-// the PHP upgrade. The write + its polling live in the store (startTtlChange), so
-// closing this modal doesn't abandon a Route 53 change mid-propagation.
+// Opened from the DNS inventory on a hosting record (one whose host we hold a
+// verified API key for), in one of two modes: `⏎` edits the TTL, `p` repoints the
+// VALUE (where the record points — the migration cutover write). This is NOT a
+// zone editor: it reads and edits the ONE record it was handed (no zone listing),
+// so the only records reachable here are a site's own hosting records — MX/TXT/
+// DKIM/etc. are never even fetched. Both modes run the same confirm-before-firing
+// flow as the PHP upgrade; the write + its polling live in the store
+// (startTtlChange / startValueChange), so closing this modal doesn't abandon a
+// Route 53 change mid-propagation.
 //
-// Target/IP repointing (step 3 of the cutover loop) is the next write; for now only
-// the TTL is editable, and only where that's well-defined — an alias / routing-policy
-// / proxied record opens read-only with a short reason. The read is on-demand and
-// ephemeral (no disk cache) — re-opening re-fetches.
+// The repoint picker leads with the account's SpinupWP servers (name + IP) —
+// pointing a record at one of your own boxes is what this is for — with a custom
+// IP as the fallback. Editability differs by mode: `editable` gates the TTL (a
+// Route 53 alias / routing-policy set / Cloudflare proxied record has no real
+// TTL), `valueEditable` gates the repoint (a Cloudflare PROXIED record's origin
+// IP stays PATCHable — that repoint is an origin swap behind the proxy). The read
+// is on-demand and ephemeral (no disk cache) — re-opening re-fetches.
 
 import { useEffect, useMemo, useState } from "react"
 import { useKeyboard, useTerminalDimensions } from "@opentui/react"
@@ -24,7 +29,7 @@ import { StatusBar } from "../StatusBar.tsx"
 import { Panel, Spinner, Centered } from "../components.tsx"
 import { moveSelection } from "../List.tsx"
 import { useStore } from "../store.tsx"
-import { isTtlWriteInFlight } from "../store.tsx"
+import { isRecordWriteInFlight } from "../store.tsx"
 
 type Phase = "pick" | "custom" | "confirm" | "tracking"
 type LoadState = "loading" | "ready" | "error"
@@ -36,9 +41,26 @@ interface TtlOption {
 }
 const CUSTOM_TTL = -1
 
+// A repoint target in the picker: one of the account's servers, or the custom-IP
+// sentinel (value = "").
+interface ValueOption {
+  value: string
+  label: string
+}
+
+// Validate a literal IP for a record type. Returns an error string, or null when ok.
+function validateIp(type: string, s: string): string | null {
+  if (type === "AAAA") {
+    return s.includes(":") && /^[0-9a-fA-F:]{2,45}$/.test(s) ? null : "Enter a valid IPv6 address."
+  }
+  const m = s.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/)
+  return m && m.slice(1).every((o) => Number(o) <= 255) ? null : "Enter a valid IPv4 address (e.g. 203.0.113.10)."
+}
+
 export function DnsRecords() {
-  const { dnsRecordsTarget, setDnsRecordsTarget, getZoneRecord, startTtlChange, clearTtlWrite, ttlWrites, setInputMode } = useStore()
+  const { dnsRecordsTarget, setDnsRecordsTarget, getZoneRecord, startTtlChange, startValueChange, clearRecordWrite, recordWrites, setInputMode, servers } = useStore()
   const target = dnsRecordsTarget
+  const mode = target?.edit ?? "ttl"
   const provider = target ? apiProviderFor(target.hostKey) : null
   const providerName = provider ? PROVIDER_REGISTRY[provider].name : ""
   const { height } = useTerminalDimensions()
@@ -52,6 +74,7 @@ export function DnsRecords() {
   const [custom, setCustom] = useState("")
   const [customError, setCustomError] = useState<string | null>(null)
   const [targetTtl, setTargetTtl] = useState<number | null>(null)
+  const [targetValue, setTargetValue] = useState<string | null>(null)
   const [activeKey, setActiveKey] = useState<string | null>(null)
   const [flash, setFlash] = useState<string | null>(null)
   // Edit-time NS-match pre-flight: when the account's hosted-zone NS don't match
@@ -80,7 +103,7 @@ export function DnsRecords() {
         // Open the picker cursor on the current value: a preset lands on its row; an
         // off-list TTL is prepended as "current" at index 0; null (CF auto) → 0.
         const i = TTL_PRESETS.findIndex((o) => o.ttl === res.record!.ttl)
-        setPickIndex(i >= 0 ? i : 0)
+        setPickIndex(target.edit === "ttl" && i >= 0 ? i : 0)
         setNs({ live: normNameservers(liveZone?.nameservers), zone: normNameservers(res.apexNs) })
       } else {
         setLoadError(res.error ?? "Couldn't read this record.")
@@ -92,7 +115,7 @@ export function DnsRecords() {
     }
   }, [target, getZoneRecord])
 
-  // The custom-TTL input owns the keyboard while it's focused.
+  // The custom-input phase owns the keyboard while it's focused.
   useEffect(() => {
     setInputMode(phase === "custom")
     return () => setInputMode(false)
@@ -107,23 +130,45 @@ export function DnsRecords() {
     return opts
   }, [record])
 
+  // Repoint options: the account's servers (name + IPv4), then Custom…. An AAAA
+  // record gets only Custom… — server IPs from the SpinupWP API are IPv4.
+  const valueOptions = useMemo<ValueOption[]>(() => {
+    const opts: ValueOption[] =
+      record?.type === "AAAA"
+        ? []
+        : servers
+            .filter((s) => s.ip_address)
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map((s) => ({ value: s.ip_address!, label: s.name }))
+    opts.push({ value: "", label: "Custom IP…" })
+    return opts
+  }, [servers, record])
+
+  const currentValue = record?.values[0] ?? ""
+  // The server name behind an IP, for labeling the current/target values.
+  const serverNameFor = (ip: string) => servers.find((s) => s.ip_address === ip)?.name
+
   // Tracking display derives from the store, like the PHP-upgrade overlay.
-  const progress = activeKey ? ttlWrites.get(activeKey) : undefined
+  const progress = activeKey ? recordWrites.get(activeKey) : undefined
   const dp: Phase | "done" | "error" =
     phase !== "tracking"
       ? phase
-      : !progress || isTtlWriteInFlight(progress)
+      : !progress || isRecordWriteInFlight(progress)
         ? "tracking"
         : progress.status === "failed"
           ? "error"
           : "done"
 
-  const blocked = loadState === "ready" && (nsMismatch || (record != null && !record.editable))
+  // Mode-specific editability: TTL needs `editable`; the repoint needs
+  // `valueEditable` (defaults to `editable` — Cloudflare sets it explicitly so a
+  // proxied record's origin stays repointable even though its TTL isn't).
+  const canEdit = record == null ? false : mode === "ttl" ? record.editable : (record.valueEditable ?? record.editable)
+  const blocked = loadState === "ready" && (nsMismatch || (record != null && !canEdit))
 
   const close = () => {
     // Drop a settled failure so its marker doesn't linger; an in-flight change
     // keeps polling in the store.
-    if (activeKey && progress?.status === "failed") clearTtlWrite(activeKey)
+    if (activeKey && progress?.status === "failed") clearRecordWrite(activeKey)
     setInputMode(false)
     setDnsRecordsTarget(null)
   }
@@ -138,18 +183,37 @@ export function DnsRecords() {
     setPhase("confirm")
   }
 
+  const chooseValue = (value: string) => {
+    if (record && value === currentValue) return showFlash("The record already points there.")
+    setTargetValue(value)
+    setPhase("confirm")
+  }
+
   const submitCustom = () => {
-    if (!provider) return
-    const n = Number(custom.trim())
-    const err = !custom.trim() || Number.isNaN(n) ? "Enter a TTL in seconds." : validateTtl(provider, n)
+    if (!provider || !record) return
+    const raw = custom.trim()
+    if (mode === "value") {
+      const err = raw ? validateIp(record.type, raw) : "Enter an IP address."
+      if (err) return setCustomError(err)
+      setCustomError(null)
+      return chooseValue(raw)
+    }
+    const n = Number(raw)
+    const err = !raw || Number.isNaN(n) ? "Enter a TTL in seconds." : validateTtl(provider, n)
     if (err) return setCustomError(err)
     setCustomError(null)
     chooseTtl(n)
   }
 
   const fire = () => {
-    if (!target || !record || targetTtl == null) return
-    startTtlChange(target.connId, zoneId, record, targetTtl)
+    if (!target || !record) return
+    if (mode === "value") {
+      if (targetValue == null) return
+      startValueChange(target.connId, zoneId, record, targetValue)
+    } else {
+      if (targetTtl == null) return
+      startTtlChange(target.connId, zoneId, record, targetTtl)
+    }
     setActiveKey(record.key)
     setPhase("tracking")
   }
@@ -170,24 +234,35 @@ export function DnsRecords() {
     if (raw === "escape" || name === "q") {
       if (phase === "confirm") return setPhase("pick")
       // After a successful change, Esc closes back to the inventory — we KEEP the
-      // settled write so its row there reflects the new TTL (the authoritative host
-      // already has it); only failures are dropped (in close()).
+      // settled write so its row there reflects the new state (the authoritative
+      // host already has it); only failures are dropped (in close()).
       return close()
     }
 
     if (loadState !== "ready" || blocked) return
 
     if (phase === "pick") {
+      const n = mode === "value" ? valueOptions.length : ttlOptions.length
       switch (name) {
         case "up":
         case "k":
-          return setPickIndex((i) => moveSelection(i, -1, ttlOptions.length))
+          return setPickIndex((i) => moveSelection(i, -1, n))
         case "down":
         case "j":
-          return setPickIndex((i) => moveSelection(i, 1, ttlOptions.length))
+          return setPickIndex((i) => moveSelection(i, 1, n))
         case "return":
         case "right":
         case "l": {
+          if (mode === "value") {
+            const opt = valueOptions[pickIndex]
+            if (!opt) return
+            if (opt.value === "") {
+              setCustom("") // start empty — repointing to the current IP is never the goal
+              setCustomError(null)
+              return setPhase("custom")
+            }
+            return chooseValue(opt.value)
+          }
           const opt = ttlOptions[pickIndex]
           if (!opt) return
           if (opt.ttl === CUSTOM_TTL) {
@@ -209,7 +284,7 @@ export function DnsRecords() {
 
     if (dp === "error") {
       if (name === "r") {
-        if (activeKey) clearTtlWrite(activeKey)
+        if (activeKey) clearRecordWrite(activeKey)
         setActiveKey(null)
         setPhase("pick")
       }
@@ -220,11 +295,12 @@ export function DnsRecords() {
   if (!target || !provider) return null
 
   const recLabel = `${truncate(target.record.name || "@", 32)} ${target.record.type}`
+  const heading = mode === "value" ? "Point at" : "Edit TTL"
 
   return (
     <box style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", flexDirection: "column", backgroundColor: theme.bg, zIndex: 235 }}>
       <box style={{ flexDirection: "row", height: 1, backgroundColor: theme.bgAlt, paddingLeft: 1, paddingRight: 1, alignItems: "center" }}>
-        <text content={`🔧 Edit TTL · ${recLabel}  `} fg={theme.brand} wrapMode="none" style={{ flexShrink: 0 }} />
+        <text content={`🔧 ${heading} · ${recLabel}  `} fg={theme.brand} wrapMode="none" style={{ flexShrink: 0 }} />
         <text content={`${truncate(apex, 28)} · ${providerName}`} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 1 }} />
         <box style={{ flexGrow: 1 }} />
         {loadState === "loading" ? <Spinner color={theme.brand} interval={120} /> : null}
@@ -232,7 +308,7 @@ export function DnsRecords() {
 
       {nsMismatch && loadState === "ready" ? (
         <box style={{ flexDirection: "column", height: 2, backgroundColor: theme.bad, paddingLeft: 1, paddingRight: 1 }}>
-          <text content={`⚠ This account's hosted zone isn't the one serving ${truncate(apex, 30)} live — TTL edits are blocked.`} fg={theme.bg} wrapMode="none" />
+          <text content={`⚠ This account's hosted zone isn't the one serving ${truncate(apex, 30)} live — edits are blocked.`} fg={theme.bg} wrapMode="none" />
           <text content={`   live NS: ${truncate(ns!.live.join(" ") || "unknown", 50)}  ·  this zone: ${truncate(ns!.zone.join(" ") || "unknown", 50)}`} fg={theme.bg} wrapMode="none" />
         </box>
       ) : null}
@@ -271,7 +347,7 @@ export function DnsRecords() {
         </Panel>
       )
     }
-    if (!record.editable) {
+    if (!canEdit) {
       return (
         <Panel title=" Read-only record " active>
           <box style={{ flexDirection: "column", width: 56, paddingTop: 1, paddingBottom: 1 }}>
@@ -280,7 +356,7 @@ export function DnsRecords() {
               <text content={record.type} fg={theme.textDim} wrapMode="none" />
             </box>
             <box style={{ height: 1 }} />
-            <text content={`Can't edit this TTL — ${record.reason ?? "read-only"}.`} fg={theme.textDim} wrapMode="none" />
+            <text content={`Can't ${mode === "value" ? "repoint this record" : "edit this TTL"} — ${record.reason ?? "read-only"}.`} fg={theme.textDim} wrapMode="none" />
             <box style={{ height: 1 }} />
             <text content="Esc to close" fg={theme.textFaint} />
           </box>
@@ -289,6 +365,34 @@ export function DnsRecords() {
     }
 
     if (phase === "pick") {
+      if (mode === "value") {
+        // The current value's server is already tagged "(current)" in the list, so
+        // the header keeps just the bare IP — the row must fit width 58.
+        return (
+          <Panel title=" Point this record at " active>
+            <box style={{ flexDirection: "column", width: 58 }}>
+              <box style={{ flexDirection: "row" }}>
+                <text content={`${truncate(record.name || "@", 30)} `} fg={theme.accent} wrapMode="none" style={{ flexShrink: 0 }} />
+                <text content={record.type} fg={theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} />
+                <box style={{ flexGrow: 1 }} />
+                <text content={`now ${truncate(currentValue || "—", 18)}`} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
+              </box>
+              <box style={{ height: 1 }} />
+              {valueOptions.map((o, i) => {
+                const sel = i === pickIndex
+                const isCustom = o.value === ""
+                const isCurrent = !isCustom && o.value === currentValue
+                return (
+                  <box key={o.label + o.value} style={{ flexDirection: "row", height: 1, backgroundColor: sel ? theme.selectedBg : undefined }}>
+                    <text content={(sel ? "❯ " : "  ") + truncate(o.label, 30)} fg={sel ? theme.text : isCurrent ? theme.textFaint : theme.textDim} style={{ flexGrow: 1 }} wrapMode="none" />
+                    <text content={isCustom ? "" : o.value + (isCurrent ? "  (current)" : "")} fg={sel ? theme.text : theme.textFaint} style={{ flexShrink: 0 }} wrapMode="none" />
+                  </box>
+                )
+              })}
+            </box>
+          </Panel>
+        )
+      }
       return (
         <Panel title=" Choose a TTL " active>
           <box style={{ flexDirection: "column", width: 44 }}>
@@ -319,11 +423,13 @@ export function DnsRecords() {
 
     if (phase === "custom") {
       const inputStyle = { backgroundColor: theme.bgAlt, focusedBackgroundColor: theme.bgAlt, textColor: theme.text }
+      const label = mode === "value" ? (record.type === "AAAA" ? "IPv6 address" : "IP address") : "TTL in seconds"
+      const placeholder = mode === "value" ? "e.g. 203.0.113.10" : "e.g. 3600"
       return (
-        <Panel title=" Custom TTL " active>
+        <Panel title={mode === "value" ? " Custom IP " : " Custom TTL "} active>
           <box style={{ flexDirection: "column", width: 48, paddingTop: 1, paddingBottom: 1 }}>
-            <text content="TTL in seconds" fg={theme.accent} />
-            <input focused value={custom} placeholder="e.g. 3600" onInput={setCustom} onSubmit={submitCustom} style={inputStyle} />
+            <text content={label} fg={theme.accent} />
+            <input focused value={custom} placeholder={placeholder} onInput={setCustom} onSubmit={submitCustom} style={inputStyle} />
             <box style={{ height: 1 }} />
             {customError ? <text content={customError} fg={theme.bad} wrapMode="none" /> : <text content="⏎ to continue · Esc to go back" fg={theme.textFaint} wrapMode="none" />}
           </box>
@@ -332,6 +438,33 @@ export function DnsRecords() {
     }
 
     if (phase === "confirm") {
+      if (mode === "value") {
+        const targetServer = targetValue ? serverNameFor(targetValue) : undefined
+        const proxied = record.reason === "proxied"
+        return (
+          <Panel title=" Confirm repoint " active>
+            <box style={{ flexDirection: "column", width: 64, paddingTop: 1, paddingBottom: 1 }}>
+              <box style={{ flexDirection: "row" }}>
+                <text content={`${truncate(record.name || "@", 28)} `} fg={theme.accent} wrapMode="none" />
+                <text content={record.type} fg={theme.textDim} wrapMode="none" />
+              </box>
+              <box style={{ flexDirection: "row" }}>
+                <text content={truncate(currentValue || "—", 22)} fg={theme.textDim} wrapMode="none" />
+                <text content="  →  " fg={theme.textFaint} />
+                <text content={`${targetValue}${targetServer ? ` (${truncate(targetServer, 24)})` : ""}`} fg={theme.good} wrapMode="none" />
+              </box>
+              <box style={{ height: 1 }} />
+              {record.values.length > 1 ? (
+                <text content={`⚠ Replaces all ${record.values.length} current values with this one.`} fg={theme.warn} wrapMode="none" />
+              ) : null}
+              {proxied ? <text content="Proxied by Cloudflare — this swaps the ORIGIN behind the proxy; visitors keep resolving Cloudflare's IPs." fg={theme.textDim} wrapMode="none" /> : null}
+              <text content={`This writes directly to ${providerName} — it moves LIVE traffic.`} fg={theme.textDim} wrapMode="none" />
+              <box style={{ height: 1 }} />
+              <text content="Press y to confirm · ← to go back · Esc to cancel" fg={theme.textFaint} wrapMode="none" />
+            </box>
+          </Panel>
+        )
+      }
       return (
         <Panel title=" Confirm TTL change " active>
           <box style={{ flexDirection: "column", width: 56, paddingTop: 1, paddingBottom: 1 }}>
@@ -354,11 +487,12 @@ export function DnsRecords() {
     }
 
     if (dp === "tracking") {
+      const doing = mode === "value" ? `Pointing at ${targetValue}` : `Setting TTL to ${formatTtl(targetTtl)}`
       return (
         <box style={{ flexDirection: "column", alignItems: "center" }}>
           <box style={{ flexDirection: "row" }}>
             <Spinner />
-            <text content={`  Setting TTL to ${formatTtl(targetTtl)} — ${progress?.status ?? "queued"}…`} fg={theme.textDim} />
+            <text content={`  ${doing} — ${progress?.status ?? "queued"}…`} fg={theme.textDim} />
           </box>
           <box style={{ height: 1 }} />
           <text content="You can press Esc — it keeps applying in the background." fg={theme.textFaint} wrapMode="none" />
@@ -367,13 +501,14 @@ export function DnsRecords() {
     }
 
     if (dp === "done") {
+      const result = mode === "value" ? `now points at ${targetValue}` : `TTL is now ${formatTtl(targetTtl)}`
       return (
         <Panel title=" Done " active>
-          <box style={{ flexDirection: "column", width: 52, paddingTop: 1, paddingBottom: 1 }}>
+          <box style={{ flexDirection: "column", width: 56, paddingTop: 1, paddingBottom: 1 }}>
             <box style={{ flexDirection: "row" }}>
               <text content="✓ " fg={theme.good} />
               <text content={`${truncate(record.name || "@", 24)} ${record.type}`} fg={theme.accent} wrapMode="none" />
-              <text content={` TTL is now ${formatTtl(targetTtl)}`} fg={theme.text} wrapMode="none" />
+              <text content={` ${result}`} fg={theme.text} wrapMode="none" />
             </box>
             <box style={{ height: 1 }} />
             <text content="Esc to close · r in the inventory to refresh" fg={theme.textFaint} wrapMode="none" />
@@ -388,7 +523,7 @@ export function DnsRecords() {
         <box style={{ flexDirection: "column", width: 64, paddingTop: 1, paddingBottom: 1 }}>
           <text content={`✕ ${progress?.error ?? "Something went wrong."}`} fg={theme.bad} wrapMode="none" />
           <box style={{ height: 1 }} />
-          <text content="Press r to choose another TTL · Esc to close" fg={theme.textFaint} wrapMode="none" />
+          <text content={`Press r to choose another ${mode === "value" ? "target" : "TTL"} · Esc to close`} fg={theme.textFaint} wrapMode="none" />
         </box>
       </Panel>
     )
@@ -400,7 +535,7 @@ export function DnsRecords() {
     switch (dp) {
       case "pick":
         return [
-          { key: "↑↓/jk", label: "TTL" },
+          { key: "↑↓/jk", label: mode === "value" ? "target" : "TTL" },
           { key: "⏎", label: "choose" },
           { key: "esc", label: "close" },
         ]


### PR DESCRIPTION
## What's in

**DNS repoint (`p` in the `N`/`n` view).** The single-record editor gains a second mode: alongside `⏎` edit TTL, `p` opens "Point at…" — a picker that leads with the account's SpinupWP servers (name + IP, the record's current home tagged `(current)`), with a custom IP as the fallback. Same confirm-before-firing flow and edit-time NS-match gate as the TTL editor. The record-write tracker is generalized (`kind: ttl | value` on one progress map), so a Route 53 repoint keeps polling to INSYNC after the editor closes and the inventory's VALUE cell shows `→ new IP` in flight / the settled value after. Guardrails: CNAMEs explain they follow their target instead of opening, Cloudflare proxied records repoint their origin (with an explanatory note; uses the existing `valueEditable` distinction), and a multi-value record warns it'll be collapsed to the one new value.

**Fix: stale `◀ here` markers.** The "points here" flag was computed at resolve time against whichever server's inventory triggered the lookup, then cached by hostname — so after checking DNS on the new server post-migration, the old server's view showed records pointing at the *new* box as `◀ here`. `HostRecord` now stores the resolved IPs server-neutrally and "here" is computed at render against the server being viewed; a just-repointed record reads correctly immediately.

**Clone wizard back navigation (`←`/`h`).** Setup steps (Plan ↔ Destination ↔ Connect dest ↔ Git access) step back freely — nothing has executed yet. Once the fan-out has fired, the one back edge is DNS cutover → the clone roster, to re-verify or retry a site before flipping live traffic. Cutover state survives the round trip: re-entering only reads records for sites never checked, so in-flight flips are never reset — and a site that became done via retry now gets its records read (previously it could be silently skipped).

**Clone verify hardening.** The source-vs-clone wp-cli facts run with `--skip-plugins --skip-themes` (identical flags both sides keeps counts comparable; no plugin code can stall the read), get a 120s budget, and end with an `eof` sentinel — a cut-off read now fails loudly naming the side instead of rendering misleading `–` mismatch rows.

**Vanity sites on busy servers.** `V` was gated on "0 sites"; it's now "no site at the server's own hostname yet", and an eligible server shows a `V — Vanity site at hostname` row under Manage in Server Control (or "Resume vanity-site build"). The build flow itself is unchanged.

## Testing

- `bun run typecheck` green.
- Back navigation driven live under pilotty (Dev Mode): every setup-step edge, the picker/drill-down layered closes, and hints.
- Repoint verified against real Route 53: full picker → confirm → fire; a production record was successfully repointed between servers with it.
- Stale-`here` fix reproduced and verified in one session (view server A, then server B — markers now correct on both).
- Vanity gating verified live: a server with a hostname site shows no row; one without shows it, and `V` opens the build confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012adzactGwef16wc61eiUEc