### PR TITLE
Uptime Kuma integration: client, wizard auto-registration, push-cron heartbeats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ versions; such changes are called out here.
 ## [Unreleased]
 
 ### Added
+- **Uptime Kuma integration — monitors register themselves.** Connect your Kuma
+  instance once (`m` on any site walks you through it; creds verified by a real
+  login and stored 0600, or via `SPINUP_KUMA_URL`/`_USERNAME`/`_PASSWORD`) and:
+  - The **vanity wizard grows two steps**: after publishing the page it registers
+    a healthz monitor + a load push monitor in Kuma, then installs a once-a-minute
+    heartbeat cron in the site user's crontab. The cron sends the 1-min load as
+    the push `ping`, so Kuma graphs server load — and a silent cron (server down,
+    cron dead, egress broken) flips the monitor: dead-man's-switch semantics.
+    Both steps auto-skip when Kuma isn't connected, and a failure there is
+    skippable — the site is already live.
+  - **`m` on any site** manages monitoring in place: vanity sites get the full
+    treatment (incl. `R` to re-publish pages seeded before the health-endpoint
+    feature existed), regular sites get a homepage monitor (up/down + cert-expiry
+    alerts) — client site files are never touched.
+  - The client speaks Kuma's socket.io API (its only management API), adopts
+    same-named monitors instead of duplicating them, reuses push tokens, and
+    handles both Kuma 1.x and 2.x monitor schemas.
 - **Vanity pages are now health endpoints any uptime monitor can watch.** The page
   the `V` wizard seeds gains two machine modes: `?healthz` returns plain
   `200 ok` / `503 unhealthy: …` (1-min load per core > 2, or disk free < 10%) so a

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@opentui/core": "latest",
         "@opentui/react": "latest",
         "react": "^19.0.0",
+        "socket.io-client": "^4.8.3",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -40,6 +41,8 @@
 
     "@opentui/react": ["@opentui/react@0.4.1", "", { "dependencies": { "@opentui/core": "0.4.1", "react-reconciler": "^0.33.0" }, "peerDependencies": { "react": ">=19.2.0", "react-devtools-core": "^7.0.1", "ws": "^8.18.0" } }, "sha512-hYNS8yhwVA+aGru74rtaxI81TM+rEIhMVOdooQOZRHcyVlml3inmKcI5n0Kroy4Vj4M0rCiVAPhovvqf+xfxGA=="],
 
+    "@socket.io/component-emitter": ["@socket.io/component-emitter@3.1.2", "", {}, "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="],
+
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
@@ -54,13 +57,21 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
     "diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
+    "engine.io-client": ["engine.io-client@6.6.6", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1", "engine.io-parser": "~5.2.1", "ws": "~8.21.0", "xmlhttprequest-ssl": "~2.1.1" } }, "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q=="],
+
+    "engine.io-parser": ["engine.io-parser@5.2.3", "", {}, "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q=="],
+
     "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
 
     "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
@@ -71,6 +82,10 @@
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
+
+    "socket.io-client": ["socket.io-client@4.8.3", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1", "engine.io-client": "~6.6.1", "socket.io-parser": "~4.2.4" } }, "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g=="],
+
+    "socket.io-parser": ["socket.io-parser@4.2.6", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1" } }, "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg=="],
 
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
@@ -83,6 +98,8 @@
     "web-tree-sitter": ["web-tree-sitter@0.25.10", "", { "peerDependencies": { "@types/emscripten": "^1.40.0" }, "optionalPeers": ["@types/emscripten"] }, "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA=="],
 
     "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "xmlhttprequest-ssl": ["xmlhttprequest-ssl@2.1.2", "", {}, "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ=="],
 
     "react-devtools-core/ws": ["ws@7.5.11", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA=="],
   }

--- a/docs/uptime-kuma.md
+++ b/docs/uptime-kuma.md
@@ -72,10 +72,22 @@ at-a-glance fleet view you can share. Monitors shown on a status page also get
 public badge URLs (`/api/badge/:id/status`, `/uptime`, `/cert-exp`, …) you can embed
 anywhere.
 
-## Roadmap
+## Let Spinup do it for you
 
-Deeper integration ships in later Spinup releases: registering these monitors
-automatically from the vanity wizard, a per-server load graph via Kuma push
-monitors (cron-fed, dead-man's-switch semantics), maintenance windows around
-server reboots, and Kuma-backed uptime/response sparklines inside Spinup's Health
-view.
+Connect your Kuma instance once and Spinup registers monitors itself:
+
+- **`m` on any site** (sites pane) opens the monitoring overlay. First use walks
+  through connecting (URL + login, verified by actually logging in; stored in
+  `config.json`, chmod 600 — or set `SPINUP_KUMA_URL`, `SPINUP_KUMA_USERNAME`,
+  `SPINUP_KUMA_PASSWORD`). Then `a` registers monitors: vanity sites get the
+  healthz monitor + a **load push monitor fed by a once-a-minute cron** in the
+  site user's crontab (Kuma graphs the load; a silent cron — server down, cron
+  dead, egress broken — flips the monitor: dead-man's-switch semantics). Regular
+  sites get a homepage monitor; Spinup never touches a client site's files.
+- **Vanity pages published before this feature** need one `R` (re-seed) from the
+  `m` overlay to gain the health endpoints, then everything above applies.
+- **The vanity wizard (`V`) does all of this automatically** as its final two
+  steps whenever a Kuma connection is configured.
+
+Spinup adopts same-named monitors rather than duplicating them, so hand-made
+monitors survive; a hand-made push monitor keeps its token (the cron adopts it).

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "@opentui-ui/toast": "^0.0.5",
     "@opentui/core": "latest",
     "@opentui/react": "latest",
-    "react": "^19.0.0"
+    "react": "^19.0.0",
+    "socket.io-client": "^4.8.3"
   },
   "devDependencies": {
     "@types/bun": "^1.3.14",

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,6 +72,14 @@ export interface AppConfig {
   // case and is never stored here — only the exceptions (e.g. "Integracon", a
   // third-party IT contact) are, so this stays empty for the common case.
   zoneAccessNotes: Record<string, string>
+  // Uptime Kuma connection (optional). Creds live here like provider creds (file
+  // is chmod 600); `jwt` is captured after the first successful login so later
+  // sessions use loginByToken (survives 2FA accounts, skips re-sending the
+  // password). Env overrides: SPINUP_KUMA_URL / _USERNAME / _PASSWORD.
+  uptimeKuma: UptimeKumaConn | null
+  // Kuma monitors Spinup has registered, keyed by site domain. `pushToken` is the
+  // token baked into the server-side cron; ids let later features pause/verify.
+  kumaMonitors: Record<string, KumaMonitorRef>
   // Per-vanity-site health keys, keyed by domain — the `key` the seeded page's
   // ?format=json mode requires (baked in at seed time). Kept here so re-seeds
   // reuse the same key (monitor URLs stay stable) and so monitor-registration
@@ -87,6 +95,20 @@ export interface AppConfig {
 export interface ServerProviderRef {
   id: number
   databaseProviderId?: number
+}
+
+export interface UptimeKumaConn {
+  url: string
+  username: string
+  password: string
+  jwt?: string
+  env?: boolean // creds came from the environment — read-only in the UI
+}
+
+export interface KumaMonitorRef {
+  healthId?: number // HTTP monitor on /?healthz
+  pushId?: number // push monitor fed by the server-side load cron
+  pushToken?: string
 }
 
 // A long-running, fire-and-forget job persisted across restarts so the app can
@@ -149,6 +171,8 @@ export interface StoredConfig {
   grantedKeys?: Record<string, string[]>
   zoneAccessNotes?: Record<string, string>
   vanityHealthKeys?: Record<string, string>
+  uptimeKuma?: UptimeKumaConn
+  kumaMonitors?: Record<string, KumaMonitorRef>
   lastSeenVersion?: string
 }
 
@@ -240,6 +264,14 @@ export function loadConfig(): AppConfig {
     grantedKeys: stored.grantedKeys ?? {},
     zoneAccessNotes: stored.zoneAccessNotes ?? {},
     vanityHealthKeys: stored.vanityHealthKeys ?? {},
+    uptimeKuma: ((): UptimeKumaConn | null => {
+      const url = process.env.SPINUP_KUMA_URL?.trim()
+      const username = process.env.SPINUP_KUMA_USERNAME?.trim()
+      const password = process.env.SPINUP_KUMA_PASSWORD?.trim()
+      if (url && username && password) return { url: url.replace(/\/+$/, ""), username, password, env: true }
+      return stored.uptimeKuma ?? null
+    })(),
+    kumaMonitors: stored.kumaMonitors ?? {},
     lastSeenVersion: stored.lastSeenVersion?.trim() || null,
   }
 }

--- a/src/lib/uptimeKuma.ts
+++ b/src/lib/uptimeKuma.ts
@@ -1,0 +1,289 @@
+// Thin Uptime Kuma client over its socket.io management API (Kuma exposes no REST
+// for management — only the push/badge/status-page endpoints). Event names and
+// payloads verified against the Kuma 2.x source; everything used here exists in
+// 1.21+ as well. Connections are short-lived: connect → login → work → disconnect.
+//
+// Auth: password login returns a JWT; we hand it back so callers can persist it
+// (config.json, 0600) and reconnect via loginByToken — the JWT stays valid until
+// the Kuma password changes, and it's what lets a 2FA-protected account work
+// beyond its first (token-prompted) login.
+
+import { io, type Socket } from "socket.io-client"
+
+export interface KumaCreds {
+  url: string
+  username: string
+  password: string
+  jwt?: string // from a prior successful login; preferred when present
+}
+
+// A monitor row as Kuma broadcasts it (monitorList / getMonitor). Only the fields
+// we read are typed; the rest ride along untyped.
+export interface KumaMonitor {
+  id: number
+  name: string
+  type: string
+  url?: string
+  active?: boolean | number
+  pushToken?: string
+  [k: string]: unknown
+}
+
+export interface KumaBeat {
+  status: number // 0 down, 1 up, 2 pending, 3 maintenance
+  time: string
+  msg?: string
+  ping?: number | null
+}
+
+interface Ack {
+  ok: boolean
+  msg?: string
+  monitorID?: number
+  maintenanceID?: number
+  token?: string
+  tokenRequired?: boolean
+  data?: unknown
+}
+
+const ACK_TIMEOUT_MS = 15_000
+const CONNECT_TIMEOUT_MS = 10_000
+
+// 32 chars, [A-Za-z0-9] — same shape the Kuma UI generates for push monitors.
+// (Kuma stores whatever the client sends; the token is chosen client-side.)
+export function genPushToken(): string {
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+  const bytes = crypto.getRandomValues(new Uint8Array(32))
+  return [...bytes].map((b) => chars[b % chars.length]).join("")
+}
+
+export function pushUrl(baseUrl: string, token: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}/api/push/${token}`
+}
+
+export class KumaError extends Error {}
+
+export class KumaClient {
+  private socket: Socket
+  version: string | null = null
+  // Kuma pushes these as events (not ack payloads) right after login and on change.
+  private monitorList: Record<string, KumaMonitor> | null = null
+  private notificationList: { id: number; isDefault?: boolean; active?: boolean; config?: string }[] = []
+
+  private constructor(socket: Socket) {
+    this.socket = socket
+    socket.on("info", (info: { version?: string }) => {
+      this.version = info?.version ?? null
+    })
+    socket.on("monitorList", (list: Record<string, KumaMonitor>) => {
+      this.monitorList = list
+    })
+    socket.on("notificationList", (list: typeof this.notificationList) => {
+      this.notificationList = list ?? []
+    })
+  }
+
+  static async connect(url: string): Promise<KumaClient> {
+    const base = url.replace(/\/+$/, "")
+    const socket = io(base, { transports: ["websocket"], reconnection: false, timeout: CONNECT_TIMEOUT_MS })
+    const client = new KumaClient(socket)
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => {
+        socket.disconnect()
+        reject(new KumaError(`Timed out reaching ${base} — is that the right URL?`))
+      }, CONNECT_TIMEOUT_MS)
+      socket.once("connect", () => {
+        clearTimeout(t)
+        resolve()
+      })
+      socket.once("connect_error", (e: Error) => {
+        clearTimeout(t)
+        socket.disconnect()
+        reject(new KumaError(`Couldn't reach Uptime Kuma at ${base}: ${e.message}`))
+      })
+    })
+    return client
+  }
+
+  disconnect(): void {
+    this.socket.disconnect()
+  }
+
+  private emitAck(event: string, ...args: unknown[]): Promise<Ack> {
+    return new Promise((resolve, reject) => {
+      const t = setTimeout(() => reject(new KumaError(`Kuma didn't answer "${event}" in time.`)), ACK_TIMEOUT_MS)
+      this.socket.emit(event, ...args, (res: Ack) => {
+        clearTimeout(t)
+        resolve(res ?? { ok: false, msg: "Empty response" })
+      })
+    })
+  }
+
+  private async must(event: string, ...args: unknown[]): Promise<Ack> {
+    const res = await this.emitAck(event, ...args)
+    if (!res.ok) throw new KumaError(res.msg || `Kuma rejected "${event}".`)
+    return res
+  }
+
+  // Login, preferring a saved JWT. Returns the JWT to persist on success (the
+  // password path mints one; the JWT path echoes it back). `tokenRequired` means
+  // the account has 2FA — retry with a current TOTP in `twofa`.
+  async login(creds: KumaCreds, twofa?: string): Promise<{ ok: true; jwt: string } | { ok: false; error: string; tokenRequired?: boolean }> {
+    if (creds.jwt) {
+      const byToken = await this.emitAck("loginByToken", creds.jwt)
+      if (byToken.ok) return { ok: true, jwt: creds.jwt }
+      // Stale JWT (password changed / server reset) — fall through to password.
+    }
+    const res = await this.emitAck("login", { username: creds.username, password: creds.password, token: twofa ?? "" })
+    if (res.ok && res.token) return { ok: true, jwt: res.token }
+    if (res.tokenRequired) return { ok: false, error: "This account has 2FA — enter a current code to log in.", tokenRequired: true }
+    return { ok: false, error: res.msg || "Uptime Kuma rejected the login." }
+  }
+
+  // The monitor list arrives as a broadcast event (login triggers one); asking via
+  // getMonitorList re-triggers it. Await whichever lands first.
+  async getMonitors(): Promise<KumaMonitor[]> {
+    if (!this.monitorList) {
+      const wait = new Promise<void>((resolve, reject) => {
+        const t = setTimeout(() => reject(new KumaError("Kuma didn't send the monitor list in time.")), ACK_TIMEOUT_MS)
+        this.socket.once("monitorList", () => {
+          clearTimeout(t)
+          resolve()
+        })
+      })
+      await this.emitAck("getMonitorList")
+      if (!this.monitorList) await wait
+    }
+    return Object.values(this.monitorList ?? {})
+  }
+
+  // Notifications flagged "Default enabled" in Kuma — the UI auto-attaches these
+  // to new monitors, so we do the same for monitors we create.
+  private defaultNotificationIds(): Record<string, boolean> {
+    const ids: Record<string, boolean> = {}
+    for (const n of this.notificationList) {
+      try {
+        const cfg = n.config ? (JSON.parse(n.config) as { isDefault?: boolean }) : {}
+        if (n.isDefault || cfg.isDefault) ids[String(n.id)] = true
+      } catch {
+        // Unparseable config — skip.
+      }
+    }
+    return ids
+  }
+
+  // Kuma 2.x monitors carry a `conditions` array its UI always sends; 1.x has no
+  // such column and the insert fails if we send one. Try the 2.x shape first and
+  // fall back, so one client speaks to either generation.
+  async addMonitor(monitor: Record<string, unknown>): Promise<number> {
+    const payload = { notificationIDList: this.defaultNotificationIds(), conditions: [], ...monitor }
+    let res = await this.emitAck("add", payload)
+    if (!res.ok && /conditions/i.test(res.msg ?? "")) {
+      const { conditions: _legacy, ...withoutConditions } = payload
+      res = await this.emitAck("add", withoutConditions)
+    }
+    if (!res.ok) throw new KumaError(res.msg || 'Kuma rejected "add".')
+    if (typeof res.monitorID !== "number") throw new KumaError("Kuma didn't return the new monitor's id.")
+    return res.monitorID
+  }
+
+  async pauseMonitor(id: number): Promise<void> {
+    await this.must("pauseMonitor", id)
+  }
+
+  async resumeMonitor(id: number): Promise<void> {
+    await this.must("resumeMonitor", id)
+  }
+
+  async deleteMonitor(id: number): Promise<void> {
+    await this.must("deleteMonitor", id)
+  }
+
+  async getMonitorBeats(id: number, periodHours: number): Promise<KumaBeat[]> {
+    const res = await this.must("getMonitorBeats", id, periodHours)
+    return (res.data as KumaBeat[]) ?? []
+  }
+
+  // Manual-strategy maintenance: active immediately, until deleted/paused.
+  async addManualMaintenance(title: string, description: string): Promise<number> {
+    const res = await this.must("addMaintenance", {
+      title,
+      description,
+      strategy: "manual",
+      active: true,
+      intervalDay: 1,
+      dateRange: [null, null],
+      timeRange: [
+        { hours: 0, minutes: 0 },
+        { hours: 0, minutes: 0 },
+      ],
+      weekdays: [],
+      daysOfMonth: [],
+    })
+    if (typeof res.maintenanceID !== "number") throw new KumaError("Kuma didn't return the maintenance id.")
+    return res.maintenanceID
+  }
+
+  async setMaintenanceMonitors(maintenanceID: number, monitorIds: number[]): Promise<void> {
+    await this.must(
+      "addMonitorMaintenance",
+      maintenanceID,
+      monitorIds.map((id) => ({ id })),
+    )
+  }
+
+  async deleteMaintenance(maintenanceID: number): Promise<void> {
+    await this.must("deleteMaintenance", maintenanceID)
+  }
+}
+
+// Standard payloads for the two monitors Spinup creates per vanity site. Kuma's
+// `add` handler tolerates missing columns, but we send what its own UI sends so
+// the rows are indistinguishable from hand-made ones.
+export function healthMonitorPayload(name: string, url: string): Record<string, unknown> {
+  return {
+    type: "http",
+    name,
+    url,
+    method: "GET",
+    interval: 60,
+    retryInterval: 60,
+    resendInterval: 0,
+    maxretries: 2, // ride out a brief load spike before alerting
+    timeout: 48,
+    accepted_statuscodes: ["200-299"],
+    expiryNotification: true, // LE-renewal canary for the whole server
+    ignoreTls: false,
+    upsideDown: false,
+    maxredirects: 10,
+  }
+}
+
+export function loadPushMonitorPayload(name: string, pushToken: string): Record<string, unknown> {
+  return {
+    type: "push",
+    name,
+    pushToken,
+    // The cron beats once a minute; alert after ~2 missed beats.
+    interval: 60,
+    retryInterval: 60,
+    maxretries: 2,
+    upsideDown: false,
+    // Kuma validates status-code arrays on every monitor type, push included.
+    accepted_statuscodes: ["200-299"],
+  }
+}
+
+// Connect → login → run → always disconnect. Returns the (possibly refreshed) JWT
+// alongside the result so callers can persist it.
+export async function withKuma<T>(creds: KumaCreds, fn: (kuma: KumaClient) => Promise<T>): Promise<{ result: T; jwt: string; version: string | null }> {
+  const kuma = await KumaClient.connect(creds.url)
+  try {
+    const login = await kuma.login(creds)
+    if (!login.ok) throw new KumaError(login.error)
+    const result = await fn(kuma)
+    return { result, jwt: login.jwt, version: kuma.version }
+  } finally {
+    kuma.disconnect()
+  }
+}

--- a/src/lib/vanitySite.ts
+++ b/src/lib/vanitySite.ts
@@ -231,3 +231,33 @@ export async function seedVanityIndex(t: VanitySeedTarget): Promise<{ ok: boolea
   if (r.code !== 0) return { ok: false, error: meaningfulError(r.stderr, "Couldn't write index.php over SSH (is your key on the server yet?).") }
   return { ok: true }
 }
+
+export interface PushCronTarget {
+  host: string // server IP / hostname for SSH
+  user: string // site_user (the cron lands in this user's crontab — no sudo needed)
+  port: number | null
+  kumaUrl: string // Uptime Kuma base URL
+  pushToken: string
+}
+
+const PUSH_CRON_MARKER = "spinup-kuma-push"
+
+// Install (or refresh) the once-a-minute heartbeat cron that feeds the Kuma push
+// monitor: status=up plus the 1-min load in `ping`, which Kuma graphs. The beat
+// stopping is the signal (dead-man's switch) — so the cron itself never reports
+// "down"; it just goes quiet when the server/cron/egress dies.
+//
+// Idempotent: a marker comment identifies our line, and the install strips any
+// previous marked line before appending. NO `%` anywhere in the line — cron
+// treats a bare % as newline.
+export async function seedVanityPushCron(t: PushCronTarget): Promise<{ ok: boolean; error?: string }> {
+  const push = `${t.kumaUrl.replace(/\/+$/, "")}/api/push/${t.pushToken}`
+  const line = `* * * * * curl -fsS --max-time 20 '${push}?status=up&msg=ok&ping='$(awk '{print $1}' /proc/loadavg) >/dev/null 2>&1 # ${PUSH_CRON_MARKER}`
+  // The line contains quotes of both kinds once cron expands it, so ship it
+  // base64'd (same trick as the index.php seed) instead of fighting nesting.
+  const b64 = Buffer.from(line + "\n", "utf8").toString("base64")
+  const remote = `( crontab -l 2>/dev/null | grep -v '${PUSH_CRON_MARKER}' ; printf '%s' '${b64}' | base64 -d ) | crontab -`
+  const r = await runProcess(["ssh", ...SSH_OPTS, ...sshPort(t.port), `${t.user}@${t.host}`, remote], 60_000)
+  if (r.code !== 0) return { ok: false, error: meaningfulError(r.stderr, "Couldn't install the heartbeat cron over SSH.") }
+  return { ok: true }
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -34,6 +34,7 @@ import { Forgotten } from "./views/Forgotten.tsx"
 import { DnsInventory } from "./views/DnsInventory.tsx"
 import { ProviderConnect } from "./views/ProviderConnect.tsx"
 import { DnsRecords } from "./views/DnsRecords.tsx"
+import { KumaSite } from "./views/KumaSite.tsx"
 
 const MIN_SPLASH_MS = 1200
 
@@ -74,7 +75,8 @@ export function App() {
     store.forgottenOpen ||
     store.dnsInventoryServer !== null ||
     store.connectZoneTarget !== null ||
-    store.dnsRecordsTarget !== null
+    store.dnsRecordsTarget !== null ||
+    store.kumaSite !== null
   useEffect(() => {
     store.setOverlayOpen(overlayActive)
   }, [overlayActive, store])
@@ -240,6 +242,7 @@ export function App() {
       {store.dnsInventoryServer && <DnsInventory />}
       {store.connectZoneTarget && <ProviderConnect />}
       {store.dnsRecordsTarget && <DnsRecords />}
+      {store.kumaSite && <KumaSite />}
       {/* Async-completion toasts (PHP upgrade, server reboot/restart). Mounted last
           so it draws over every view + overlay; top-right, nudged clear of the
           2-row Header. It never takes keyboard focus. */}

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -11,7 +11,7 @@ import { SpinupWPClient, ApiError, type ServerService, type SpinupWPClientLike }
 import { isDevMode } from "../dev/devMode.ts"
 import { createMockClient } from "../dev/mockClient.ts"
 import type { Server, Site, Event, ProviderMetadata, CreateServerPayload, CreateSitePayload, AdditionalDomain } from "../api/types.ts"
-import { loadConfig, saveConfig, type ServerProviderRef } from "../config.ts"
+import { loadConfig, saveConfig, type ServerProviderRef, type KumaMonitorRef } from "../config.ts"
 import { saveJob, removeJob } from "../lib/jobs.ts"
 import { APP_VERSION } from "../version.ts"
 import { cachedUpdateInfo, refreshUpdateInfo, type UpdateInfo } from "../lib/appUpdate.ts"
@@ -40,7 +40,8 @@ import {
 } from "../lib/providers.ts"
 import { ProvidersCache, type VerifiedConn } from "../lib/providersCache.ts"
 import { recordProviderFor, type DnsRecord, type RecordResult } from "../lib/dnsRecords.ts"
-import { deriveSiteUser, seedVanityIndex, aRecordResolves } from "../lib/vanitySite.ts"
+import { deriveSiteUser, seedVanityIndex, seedVanityPushCron, aRecordResolves } from "../lib/vanitySite.ts"
+import { withKuma, genPushToken, healthMonitorPayload, loadPushMonitorPayload } from "../lib/uptimeKuma.ts"
 import type { StoredProviders } from "../config.ts"
 import { fetchRebootInfo, grantSiteSshKey, revokeSiteSshKey, verifySudo, ensureSpinupKey, listPersonalKeys, keyBody, type RebootInfo } from "../lib/ssh.ts"
 import { estimateSourceSiteSizes, runStandardWpPull, runBedrockPull, runFilesOnlyPull, verifyClone, verifyFilesClone, type SudoCtx, type CloneStage, type CloneExecRecord, type VerifyResult as CloneVerifyResult } from "../lib/serverClone.ts"
@@ -149,10 +150,13 @@ export interface NewServerJob {
 }
 
 // The vanity-site build: a multi-step orchestration (DNS A record → propagate →
-// create site → enable HTTPS → SSH-key handoff → seed index.php) that connects a
-// fresh, empty server. Steps dns/site/https are event/poll-backed (true resume);
-// sshkey is a manual park; seed is an idempotent SSH push.
-export type VanityStep = "dns" | "propagate" | "site" | "https" | "sshkey" | "seed" | "done" | "error"
+// create site → enable HTTPS → SSH-key handoff → seed index.php → register Kuma
+// monitors → install heartbeat cron) that connects a fresh, empty server. Steps
+// dns/site/https are event/poll-backed (true resume); sshkey is a manual park;
+// seed/monitor/cron are idempotent pushes. monitor/cron auto-skip (straight to
+// done) when no Uptime Kuma connection is configured, and a failure there can be
+// skipped — the site itself is already live.
+export type VanityStep = "dns" | "propagate" | "site" | "https" | "sshkey" | "seed" | "monitor" | "cron" | "done" | "error"
 export interface VanityJob {
   serverId: number
   serverIp: string
@@ -172,9 +176,20 @@ export interface VanityJob {
   propagateStartedAt?: number
   keepWaiting?: boolean // user chose "keep waiting" after the first timeout → poll
                         // indefinitely (count-up in the UI), no more timeout prompts
+  kumaHealthId?: number // Uptime Kuma monitor ids + push token, once registered
+  kumaPushId?: number
+  kumaPushToken?: string
 }
 export function isVanityInFlight(j: VanityJob | null | undefined): boolean {
   return j != null && j.step !== "done" && j.step !== "error"
+}
+
+// A per-site Uptime Kuma setup run (the `m` overlay): optional page re-seed →
+// register monitors → install the heartbeat cron.
+export interface KumaOp {
+  status: "running" | "done" | "error"
+  detail: string
+  error?: string
 }
 
 // Clone a server to a new server (backlog item 5). Five server-level steps wrapping
@@ -486,8 +501,16 @@ interface StoreValue extends DataState {
   vanityKeepWaiting: () => void // from the prompt: poll indefinitely (count-up), no re-prompt
   vanityStopWaiting: () => void // from keep-waiting: stop waiting, continue the normal flow
   vanityRetry: () => void // re-enter the failed step
+  vanitySkipKuma: () => void // failed monitor/cron step → settle as done (site is live)
   clearVanity: () => void
   vanityHealthKeyFor: (domain: string) => string | null // key baked into the seeded page's ?format=json mode
+  kumaConfigured: boolean // an Uptime Kuma connection exists (config or env)
+  kumaSite: Site | null // site whose Kuma overlay (m) is open
+  setKumaSite: (s: Site | null) => void
+  kumaOps: Map<number, KumaOp> // in-flight/settled monitor setups, by site id
+  connectKuma: (conn: { url: string; username: string; password: string }) => Promise<{ ok: true; version: string | null } | { ok: false; error: string }>
+  kumaMonitorFor: (domain: string) => KumaMonitorRef | null // monitors Spinup registered for a domain
+  startKumaSetup: (site: Site, opts?: { reseed?: boolean }) => void
   // Clone a server to a new server (item 5). `cloneServer` opens the wizard; `cloneJob`
   // is the (Plan-draft then running) job whose heavy work lives in its `sites[]` vector.
   cloneServer: Server | null
@@ -2602,6 +2625,52 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         const res = await seedVanityIndex({ host: j.serverIp, user: j.siteUser, port: j.port, domain: j.hostname, publicFolder: j.publicFolder, healthKey })
         if (!res.ok) return fail(j, "seed", res.error || "Couldn't seed index.php over SSH.")
         await refresh()
+        void doMonitor({ ...j, step: "monitor" })
+      }
+
+      // Register the two Uptime Kuma monitors (healthz HTTP + load push). Auto-skips
+      // to done when no Kuma connection is configured. Idempotent on resume: reuses
+      // ids we already recorded, or adopts same-named monitors already in Kuma.
+      async function doMonitor(j: VanityJob) {
+        const conn = cfgRef.current.uptimeKuma
+        if (!conn) return persist({ ...j, step: "done" })
+        persist({ ...j, step: "monitor" })
+        try {
+          const known = cfgRef.current.kumaMonitors[j.hostname] ?? {}
+          const proto = j.sslSkipped ? "http" : "https"
+          let pushToken = j.kumaPushToken ?? known.pushToken ?? genPushToken()
+          const { result, jwt } = await withKuma(conn, async (kuma) => {
+            const byName = new Map((await kuma.getMonitors()).map((m) => [m.name, m]))
+            const existingPush = byName.get(`${j.hostname} load`)
+            // A push monitor made outside Spinup keeps its own token — the cron
+            // must feed THAT one, so adopt it.
+            if (existingPush?.pushToken) pushToken = existingPush.pushToken
+            const healthId = known.healthId ?? byName.get(j.hostname)?.id ?? (await kuma.addMonitor(healthMonitorPayload(j.hostname, `${proto}://${j.hostname}/?healthz`)))
+            const pushId = known.pushId ?? existingPush?.id ?? (await kuma.addMonitor(loadPushMonitorPayload(`${j.hostname} load`, pushToken)))
+            return { healthId, pushId }
+          })
+          // Keep the JWT fresh so later sessions log in by token (2FA-friendly).
+          if (!conn.env && jwt !== conn.jwt) {
+            cfgRef.current.uptimeKuma = { ...conn, jwt }
+            void saveConfig({ uptimeKuma: { ...conn, jwt } })
+          }
+          const map = { ...cfgRef.current.kumaMonitors, [j.hostname]: { healthId: result.healthId, pushId: result.pushId, pushToken } }
+          cfgRef.current.kumaMonitors = map
+          void saveConfig({ kumaMonitors: map })
+          void doCron({ ...j, step: "cron", kumaHealthId: result.healthId, kumaPushId: result.pushId, kumaPushToken: pushToken })
+        } catch (err) {
+          fail(j, "monitor", (err as Error).message)
+        }
+      }
+
+      // Install the once-a-minute heartbeat cron in the site user's crontab (feeds
+      // the push monitor: load value graphed, silence = dead-man's switch).
+      async function doCron(j: VanityJob) {
+        const conn = cfgRef.current.uptimeKuma
+        if (!conn || !j.kumaPushToken) return persist({ ...j, step: "done" })
+        persist({ ...j, step: "cron" })
+        const res = await seedVanityPushCron({ host: j.serverIp, user: j.siteUser, port: j.port, kumaUrl: conn.url, pushToken: j.kumaPushToken })
+        if (!res.ok) return fail(j, "cron", res.error || "Couldn't install the heartbeat cron.")
         persist({ ...j, step: "done" })
       }
 
@@ -2618,6 +2687,10 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           return doSshkey(job)
         case "seed":
           return void doSeed(job)
+        case "monitor":
+          return void doMonitor(job)
+        case "cron":
+          return void doCron(job)
         default:
           return
       }
@@ -2698,6 +2771,15 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     driveVanity(next)
   }, [vanityJob, driveVanity])
 
+  // A Kuma monitor/cron failure shouldn't hold the build hostage — the site itself
+  // is already live. Skip settles the job as done; monitors can be added later.
+  const vanitySkipKuma = useCallback(() => {
+    if (!vanityJob || vanityJob.step !== "error") return
+    if (vanityJob.failedStep !== "monitor" && vanityJob.failedStep !== "cron") return
+    setVanityJob({ ...vanityJob, step: "done", error: undefined, failedStep: undefined })
+    void removeJob(VANITY_JOB_ID)
+  }, [vanityJob])
+
   const clearVanity = useCallback(() => {
     setVanityJob(null)
     void removeJob(VANITY_JOB_ID)
@@ -2706,6 +2788,95 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   // Reads through cfgRef (not reactive state): the key is written by doSeed before
   // the job reaches "done", so any render that can show it already sees it.
   const vanityHealthKeyFor = useCallback((domain: string) => cfgRef.current.vanityHealthKeys[domain] ?? null, [])
+
+  // ---- Uptime Kuma (connect + per-site monitor setup) ----------------------
+
+  const [kumaSite, setKumaSite] = useState<Site | null>(null)
+  const [kumaOps, setKumaOps] = useState<Map<number, KumaOp>>(new Map())
+
+  // Verify a Kuma connection by actually logging in, then persist it (with the
+  // minted JWT, so later sessions use loginByToken). The env-sourced connection
+  // is never overwritten — mirrors the provider-connection convention.
+  const connectKuma = useCallback(async (conn: { url: string; username: string; password: string }): Promise<{ ok: true; version: string | null } | { ok: false; error: string }> => {
+    try {
+      const url = conn.url.trim().replace(/\/+$/, "")
+      const { jwt, version } = await withKuma({ ...conn, url }, async () => true)
+      const stored = { url, username: conn.username, password: conn.password, jwt }
+      cfgRef.current.uptimeKuma = stored
+      void saveConfig({ uptimeKuma: stored })
+      return { ok: true, version }
+    } catch (err) {
+      return { ok: false, error: (err as Error).message }
+    }
+  }, [])
+
+  const kumaMonitorFor = useCallback((domain: string) => cfgRef.current.kumaMonitors[domain] ?? null, [])
+
+  // Set up monitoring for an existing site. A vanity site (domain = server name)
+  // gets the full treatment — optional page re-seed (the upgrade path for pages
+  // published before the health-endpoint feature), healthz monitor, load push
+  // monitor + heartbeat cron. A regular site gets a plain HTTPS monitor on its
+  // homepage (up/down + cert expiry); we never touch a client site's files.
+  const startKumaSetup = useCallback(
+    (site: Site, opts: { reseed?: boolean } = {}) => {
+      const conn = cfgRef.current.uptimeKuma
+      if (!conn) return
+      const server = servers.find((s) => s.id === site.server_id)
+      const isVanity = !!server && server.name === site.domain
+      const setOp = (op: KumaOp) => setKumaOps((prev) => new Map(prev).set(site.id, op))
+      const run = async () => {
+        try {
+          const domain = site.domain
+          if (isVanity && opts.reseed && server) {
+            setOp({ status: "running", detail: "Publishing the updated page…" })
+            const keys = { ...cfgRef.current.vanityHealthKeys }
+            const healthKey = keys[domain] ?? crypto.randomUUID().replace(/-/g, "")
+            if (keys[domain] !== healthKey) {
+              keys[domain] = healthKey
+              cfgRef.current.vanityHealthKeys = keys
+              void saveConfig({ vanityHealthKeys: keys })
+            }
+            const seed = await seedVanityIndex({ host: server.ip_address ?? "", user: site.site_user ?? deriveSiteUser(domain), port: server.ssh_port ?? null, domain, publicFolder: site.public_folder, healthKey })
+            if (!seed.ok) throw new Error(seed.error || "Couldn't re-seed the page over SSH.")
+          }
+          setOp({ status: "running", detail: "Registering monitors in Uptime Kuma…" })
+          const known = cfgRef.current.kumaMonitors[domain] ?? {}
+          let pushToken = known.pushToken ?? genPushToken()
+          const { result, jwt } = await withKuma(conn, async (kuma) => {
+            const byName = new Map((await kuma.getMonitors()).map((m) => [m.name, m]))
+            const targetUrl = isVanity ? `https://${domain}/?healthz` : `https://${domain}/`
+            const healthId = known.healthId ?? byName.get(domain)?.id ?? (await kuma.addMonitor(healthMonitorPayload(domain, targetUrl)))
+            let pushId: number | undefined
+            if (isVanity) {
+              const existingPush = byName.get(`${domain} load`)
+              // A push monitor made outside Spinup keeps its own token — the cron
+              // must feed THAT one, so adopt it.
+              if (existingPush?.pushToken) pushToken = existingPush.pushToken
+              pushId = known.pushId ?? existingPush?.id ?? (await kuma.addMonitor(loadPushMonitorPayload(`${domain} load`, pushToken)))
+            }
+            return { healthId, pushId }
+          })
+          if (!conn.env && jwt !== conn.jwt) {
+            cfgRef.current.uptimeKuma = { ...conn, jwt }
+            void saveConfig({ uptimeKuma: { ...conn, jwt } })
+          }
+          const map = { ...cfgRef.current.kumaMonitors, [domain]: { healthId: result.healthId, pushId: result.pushId, pushToken: result.pushId ? pushToken : known.pushToken } }
+          cfgRef.current.kumaMonitors = map
+          void saveConfig({ kumaMonitors: map })
+          if (isVanity && result.pushId && server) {
+            setOp({ status: "running", detail: "Installing the heartbeat cron…" })
+            const cron = await seedVanityPushCron({ host: server.ip_address ?? "", user: site.site_user ?? deriveSiteUser(domain), port: server.ssh_port ?? null, kumaUrl: conn.url, pushToken })
+            if (!cron.ok) throw new Error(cron.error || "Couldn't install the heartbeat cron.")
+          }
+          setOp({ status: "done", detail: isVanity ? "Monitors live: healthz checks + load graph (cron beating every minute)." : "Monitor live: homepage checks + certificate-expiry alerts." })
+        } catch (err) {
+          setOp({ status: "error", detail: "", error: (err as Error).message })
+        }
+      }
+      void run()
+    },
+    [servers],
+  )
 
   // ---- Clone a server to a new server (item 5) -----------------------------
 
@@ -3430,8 +3601,16 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     vanityKeepWaiting,
     vanityStopWaiting,
     vanityRetry,
+    vanitySkipKuma,
     clearVanity,
     vanityHealthKeyFor,
+    kumaConfigured: cfgRef.current.uptimeKuma != null,
+    kumaSite,
+    setKumaSite,
+    kumaOps,
+    connectKuma,
+    kumaMonitorFor,
+    startKumaSetup,
     cloneServer,
     setCloneServer,
     cloneJob,

--- a/src/ui/views/Browser.tsx
+++ b/src/ui/views/Browser.tsx
@@ -22,7 +22,7 @@ type Focus = "servers" | "sites"
 
 export function Browser({ rows }: { rows: number }) {
   const store = useStore()
-  const { servers, sitesForServer, route, inputMode, overlayOpen, setHealthServer, runProbe, accountSlug, setPhpUpgradeSite, phpUpgrades, setHttpsToggleSite, setPurgeCacheSite, setGrantKeySite, setSudoConnectServer, isSudoConnected, grantedKeyKinds, setServerActionsServer, serverOps, setLocalLinkSite, openLocalTerminal, openLocalUrl, localLinks, sshSite, setDnsInventoryServer, setNewServerSource, setNewServerOpen, setVanityServer, vanityJob, beginClone, isServerOsEol } = store
+  const { servers, sitesForServer, route, inputMode, overlayOpen, setHealthServer, runProbe, accountSlug, setPhpUpgradeSite, phpUpgrades, setHttpsToggleSite, setPurgeCacheSite, setGrantKeySite, setSudoConnectServer, isSudoConnected, grantedKeyKinds, setServerActionsServer, serverOps, setLocalLinkSite, openLocalTerminal, openLocalUrl, localLinks, sshSite, setDnsInventoryServer, setNewServerSource, setNewServerOpen, setVanityServer, vanityJob, beginClone, isServerOsEol, setKumaSite } = store
 
   const [serverIndex, setServerIndex] = useState(0)
   const [siteIndex, setSiteIndex] = useState(0)
@@ -108,6 +108,10 @@ export function Browser({ rows }: { rows: number }) {
       case "P":
         // Purge page cache + object cache on the selected site.
         if (focus === "sites" && sites[siteIndex]) setPurgeCacheSite(sites[siteIndex])
+        return
+      case "m":
+        // Uptime Kuma monitoring for the selected site (connect on first use).
+        if (focus === "sites" && sites[siteIndex]) setKumaSite(sites[siteIndex])
         return
       case "K":
         // Grant Spinup's machine key to the selected site over SSH (privileged
@@ -226,6 +230,7 @@ export function Browser({ rows }: { rows: number }) {
           { key: "d", label: "identify app" },
           { key: "n", label: "DNS host" },
           { key: "u", label: "change PHP" },
+          { key: "m", label: "monitoring" },
           { key: "K", label: "grant key" },
           { key: "o", label: "open" },
           { key: "w", label: "SpinupWP" },

--- a/src/ui/views/KumaSite.tsx
+++ b/src/ui/views/KumaSite.tsx
@@ -1,0 +1,188 @@
+// Uptime Kuma overlay for a site — opened with `m` in the sites pane.
+//
+// Two jobs in one window, taught in context:
+//   1. No Kuma connection yet → a connect form (URL / username / password). The
+//      credential is verified by actually logging in before anything persists;
+//      the minted JWT is stored so later sessions (and 2FA accounts) log in by
+//      token. Env-sourced connections (SPINUP_KUMA_*) skip this form entirely.
+//   2. Connected → monitor setup for THIS site. A vanity site (domain = server
+//      name) gets the full treatment: healthz monitor, load push monitor + the
+//      once-a-minute heartbeat cron, and `R` re-seeds the page first (the upgrade
+//      path for pages published before the health-endpoint feature). A regular
+//      site gets a homepage monitor (up/down + cert expiry) — we never touch a
+//      client site's files.
+
+import { useEffect, useState } from "react"
+import { useKeyboard } from "@opentui/react"
+import { theme } from "../../lib/theme.ts"
+import { Panel, Centered, Field, SecretInput, Spinner } from "../components.tsx"
+import { StatusBar } from "../StatusBar.tsx"
+import { useStore } from "../store.tsx"
+
+const FIELDS = ["url", "username", "password"] as const
+
+export function KumaSite() {
+  const { kumaSite: site, setKumaSite, kumaConfigured, connectKuma, kumaMonitorFor, kumaOps, startKumaSetup, servers, setInputMode } = useStore()
+
+  const [draft, setDraft] = useState({ url: "", username: "", password: "" })
+  const [fieldIdx, setFieldIdx] = useState(0)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [connectedVersion, setConnectedVersion] = useState<string | null>(null)
+
+  const server = site ? servers.find((s) => s.id === site.server_id) : undefined
+  const isVanity = !!site && !!server && server.name === site.domain
+  const registered = site ? kumaMonitorFor(site.domain) : null
+  const op = site ? kumaOps.get(site.id) : undefined
+  const connecting = !kumaConfigured && !connectedVersion
+
+  // While the connect form is up, its inputs own the keyboard (suppresses the
+  // global single-key shortcuts); cleared on connect/close.
+  useEffect(() => {
+    setInputMode(connecting)
+    return () => setInputMode(false)
+  }, [connecting, setInputMode])
+
+  const close = () => {
+    setInputMode(false)
+    setKumaSite(null)
+  }
+
+  const verify = () => {
+    if (busy) return
+    if (!draft.url.trim() || !draft.username.trim() || !draft.password) {
+      setError("All three fields are needed.")
+      return
+    }
+    setBusy(true)
+    setError(null)
+    void connectKuma(draft).then((r) => {
+      setBusy(false)
+      if (r.ok) {
+        setConnectedVersion(r.version ?? "connected")
+        setInputMode(false)
+      } else setError(r.error)
+    })
+  }
+
+  useKeyboard((key) => {
+    const name = key.name ?? ""
+    if (connecting) {
+      // The focused <input> consumes printable keys; only navigation reaches us.
+      if (name === "escape") {
+        if (busy) return
+        return close()
+      }
+      if (name === "return") {
+        if (busy) return
+        if (fieldIdx < FIELDS.length - 1) return setFieldIdx(fieldIdx + 1)
+        return verify()
+      }
+      if (name === "tab" || name === "down") return setFieldIdx((i) => Math.min(i + 1, FIELDS.length - 1))
+      if (name === "up") return setFieldIdx((i) => Math.max(i - 1, 0))
+      return
+    }
+    if (name === "a" && site && op?.status !== "running") return startKumaSetup(site)
+    if (name === "R" && isVanity && site && op?.status !== "running") return startKumaSetup(site, { reseed: true })
+    if (name === "escape" || name === "q") return close()
+  })
+
+  if (!site) return null
+
+  return (
+    <box style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", flexDirection: "column", backgroundColor: theme.bg, zIndex: 215 }}>
+      <box style={{ flexDirection: "row", height: 1, backgroundColor: theme.bgAlt, paddingLeft: 1, paddingRight: 1, alignItems: "center" }}>
+        <text content="◉ Uptime Kuma  " fg={theme.brand} style={{ flexShrink: 0 }} />
+        <text content={site.domain} fg={theme.text} wrapMode="none" style={{ flexShrink: 1 }} />
+      </box>
+
+      <Centered>{connecting ? renderConnect() : renderMonitor()}</Centered>
+
+      <StatusBar hints={hints()} showGlobal={false} />
+    </box>
+  )
+
+  function renderConnect() {
+    return (
+      <Panel title=" Connect Uptime Kuma " active>
+        <box style={{ flexDirection: "column", width: 66, paddingTop: 1, paddingBottom: 1 }}>
+          <text content="One-time setup: your Uptime Kuma instance's URL and login." fg={theme.textDim} wrapMode="none" />
+          <text content="Verified by logging in before anything is saved (config, 0600)." fg={theme.textFaint} wrapMode="none" />
+          <box style={{ height: 1 }} />
+          {FIELDS.map((f, i) => (
+            <box key={f} style={{ flexDirection: "row" }}>
+              <text content={`${i === fieldIdx ? "❯" : " "} ${f.padEnd(9)}`} fg={i === fieldIdx ? theme.brand : theme.textDim} style={{ flexShrink: 0 }} />
+              {f === "password" ? (
+                <SecretInput focused={i === fieldIdx && !busy} value={draft.password} onChange={(v: string) => setDraft((d) => ({ ...d, password: v }))} onSubmit={verify} />
+              ) : (
+                <input
+                  focused={i === fieldIdx && !busy}
+                  value={draft[f]}
+                  onInput={(v: string) => setDraft((d) => ({ ...d, [f]: v }))}
+                  placeholder={f === "url" ? "https://kuma.example.com" : ""}
+                  style={{ backgroundColor: theme.bgAlt, focusedBackgroundColor: theme.bgAlt, textColor: theme.text }}
+                />
+              )}
+            </box>
+          ))}
+          <box style={{ height: 1 }} />
+          {busy ? (
+            <box style={{ flexDirection: "row" }}>
+              <Spinner />
+              <text content="  Logging in…" fg={theme.textDim} wrapMode="none" />
+            </box>
+          ) : error ? (
+            <text content={`✕ ${error}`} fg={theme.bad} wrapMode="none" />
+          ) : (
+            <text content="⏎ next field / connect · Esc cancel" fg={theme.textFaint} wrapMode="none" />
+          )}
+        </box>
+      </Panel>
+    )
+  }
+
+  function renderMonitor() {
+    return (
+      <Panel title=" Site monitoring " active>
+        <box style={{ flexDirection: "column", width: 68, paddingTop: 1, paddingBottom: 1 }}>
+          {connectedVersion && (
+            <>
+              <text content={`● Uptime Kuma connected (${connectedVersion}).`} fg={theme.good} wrapMode="none" />
+              <box style={{ height: 1 }} />
+            </>
+          )}
+          <Field label="Site" value={site!.domain} />
+          <Field label="Kind" value={isVanity ? "vanity page (full server monitoring)" : "site homepage (up/down + cert expiry)"} />
+          <Field label="Monitors" value={registered ? `registered${registered.pushId ? " (healthz + load push)" : ""}` : "not registered yet"} />
+          <box style={{ height: 1 }} />
+          {op?.status === "running" ? (
+            <box style={{ flexDirection: "row" }}>
+              <Spinner />
+              <text content={`  ${op.detail}`} fg={theme.textDim} wrapMode="none" />
+            </box>
+          ) : op?.status === "error" ? (
+            <text content={`✕ ${op.error}`} fg={theme.bad} />
+          ) : op?.status === "done" ? (
+            <text content={`✓ ${op.detail}`} fg={theme.good} />
+          ) : isVanity ? (
+            <>
+              <text content="a — register monitors (healthz + load push) & install the cron" fg={theme.textDim} wrapMode="none" />
+              <text content="R — also re-publish the page first (pages seeded before the" fg={theme.textDim} wrapMode="none" />
+              <text content="    health-endpoint feature need this once)" fg={theme.textFaint} wrapMode="none" />
+            </>
+          ) : (
+            <text content="a — register a homepage monitor in Uptime Kuma" fg={theme.textDim} wrapMode="none" />
+          )}
+        </box>
+      </Panel>
+    )
+  }
+
+  function hints() {
+    if (connecting) return [{ key: "⏎", label: "next / connect" }, { key: "esc", label: "cancel" }]
+    if (op?.status === "running") return [{ key: "esc", label: "background" }]
+    const base = [{ key: "a", label: registered ? "repair monitors" : "add monitors" }]
+    if (isVanity) base.push({ key: "R", label: "re-seed + monitors" })
+    return [...base, { key: "esc", label: "close" }]
+  }
+}

--- a/src/ui/views/VanityNewSite.tsx
+++ b/src/ui/views/VanityNewSite.tsx
@@ -22,6 +22,8 @@ const STEP_LABELS: { step: VanityStep; label: string }[] = [
   { step: "https", label: "Enable HTTPS (Let's Encrypt)" },
   { step: "sshkey", label: "Add your SSH key" },
   { step: "seed", label: "Publish the page" },
+  { step: "monitor", label: "Register Uptime Kuma monitors" },
+  { step: "cron", label: "Install the heartbeat cron" },
 ]
 const STEP_ORDER: VanityStep[] = STEP_LABELS.map((s) => s.step)
 
@@ -32,7 +34,7 @@ function fmtClock(ms: number): string {
 }
 
 export function VanityNewSite() {
-  const { vanityServer: server, setVanityServer, vanityJob: job, startVanity, vanitySshKeyDone, vanitySkipSsl, vanityKeepWaiting, vanityStopWaiting, vanityRetry, clearVanity, vanityHealthKeyFor, accountSlug, setInputMode, sites, isSudoConnected, keyGrants, startGrantRemembered, preferredGrantKeys, clearGrantKey, sudoConnectServer, setSudoConnectServer } = useStore()
+  const { vanityServer: server, setVanityServer, vanityJob: job, startVanity, vanitySshKeyDone, vanitySkipSsl, vanityKeepWaiting, vanityStopWaiting, vanityRetry, vanitySkipKuma, clearVanity, vanityHealthKeyFor, kumaConfigured, accountSlug, setInputMode, sites, isSudoConnected, keyGrants, startGrantRemembered, preferredGrantKeys, clearGrantKey, sudoConnectServer, setSudoConnectServer } = useStore()
 
   const [siteUser, setSiteUser] = useState(() => (server ? deriveSiteUser(server.name) : ""))
   const [editingUser, setEditingUser] = useState(false)
@@ -138,6 +140,8 @@ export function VanityNewSite() {
     }
     if (job.step === "error") {
       if (name === "r") return vanityRetry()
+      // Monitoring failures are skippable — the site itself is already live.
+      if (name === "s" && (job.failedStep === "monitor" || job.failedStep === "cron")) return vanitySkipKuma()
       if (name === "x") return discard()
     }
     if (job.step === "done" && name === "o") {
@@ -176,7 +180,9 @@ export function VanityNewSite() {
   function stepRows(): StepRow[] {
     const cur = job?.step
     const failed = job?.step === "error" ? job.failedStep : undefined
-    return STEP_LABELS.filter((s) => !(s.step === "https" && job?.sslSkipped)).map(({ step, label }) => {
+    return STEP_LABELS.filter((s) => !(s.step === "https" && job?.sslSkipped))
+      .filter((s) => !((s.step === "monitor" || s.step === "cron") && !kumaConfigured))
+      .map(({ step, label }) => {
       let state: StepRow["state"] = "pending"
       if (failed === step) state = "failed"
       else if (cur === "done") state = "done"
@@ -275,7 +281,11 @@ export function VanityNewSite() {
             <box style={{ height: 1 }} />
             <text content={`✕ ${job.error ?? "Something went wrong."}`} fg={theme.bad} wrapMode="none" />
             <box style={{ height: 1 }} />
-            <text content="r retry this step · x discard · Esc keep for later" fg={theme.textFaint} wrapMode="none" />
+            <text
+              content={job.failedStep === "monitor" || job.failedStep === "cron" ? "r retry · s skip monitoring (site is live) · x discard · Esc later" : "r retry this step · x discard · Esc keep for later"}
+              fg={theme.textFaint}
+              wrapMode="none"
+            />
           </box>
         </Panel>
       )
@@ -375,7 +385,10 @@ export function VanityNewSite() {
       return [...(sudoOn ? [] : [{ key: "S", label: "connect sudo" }]), { key: "e", label: "edit user" }, { key: "y", label: "create" }, { key: "q", label: "cancel" }]
     }
     if (job.step === "done") return [{ key: "o", label: "open site" }, { key: "esc", label: "close" }]
-    if (job.step === "error") return [{ key: "r", label: "retry" }, { key: "x", label: "discard" }, { key: "esc", label: "later" }]
+    if (job.step === "error") {
+      const skippable = job.failedStep === "monitor" || job.failedStep === "cron"
+      return [{ key: "r", label: "retry" }, ...(skippable ? [{ key: "s", label: "skip monitoring" }] : []), { key: "x", label: "discard" }, { key: "esc", label: "later" }]
+    }
     if (job.step === "sshkey") {
       const granting = grant && isKeyGrantInFlight(grant)
       if (granting) return [{ key: "esc", label: "background" }]


### PR DESCRIPTION
## What

PR 2 of 3 (stacked on #14 — merge that first; this PR's base is `feat/vanity-health-endpoint`).

- **`src/lib/uptimeKuma.ts`** — thin client for Kuma's socket.io management API: JWT-persisting login (2FA-friendly via loginByToken), monitor add/pause/resume/delete, list/beats, manual maintenance windows (used by PR 3). Handles both Kuma 1.x and 2.x monitor schemas (adaptive `conditions` field).
- **Vanity wizard** gains two final steps when Kuma is connected: register healthz + load push monitors, then install a once-a-minute heartbeat cron in the site user's crontab. The cron pushes the 1-min load as `ping` → Kuma graphs server load; a silent cron = dead-man's switch. Auto-skips when Kuma isn't configured; failures are skippable (the site is already live).
- **`m` on any site** — monitoring overlay: first-use connect form (verified by a real login; creds in config.json 0600 or `SPINUP_KUMA_*` env), then `a` add/repair monitors. Vanity sites get the full treatment including `R` re-seed (the upgrade path for pages published before the health endpoints). Regular sites get a homepage monitor only — client site files are never touched.
- Adoption over duplication: same-named monitors in Kuma are reused, and a hand-made push monitor keeps its token (the cron adopts it).

## Testing

- Spun up a real Uptime Kuma locally (npm build) and ran the client's full lifecycle e2e: setup, password→JWT and JWT logins, both monitor payloads, push beat with a real load value from the test box (`{"ok":true}`, graphable ping), maintenance create/assign/delete, pause/resume/delete. **ALL PASS**.
- Monitor adoption re-run: same ids + token, nothing duplicated.
- Cron install on `web1.spinuptui.com`: exactly one marker line after two installs; quoting verified verbatim in `crontab -l`; test cron removed after.
- TUI: `m` overlay opens/renders/closes under PTY in dev mode; typecheck green.
- **Not yet exercised**: a full `V` wizard run with the new steps (needs a fresh vanity build) and the real `monitor.wenmarkdigital.com` instance — planned as the acceptance test once creds are configured (I'll ask before touching it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYCqn15ypvbEjBFdzpd13u