### PR TITLE
Vanity pages double as health endpoints for any uptime monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+### Added
+- **Vanity pages are now health endpoints any uptime monitor can watch.** The page
+  the `V` wizard seeds gains two machine modes: `?healthz` returns plain
+  `200 ok` / `503 unhealthy: …` (1-min load per core > 2, or disk free < 10%) so a
+  plain HTTP monitor gets resource alerting for free, and `?format=json&key=…`
+  returns full metrics (load, cores, uptime, disk, memory, PHP version) guarded by
+  a per-site key generated at seed time (shown on the wizard's done screen, kept in
+  `vanityHealthKeys` in config.json so re-seeds keep monitor URLs stable). The
+  human page and its WHMCS-parseable `<load>`/`<uptime>` tags are unchanged.
+  Monitoring recipes — including Uptime Kuma keyword/JSON-query/cert-expiry
+  setups — live in `docs/uptime-kuma.md`.
+
 ## [0.13.0] - 2026-07-03
 
 ### Added

--- a/docs/uptime-kuma.md
+++ b/docs/uptime-kuma.md
@@ -1,0 +1,81 @@
+# Monitoring vanity sites with Uptime Kuma
+
+Every vanity site Spinup seeds (the `V` wizard) is also a machine-readable health
+endpoint. This doc covers wiring those pages into [Uptime Kuma](https://github.com/louislam/uptime-kuma)
+— though the endpoints are tool-agnostic and work with any HTTP monitor.
+
+Examples use `web1.example.com` for the vanity site and `kuma.example.com` for the
+Uptime Kuma instance; substitute your own.
+
+## What the page exposes
+
+| URL | Auth | Returns |
+| --- | --- | --- |
+| `https://web1.example.com/` | none | Human status page. `Online`, uptime, 1-min load (machine-parseable `<load>`/`<uptime>` tags — WHMCS-compatible). |
+| `https://web1.example.com/?healthz` | none | `200 ok`, or `503 unhealthy: load disk` when 1-min load per core > 2 or disk free < 10%. Plain text. |
+| `https://web1.example.com/?format=json&key=KEY` | `key` | Metrics JSON: `host, status, load_1m, cores, uptime_s, disk_free_pct, mem_available_pct, php_version, time`. `403` on a bad/missing key. |
+
+The `key` is generated when the wizard seeds the page (shown on the wizard's done
+screen; stored per domain under `vanityHealthKeys` in `config.json`). `?healthz`
+deliberately needs no key — it reveals only a binary state, so it's safe for any
+monitor, load balancer, or badge.
+
+## Recipes
+
+### 1. Server up/down + resource alerting in one monitor (recommended)
+
+Monitor type **HTTP(s)** on `https://web1.example.com/?healthz`, accepted status
+codes `200-299`, interval 60s. Because the page returns `503` under CPU pressure or
+low disk, this single plain-HTTP monitor also alerts on resource trouble — no
+special monitor type needed.
+
+Kuma retries before alerting (default 1); bump **Retries** to 2–3 so a brief load
+spike doesn't page you.
+
+### 2. Keyword sanity check on the human page
+
+Monitor type **HTTP(s) - Keyword** on `https://web1.example.com/` with keyword
+`Online`. Exercises the full nginx → PHP-FPM path and confirms the page actually
+renders. Mostly redundant with recipe 1; useful if you want to monitor the page a
+visitor sees.
+
+### 3. Certificate-expiry canary (free with any HTTPS monitor)
+
+Any HTTPS monitor on the vanity site tracks its Let's Encrypt certificate. In Kuma:
+Settings → Notifications, and enable **Certificate Expiry Notification** (defaults:
+21/14/7 days). Since SpinupWP renews all LE certs on the server the same way, the
+vanity cert doubles as a canary for server-wide renewal problems — you find out
+without pointing monitors at client sites.
+
+### 4. Custom thresholds with JSON Query monitors
+
+Monitor type **HTTP(s) - Json Query** on
+`https://web1.example.com/?format=json&key=KEY` lets you pick your own thresholds
+instead of the baked-in healthz ones:
+
+- Json Query `load_1m`, expected condition `< 8` — alert on sustained load.
+- Json Query `disk_free_pct`, expected condition `> 10` — alert before disk fills.
+- Json Query `status`, expected value `ok` — same semantics as healthz.
+
+One monitor per expression (Kuma evaluates a single query each).
+
+### 5. Response-time trend
+
+Any of the above monitors also charts response time in Kuma. The page does real
+PHP work per request, so its response-time graph loosely tracks server strain —
+a useful early-warning trend line between hard alerts.
+
+## Status pages and badges
+
+Group vanity monitors on a Kuma **status page** (one entry per server) for an
+at-a-glance fleet view you can share. Monitors shown on a status page also get
+public badge URLs (`/api/badge/:id/status`, `/uptime`, `/cert-exp`, …) you can embed
+anywhere.
+
+## Roadmap
+
+Deeper integration ships in later Spinup releases: registering these monitors
+automatically from the vanity wizard, a per-server load graph via Kuma push
+monitors (cron-fed, dead-man's-switch semantics), maintenance windows around
+server reboots, and Kuma-backed uptime/response sparklines inside Spinup's Health
+view.

--- a/docs/vanity-site/index.php
+++ b/docs/vanity-site/index.php
@@ -18,6 +18,68 @@
 
     // Reusable on any server: derive the name from the request host, not a literal.
     $host = $_SERVER['HTTP_HOST'] ?? gethostname();
+
+    // --- Machine-readable modes (?healthz, ?format=json) ------------------------
+    // Substituted at seed time; empty means the JSON mode needs no key.
+    $health_key = '__SPINUP_HEALTH_KEY__';
+    if (isset($_GET['healthz']) || (($_GET['format'] ?? '') === 'json')) {
+        header('Cache-Control: no-store');
+        $cores = 1;
+        $cpuinfo = @file_get_contents('/proc/cpuinfo');
+        if ($cpuinfo && preg_match_all('/^processor\s*:/m', $cpuinfo, $m)) $cores = max(1, count($m[0]));
+        // SpinupWP's FPM pool disables disk_*/exec (fatal even with @) but leaves
+        // shell_exec — guard with function_exists and fall back to df.
+        $disk_free_pct = null;
+        if (function_exists('disk_free_space') && function_exists('disk_total_space')) {
+            $dt = @disk_total_space(__DIR__);
+            $df = @disk_free_space(__DIR__);
+            if ($dt && $df !== false) $disk_free_pct = round($df / $dt * 100, 1);
+        } elseif (function_exists('shell_exec')) {
+            $df_out = @shell_exec('df -Pk ' . escapeshellarg(__DIR__) . ' 2>/dev/null');
+            if ($df_out && preg_match('/\n\S+\s+(\d+)\s+\d+\s+(\d+)\s/', $df_out, $dm) && (int)$dm[1] > 0) {
+                $disk_free_pct = round((int)$dm[2] / (int)$dm[1] * 100, 1);
+            }
+        }
+        $mem_available_pct = null;
+        $meminfo = @file_get_contents('/proc/meminfo');
+        if ($meminfo && preg_match('/^MemTotal:\s+(\d+)/m', $meminfo, $mt)
+                     && preg_match('/^MemAvailable:\s+(\d+)/m', $meminfo, $ma)
+                     && (int)$mt[1] > 0) {
+            $mem_available_pct = round((int)$ma[1] / (int)$mt[1] * 100, 1);
+        }
+        // Unhealthy = CPU pressure (1-min load per core > 2) or low disk (< 10% free).
+        $reasons = [];
+        if ($load !== '' && ((float)$load / $cores) > 2) $reasons[] = 'load';
+        if ($disk_free_pct !== null && $disk_free_pct < 10) $reasons[] = 'disk';
+
+        // ?healthz: binary state only — safe without a key. A plain HTTP monitor
+        // (200-299 = up) gets threshold alerting for free via the 503.
+        if (isset($_GET['healthz'])) {
+            http_response_code($reasons ? 503 : 200);
+            header('Content-Type: text/plain; charset=utf-8');
+            echo $reasons ? 'unhealthy: ' . implode(' ', $reasons) : 'ok';
+            exit;
+        }
+        if ($health_key !== '' && !hash_equals($health_key, (string)($_GET['key'] ?? ''))) {
+            http_response_code(403);
+            header('Content-Type: application/json');
+            echo '{"error":"forbidden"}';
+            exit;
+        }
+        header('Content-Type: application/json');
+        echo json_encode([
+            'host' => $host,
+            'status' => $reasons ? 'unhealthy' : 'ok',
+            'load_1m' => $load === '' ? null : (float)$load,
+            'cores' => $cores,
+            'uptime_s' => (int)$uptime,
+            'disk_free_pct' => $disk_free_pct,
+            'mem_available_pct' => $mem_available_pct,
+            'php_version' => PHP_VERSION,
+            'time' => gmdate('c'),
+        ]);
+        exit;
+    }
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,6 +72,11 @@ export interface AppConfig {
   // case and is never stored here — only the exceptions (e.g. "Integracon", a
   // third-party IT contact) are, so this stays empty for the common case.
   zoneAccessNotes: Record<string, string>
+  // Per-vanity-site health keys, keyed by domain — the `key` the seeded page's
+  // ?format=json mode requires (baked in at seed time). Kept here so re-seeds
+  // reuse the same key (monitor URLs stay stable) and so monitor-registration
+  // features can build the JSON URL later. Letters/digits only.
+  vanityHealthKeys: Record<string, string>
   // The last app version the user actually saw the Release Notes overlay for
   // (or, on a fresh install / pre-this-feature upgrade, silently seeded to the
   // running version with no notes shown — nothing meaningful to announce). A
@@ -143,6 +148,7 @@ export interface StoredConfig {
   preferredGrantKeys?: string[]
   grantedKeys?: Record<string, string[]>
   zoneAccessNotes?: Record<string, string>
+  vanityHealthKeys?: Record<string, string>
   lastSeenVersion?: string
 }
 
@@ -233,6 +239,7 @@ export function loadConfig(): AppConfig {
     preferredGrantKeys: stored.preferredGrantKeys ?? [],
     grantedKeys: stored.grantedKeys ?? {},
     zoneAccessNotes: stored.zoneAccessNotes ?? {},
+    vanityHealthKeys: stored.vanityHealthKeys ?? {},
     lastSeenVersion: stored.lastSeenVersion?.trim() || null,
   }
 }

--- a/src/lib/vanitySite.ts
+++ b/src/lib/vanitySite.ts
@@ -21,6 +21,10 @@ export async function aRecordResolves(host: string, ip: string): Promise<boolean
 
 // Brand-neutral, auto light/dark, reads its hostname from the request. The
 // <load>/<uptime> tags are machine-readable (WHMCS uptime checker parses them).
+// Machine modes for monitoring tools (Uptime Kuma etc. — see docs/uptime-kuma.md):
+//   ?healthz            → 200 "ok" / 503 "unhealthy: …" (plain text, no key)
+//   ?format=json[&key=] → metrics JSON; key required when one is baked in at
+//                         seed time via the __SPINUP_HEALTH_KEY__ placeholder.
 export const VANITY_INDEX_PHP = `<?php
     // --- Server load (1-min average) -------------------------------------------
     $load = @file_get_contents("/proc/loadavg");
@@ -41,6 +45,68 @@ export const VANITY_INDEX_PHP = `<?php
 
     // Reusable on any server: derive the name from the request host, not a literal.
     $host = $_SERVER['HTTP_HOST'] ?? gethostname();
+
+    // --- Machine-readable modes (?healthz, ?format=json) ------------------------
+    // Substituted at seed time; empty means the JSON mode needs no key.
+    $health_key = '__SPINUP_HEALTH_KEY__';
+    if (isset($_GET['healthz']) || (($_GET['format'] ?? '') === 'json')) {
+        header('Cache-Control: no-store');
+        $cores = 1;
+        $cpuinfo = @file_get_contents('/proc/cpuinfo');
+        if ($cpuinfo && preg_match_all('/^processor\\s*:/m', $cpuinfo, $m)) $cores = max(1, count($m[0]));
+        // SpinupWP's FPM pool disables disk_*/exec (fatal even with @) but leaves
+        // shell_exec — guard with function_exists and fall back to df.
+        $disk_free_pct = null;
+        if (function_exists('disk_free_space') && function_exists('disk_total_space')) {
+            $dt = @disk_total_space(__DIR__);
+            $df = @disk_free_space(__DIR__);
+            if ($dt && $df !== false) $disk_free_pct = round($df / $dt * 100, 1);
+        } elseif (function_exists('shell_exec')) {
+            $df_out = @shell_exec('df -Pk ' . escapeshellarg(__DIR__) . ' 2>/dev/null');
+            if ($df_out && preg_match('/\\n\\S+\\s+(\\d+)\\s+\\d+\\s+(\\d+)\\s/', $df_out, $dm) && (int)$dm[1] > 0) {
+                $disk_free_pct = round((int)$dm[2] / (int)$dm[1] * 100, 1);
+            }
+        }
+        $mem_available_pct = null;
+        $meminfo = @file_get_contents('/proc/meminfo');
+        if ($meminfo && preg_match('/^MemTotal:\\s+(\\d+)/m', $meminfo, $mt)
+                     && preg_match('/^MemAvailable:\\s+(\\d+)/m', $meminfo, $ma)
+                     && (int)$mt[1] > 0) {
+            $mem_available_pct = round((int)$ma[1] / (int)$mt[1] * 100, 1);
+        }
+        // Unhealthy = CPU pressure (1-min load per core > 2) or low disk (< 10% free).
+        $reasons = [];
+        if ($load !== '' && ((float)$load / $cores) > 2) $reasons[] = 'load';
+        if ($disk_free_pct !== null && $disk_free_pct < 10) $reasons[] = 'disk';
+
+        // ?healthz: binary state only — safe without a key. A plain HTTP monitor
+        // (200-299 = up) gets threshold alerting for free via the 503.
+        if (isset($_GET['healthz'])) {
+            http_response_code($reasons ? 503 : 200);
+            header('Content-Type: text/plain; charset=utf-8');
+            echo $reasons ? 'unhealthy: ' . implode(' ', $reasons) : 'ok';
+            exit;
+        }
+        if ($health_key !== '' && !hash_equals($health_key, (string)($_GET['key'] ?? ''))) {
+            http_response_code(403);
+            header('Content-Type: application/json');
+            echo '{"error":"forbidden"}';
+            exit;
+        }
+        header('Content-Type: application/json');
+        echo json_encode([
+            'host' => $host,
+            'status' => $reasons ? 'unhealthy' : 'ok',
+            'load_1m' => $load === '' ? null : (float)$load,
+            'cores' => $cores,
+            'uptime_s' => (int)$uptime,
+            'disk_free_pct' => $disk_free_pct,
+            'mem_available_pct' => $mem_available_pct,
+            'php_version' => PHP_VERSION,
+            'time' => gmdate('c'),
+        ]);
+        exit;
+    }
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -149,13 +215,17 @@ export interface VanitySeedTarget {
   port: number | null
   domain: string // the site domain (for the docroot path)
   publicFolder: string | null
+  // Baked into the page's ?format=json mode (letters/digits only — it lands inside
+  // a single-quoted PHP string). Empty/absent ⇒ the JSON mode needs no key.
+  healthKey?: string | null
 }
 
 // Push the embedded index.php into the site's docroot over SSH. Idempotent — safe
 // to re-run on resume (it overwrites). base64-pipe avoids any quoting headaches.
 export async function seedVanityIndex(t: VanitySeedTarget): Promise<{ ok: boolean; error?: string }> {
   const docroot = remoteDocRoot(t.domain, t.publicFolder)
-  const b64 = Buffer.from(VANITY_INDEX_PHP, "utf8").toString("base64")
+  const php = VANITY_INDEX_PHP.replace("__SPINUP_HEALTH_KEY__", t.healthKey ?? "")
+  const b64 = Buffer.from(php, "utf8").toString("base64")
   const remote = `mkdir -p '${docroot}' && printf '%s' '${b64}' | base64 -d > '${docroot}/index.php'`
   const r = await runProcess(["ssh", ...SSH_OPTS, ...sshPort(t.port), `${t.user}@${t.host}`, remote], 60_000)
   if (r.code !== 0) return { ok: false, error: meaningfulError(r.stderr, "Couldn't write index.php over SSH (is your key on the server yet?).") }

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -487,6 +487,7 @@ interface StoreValue extends DataState {
   vanityStopWaiting: () => void // from keep-waiting: stop waiting, continue the normal flow
   vanityRetry: () => void // re-enter the failed step
   clearVanity: () => void
+  vanityHealthKeyFor: (domain: string) => string | null // key baked into the seeded page's ?format=json mode
   // Clone a server to a new server (item 5). `cloneServer` opens the wizard; `cloneJob`
   // is the (Plan-draft then running) job whose heavy work lives in its `sites[]` vector.
   cloneServer: Server | null
@@ -2589,7 +2590,16 @@ export function StoreProvider({ children }: { children: ReactNode }) {
 
       async function doSeed(j: VanityJob) {
         persist({ ...j, step: "seed" })
-        const res = await seedVanityIndex({ host: j.serverIp, user: j.siteUser, port: j.port, domain: j.hostname, publicFolder: j.publicFolder })
+        // One stable key per domain: a resume/re-seed reuses it, so a monitor URL
+        // built against the page's ?format=json mode never goes stale.
+        const keys = { ...cfgRef.current.vanityHealthKeys }
+        const healthKey = keys[j.hostname] ?? crypto.randomUUID().replace(/-/g, "")
+        if (keys[j.hostname] !== healthKey) {
+          keys[j.hostname] = healthKey
+          cfgRef.current.vanityHealthKeys = keys
+          void saveConfig({ vanityHealthKeys: keys })
+        }
+        const res = await seedVanityIndex({ host: j.serverIp, user: j.siteUser, port: j.port, domain: j.hostname, publicFolder: j.publicFolder, healthKey })
         if (!res.ok) return fail(j, "seed", res.error || "Couldn't seed index.php over SSH.")
         await refresh()
         persist({ ...j, step: "done" })
@@ -2692,6 +2702,10 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     setVanityJob(null)
     void removeJob(VANITY_JOB_ID)
   }, [])
+
+  // Reads through cfgRef (not reactive state): the key is written by doSeed before
+  // the job reaches "done", so any render that can show it already sees it.
+  const vanityHealthKeyFor = useCallback((domain: string) => cfgRef.current.vanityHealthKeys[domain] ?? null, [])
 
   // ---- Clone a server to a new server (item 5) -----------------------------
 
@@ -3417,6 +3431,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     vanityStopWaiting,
     vanityRetry,
     clearVanity,
+    vanityHealthKeyFor,
     cloneServer,
     setCloneServer,
     cloneJob,

--- a/src/ui/views/VanityNewSite.tsx
+++ b/src/ui/views/VanityNewSite.tsx
@@ -32,7 +32,7 @@ function fmtClock(ms: number): string {
 }
 
 export function VanityNewSite() {
-  const { vanityServer: server, setVanityServer, vanityJob: job, startVanity, vanitySshKeyDone, vanitySkipSsl, vanityKeepWaiting, vanityStopWaiting, vanityRetry, clearVanity, accountSlug, setInputMode, sites, isSudoConnected, keyGrants, startGrantRemembered, preferredGrantKeys, clearGrantKey, sudoConnectServer, setSudoConnectServer } = useStore()
+  const { vanityServer: server, setVanityServer, vanityJob: job, startVanity, vanitySshKeyDone, vanitySkipSsl, vanityKeepWaiting, vanityStopWaiting, vanityRetry, clearVanity, vanityHealthKeyFor, accountSlug, setInputMode, sites, isSudoConnected, keyGrants, startGrantRemembered, preferredGrantKeys, clearGrantKey, sudoConnectServer, setSudoConnectServer } = useStore()
 
   const [siteUser, setSiteUser] = useState(() => (server ? deriveSiteUser(server.name) : ""))
   const [editingUser, setEditingUser] = useState(false)
@@ -242,14 +242,23 @@ export function VanityNewSite() {
 
     // Done.
     if (job.step === "done") {
+      const healthKey = vanityHealthKeyFor(job.hostname)
       return (
         <Panel title=" Server connected " active>
-          <box style={{ flexDirection: "column", width: 60, paddingTop: 1, paddingBottom: 1 }}>
+          <box style={{ flexDirection: "column", width: 66, paddingTop: 1, paddingBottom: 1 }}>
             <box style={{ flexDirection: "row" }}>
               <text content="✓ " fg={theme.good} style={{ flexShrink: 0 }} />
               <text content={job.hostname} fg={theme.accent} wrapMode="none" style={{ flexShrink: 1 }} />
             </box>
             <text content="The vanity site is live and the server now has a site." fg={theme.textDim} wrapMode="none" />
+            {healthKey && (
+              <>
+                <box style={{ height: 1 }} />
+                <text content="The page doubles as a health endpoint for any uptime tool:" fg={theme.textDim} wrapMode="none" />
+                <text content="  /?healthz — up/down (503 on high load or low disk)" fg={theme.textFaint} wrapMode="none" />
+                <text content={`  /?format=json&key=${healthKey}`} fg={theme.textFaint} wrapMode="none" />
+              </>
+            )}
             <box style={{ height: 1 }} />
             <text content="o open in browser · Esc to close" fg={theme.textFaint} wrapMode="none" />
           </box>


### PR DESCRIPTION
## What

PR 1 of 3 for the Uptime Kuma integration. The vanity page the `V` wizard seeds gains two machine-readable modes — tool-agnostic, works with any HTTP monitor:

- **`?healthz`** — plain `200 ok` / `503 unhealthy: …` when 1-min load per core > 2 or disk free < 10%. A plain HTTP monitor gets resource alerting for free via the status code.
- **`?format=json&key=…`** — full metrics JSON (`load_1m, cores, uptime_s, disk_free_pct, mem_available_pct, php_version, …`), guarded by a per-site key generated at seed time. Keys persist in `config.json` (`vanityHealthKeys`) so re-seeds keep monitor URLs stable; the wizard's done screen shows both endpoints.

The human page and its WHMCS-parseable `<load>`/`<uptime>` tags are unchanged. `docs/uptime-kuma.md` collects the monitor recipes (healthz monitor, keyword, cert-expiry canary, JSON-query thresholds, status pages/badges).

## Hard-won detail

SpinupWP's FPM pool **hard-disables `disk_free_space`/`disk_total_space`/`exec`** — calling them is a fatal error `@` can't suppress (CLI PHP has them, so local testing passes and the pool 500s). Every risky call is now behind `function_exists`, with a `shell_exec df -Pk` fallback for disk.

## Testing

- `bun run typecheck` green; app boots in dev mode under a PTY.
- PHP template lints (`php -l`) and all modes exercised locally via `php -S`, including a forced-503 branch check.
- **Live on the test box** (`web1.spinuptui.com`, seeded through the real `seedVanityIndex()` path): healthz `200 ok`; JSON without/with wrong key → `403`; with key → real metrics (`load_1m: 0.21`, `disk_free_pct: 84.2` via the df fallback, `mem_available_pct: 34.9`); human page intact.

Follow-ups: PR 2 (Kuma socket.io client, wizard auto-registration, push-cron load graphs), PR 3 (Health-view sparklines, reboot maintenance windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYCqn15ypvbEjBFdzpd13u