### PR TITLE
Kuma metrics in the TUI + maintenance windows around reboots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,21 @@ versions; such changes are called out here.
   - The client speaks Kuma's socket.io API (its only management API), adopts
     same-named monitors instead of duplicating them, reuses push tokens, and
     handles both Kuma 1.x and 2.x monitor schemas.
+- **Kuma metrics live inside Spinup.** With a connection configured, the store
+  polls Kuma once a minute and the data surfaces where you already look:
+  - **Health view** gains a "Monitor (Uptime Kuma)" panel — up/down, 24h uptime %,
+    a response-time sparkline, and a server-load sparkline fed by the heartbeat
+    cron (real history that survives reopening the view, which the SSH-sampled
+    CPU history can't).
+  - **Details pane** shows a Monitor row per site (up/down + 24h uptime, or
+    "not monitored · m"); the **header** shows a "▼ N monitors down" badge —
+    only bad news earns header space.
+  - **Reboots never page you**: firing a reboot first wraps the server's
+    monitors in a Kuma maintenance window and removes it when the reboot event
+    settles. Strictly best-effort — Kuma being unreachable never blocks the
+    reboot — and the confirm screen says it's happening.
+  - Load pushes are sent ×100 as integers (some Kuma builds silently drop float
+    pings — found the hard way); Spinup's views scale them back.
 - **Vanity pages are now health endpoints any uptime monitor can watch.** The page
   the `V` wizard seeds gains two machine modes: `?healthz` returns plain
   `200 ok` / `503 unhealthy: …` (1-min load per core > 2, or disk free < 10%) so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,10 @@ versions; such changes are called out here.
   - **`m` on any site** manages monitoring in place: vanity sites get the full
     treatment (incl. `R` to re-publish pages seeded before the health-endpoint
     feature existed), regular sites get a homepage monitor (up/down + cert-expiry
-    alerts) — client site files are never touched.
+    alerts) — client site files are never touched. **`R` works without Kuma
+    too**: unconnected, it simply pushes the current page (a vanity-page
+    refresh); connected, it also registers monitors + the cron. The connect
+    form is opt-in (`c`), never a gate.
   - The client speaks Kuma's socket.io API (its only management API), adopts
     same-named monitors instead of duplicating them, reuses push tokens, and
     handles both Kuma 1.x and 2.x monitor schemas.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,18 @@ Once you're in, the dashboard looks like this:
   so it auto-unlocks next time), then `K` on a site to **grant or revoke** your
   personal key and/or Spinup's dedicated machine key — one site or every site on the
   server. (See "Privileged writes over SSH" below.)
+- **Uptime Kuma monitoring** — press `m` on a site to wire it into your own
+  [Uptime Kuma](https://github.com/louislam/uptime-kuma) instance (one-time
+  connect, 2FA supported, verified by a real login). Vanity pages double as
+  health endpoints (`?healthz` returns 503 under CPU pressure / low disk;
+  `?format=json&key=…` serves full metrics) and get a load push monitor fed by a
+  once-a-minute cron — Kuma graphs server load, and a silent cron acts as a
+  dead-man's switch. Monitor status flows back in: a Monitor row in Details, a
+  "▼ N monitors down" header badge, uptime/response/load sparklines in the
+  Health view, and reboots automatically open a Kuma maintenance window so
+  planned downtime never pages you. Regular sites get a homepage monitor
+  (up/down + cert-expiry alerts) — client site files are never touched.
+  (See `docs/uptime-kuma.md` for recipes.)
 - **Completion toasts** — background writes that take a while (a PHP upgrade, a
   server reboot/restart, resolving your fleet's DNS) raise a non-focus-stealing
   toast when they finish, so you're not left guessing after you've moved on.
@@ -238,6 +250,13 @@ These can be set in `config.json` or via an environment variable:
   project `.env` won't take effect for the globally-installed `spinup` run from
   elsewhere. For a persistent, location-independent setting, use `config.json`.
 
+- **`uptimeKuma`** / `SPINUP_KUMA_URL` + `SPINUP_KUMA_USERNAME` +
+  `SPINUP_KUMA_PASSWORD` — an Uptime Kuma connection for the monitoring
+  features. Easiest path: press `m` on any site and connect in-app (creds are
+  verified by logging in, then stored in `config.json`, chmod 600, alongside a
+  login token so 2FA is only asked once). The env trio exists for
+  externally-managed setups and is read-only in the UI.
+
 ## Keybindings
 
 | Key | Action |
@@ -265,6 +284,7 @@ These can be set in `config.json` or via an environment variable:
 | `u` | Upgrade a site's PHP version (Servers / Stacks / Search; needs a Read/Write token) |
 | `H` | Enable / disable HTTPS on a site (Servers / Stacks / Search; needs a Read/Write token) |
 | `P` | Purge a site's page cache + object cache (Servers / Stacks / Search; needs a Read/Write token) |
+| `m` | Site monitoring via Uptime Kuma — connect, add monitors, refresh a vanity page (Servers tab, sites pane) |
 | `a` | Server actions: reboot / restart a service (Servers / Search; needs a Read/Write token) |
 | `c` | Create a new server (Servers tab; needs a Read/Write token) |
 | `V` | Add a vanity site at the server's own hostname — DNS + site + HTTPS + SSH-key handoff (Servers tab; offered when no hostname site exists; needs a Read/Write token) |

--- a/docs/uptime-kuma.md
+++ b/docs/uptime-kuma.md
@@ -86,8 +86,10 @@ Connect your Kuma instance once and Spinup registers monitors itself:
   views scale it back). A silent cron — server down, cron dead, egress broken —
   flips the monitor: dead-man's-switch semantics. Regular
   sites get a homepage monitor; Spinup never touches a client site's files.
-- **Vanity pages published before this feature** need one `R` (re-seed) from the
-  `m` overlay to gain the health endpoints, then everything above applies.
+- **Vanity pages published before this feature** need one `R` (refresh) from the
+  `m` overlay to gain the health endpoints, then everything above applies. `R`
+  doesn't require a Kuma connection — unconnected it just re-publishes the
+  current page; connected it also registers the monitors and cron in one go.
 - **The vanity wizard (`V`) does all of this automatically** as its final two
   steps whenever a Kuma connection is configured.
 

--- a/docs/uptime-kuma.md
+++ b/docs/uptime-kuma.md
@@ -81,8 +81,10 @@ Connect your Kuma instance once and Spinup registers monitors itself:
   `config.json`, chmod 600 — or set `SPINUP_KUMA_URL`, `SPINUP_KUMA_USERNAME`,
   `SPINUP_KUMA_PASSWORD`). Then `a` registers monitors: vanity sites get the
   healthz monitor + a **load push monitor fed by a once-a-minute cron** in the
-  site user's crontab (Kuma graphs the load; a silent cron — server down, cron
-  dead, egress broken — flips the monitor: dead-man's-switch semantics). Regular
+  site user's crontab. Kuma graphs the pushed value: 1-min load ×100 as an
+  integer (164 = load 1.64 — some Kuma builds drop float pings; Spinup's own
+  views scale it back). A silent cron — server down, cron dead, egress broken —
+  flips the monitor: dead-man's-switch semantics. Regular
   sites get a homepage monitor; Spinup never touches a client site's files.
 - **Vanity pages published before this feature** need one `R` (re-seed) from the
   `m` overlay to gain the health endpoints, then everything above applies.

--- a/src/lib/uptimeKuma.ts
+++ b/src/lib/uptimeKuma.ts
@@ -70,6 +70,12 @@ export class KumaClient {
   private monitorList: Record<string, KumaMonitor> | null = null
   private notificationList: { id: number; isDefault?: boolean; active?: boolean; config?: string }[] = []
 
+  // Kuma pushes each monitor's recent beats + uptime percentages as events right
+  // after login (it's how its own dashboard populates) — capture them so one
+  // short-lived connection yields a full status snapshot with no extra queries.
+  private heartbeats = new Map<number, KumaBeat[]>()
+  private uptimes = new Map<string, number>() // "<monitorId>:<period>" → percent
+
   private constructor(socket: Socket) {
     this.socket = socket
     socket.on("info", (info: { version?: string }) => {
@@ -81,6 +87,29 @@ export class KumaClient {
     socket.on("notificationList", (list: typeof this.notificationList) => {
       this.notificationList = list ?? []
     })
+    socket.on("heartbeatList", (monitorID: number | string, beats: KumaBeat[], overwrite?: boolean) => {
+      const id = Number(monitorID)
+      const prev = overwrite ? [] : (this.heartbeats.get(id) ?? [])
+      this.heartbeats.set(id, [...prev, ...(beats ?? [])])
+    })
+    socket.on("uptime", (monitorID: number | string, period: number | string, percent: number) => {
+      this.uptimes.set(`${Number(monitorID)}:${period}`, percent)
+    })
+  }
+
+  beatsFor(monitorId: number): KumaBeat[] {
+    return this.heartbeats.get(monitorId) ?? []
+  }
+
+  uptimeFor(monitorId: number, period: number): number | null {
+    return this.uptimes.get(`${monitorId}:${period}`) ?? null
+  }
+
+  // The post-login event burst arrives over ~a second; waiting a beat makes a
+  // fresh connection's snapshot complete. No-op if data is already here.
+  async waitForSnapshot(ms = 1500): Promise<void> {
+    if (this.heartbeats.size > 0) return
+    await new Promise((r) => setTimeout(r, ms))
   }
 
   static async connect(url: string): Promise<KumaClient> {
@@ -264,6 +293,7 @@ export function loadPushMonitorPayload(name: string, pushToken: string): Record<
     type: "push",
     name,
     pushToken,
+    description: "1-min load average ×100 (integer), pushed by Spinup's heartbeat cron. 164 = load 1.64.",
     // The cron beats once a minute; alert after ~2 missed beats.
     interval: 60,
     retryInterval: 60,

--- a/src/lib/uptimeKuma.ts
+++ b/src/lib/uptimeKuma.ts
@@ -9,6 +9,13 @@
 // beyond its first (token-prompted) login.
 
 import { io, type Socket } from "socket.io-client"
+import type { KumaMonitorRef } from "../config.ts"
+
+// The push cron sends 1-min load ×this as an INTEGER (some Kuma builds validate
+// `ping` as an int and silently store null for floats — verified live). Every
+// encoder (the cron line) and decoder (the store's status poll) shares this one
+// constant so the unit contract can't drift.
+export const LOAD_PUSH_SCALE = 100
 
 export interface KumaCreds {
   url: string
@@ -90,7 +97,9 @@ export class KumaClient {
     socket.on("heartbeatList", (monitorID: number | string, beats: KumaBeat[], overwrite?: boolean) => {
       const id = Number(monitorID)
       const prev = overwrite ? [] : (this.heartbeats.get(id) ?? [])
-      this.heartbeats.set(id, [...prev, ...(beats ?? [])])
+      // Cap the retained history: the UI reads the last ~40 beats, and an
+      // uncapped append would grow without bound on a long-lived connection.
+      this.heartbeats.set(id, [...prev, ...(beats ?? [])].slice(-100))
     })
     socket.on("uptime", (monitorID: number | string, period: number | string, percent: number) => {
       this.uptimes.set(`${Number(monitorID)}:${period}`, percent)
@@ -105,11 +114,27 @@ export class KumaClient {
     return this.uptimes.get(`${monitorId}:${period}`) ?? null
   }
 
-  // The post-login event burst arrives over ~a second; waiting a beat makes a
-  // fresh connection's snapshot complete. No-op if data is already here.
-  async waitForSnapshot(ms = 1500): Promise<void> {
-    if (this.heartbeats.size > 0) return
-    await new Promise((r) => setTimeout(r, ms))
+  // The post-login event burst (one heartbeatList per monitor) arrives over ~a
+  // second. Wait until we've heard from `expected` monitors (not just one — a
+  // single early arrival is a partial snapshot) or the deadline passes.
+  async waitForSnapshot(expected: number, ms = 1500): Promise<void> {
+    const deadline = Date.now() + ms
+    while (this.heartbeats.size < Math.max(1, expected) && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 100))
+    }
+  }
+
+  // `info` (with the version) can land after the login ack; wait briefly so the
+  // connect flow can report a real version instead of racing it.
+  async waitForVersion(ms = 1200): Promise<void> {
+    if (this.version) return
+    await new Promise<void>((resolve) => {
+      const t = setTimeout(resolve, ms)
+      this.socket.once("info", () => {
+        clearTimeout(t)
+        resolve()
+      })
+    })
   }
 
   static async connect(url: string): Promise<KumaClient> {
@@ -180,6 +205,10 @@ export class KumaClient {
           resolve()
         })
       })
+      // If the ack below rejects first, `wait` is never awaited — pre-attach a
+      // no-op handler so its own later timeout can't become an unhandled
+      // rejection (the `await wait` path still observes the real error).
+      wait.catch(() => {})
       await this.emitAck("getMonitorList")
       if (!this.monitorList) await wait
     }
@@ -302,6 +331,39 @@ export function loadPushMonitorPayload(name: string, pushToken: string): Record<
     // Kuma validates status-code arrays on every monitor type, push included.
     accepted_statuscodes: ["200-299"],
   }
+}
+
+// Adopt-or-create the monitors for one domain — THE single implementation shared
+// by the vanity wizard's monitor step and the `m` overlay's add/repair, so the
+// two paths cannot drift. Rules:
+//   - A recorded id is trusted only if the monitor still EXISTS in Kuma (deleted
+//     over there ⇒ re-create, don't silently no-op).
+//   - Same-named monitors are adopted rather than duplicated; an adopted push
+//     monitor keeps its own token so the cron feeds the right one.
+//   - The two creates are independent acks — run them in parallel.
+export async function registerMonitors(
+  kuma: KumaClient,
+  domain: string,
+  opts: { proto: "http" | "https"; healthzPath: string; wantPush: boolean; known?: KumaMonitorRef | null; pushToken?: string | null },
+): Promise<{ healthId: number; pushId?: number; pushToken?: string }> {
+  const monitors = await kuma.getMonitors()
+  const byId = new Map(monitors.map((m) => [m.id, m]))
+  const byName = new Map(monitors.map((m) => [m.name, m]))
+  const known = opts.known ?? {}
+  const live = (id?: number) => (id != null && byId.has(id) ? id : undefined)
+
+  let pushToken = opts.pushToken ?? known.pushToken ?? genPushToken()
+  const existingPush = opts.wantPush && live(known.pushId) == null ? byName.get(`${domain} load`) : undefined
+  if (existingPush?.pushToken) pushToken = existingPush.pushToken
+
+  const [healthId, pushId] = await Promise.all([
+    (async () => live(known.healthId) ?? byName.get(domain)?.id ?? (await kuma.addMonitor(healthMonitorPayload(domain, `${opts.proto}://${domain}${opts.healthzPath}`))))(),
+    (async () => {
+      if (!opts.wantPush) return undefined
+      return live(known.pushId) ?? existingPush?.id ?? (await kuma.addMonitor(loadPushMonitorPayload(`${domain} load`, pushToken)))
+    })(),
+  ])
+  return { healthId, pushId, pushToken: opts.wantPush ? pushToken : undefined }
 }
 
 // Connect → login → run → always disconnect. Returns the (possibly refreshed) JWT

--- a/src/lib/vanitySite.ts
+++ b/src/lib/vanitySite.ts
@@ -247,12 +247,16 @@ const PUSH_CRON_MARKER = "spinup-kuma-push"
 // stopping is the signal (dead-man's switch) — so the cron itself never reports
 // "down"; it just goes quiet when the server/cron/egress dies.
 //
+// Load is sent ×100 as an INTEGER (1.64 → 164, i.e. percent-of-one-core): some
+// Kuma builds validate `ping` as an int and silently store null for floats
+// (verified live). Consumers divide by 100 (see the store's Kuma poll).
+//
 // Idempotent: a marker comment identifies our line, and the install strips any
 // previous marked line before appending. NO `%` anywhere in the line — cron
-// treats a bare % as newline.
+// treats a bare % as newline (which also rules out awk printf here).
 export async function seedVanityPushCron(t: PushCronTarget): Promise<{ ok: boolean; error?: string }> {
   const push = `${t.kumaUrl.replace(/\/+$/, "")}/api/push/${t.pushToken}`
-  const line = `* * * * * curl -fsS --max-time 20 '${push}?status=up&msg=ok&ping='$(awk '{print $1}' /proc/loadavg) >/dev/null 2>&1 # ${PUSH_CRON_MARKER}`
+  const line = `* * * * * curl -fsS --max-time 20 '${push}?status=up&msg=ok&ping='$(awk '{print int($1*100)}' /proc/loadavg) >/dev/null 2>&1 # ${PUSH_CRON_MARKER}`
   // The line contains quotes of both kinds once cron expands it, so ship it
   // base64'd (same trick as the index.php seed) instead of fighting nesting.
   const b64 = Buffer.from(line + "\n", "utf8").toString("base64")

--- a/src/lib/vanitySite.ts
+++ b/src/lib/vanitySite.ts
@@ -7,6 +7,14 @@
 
 import { resolve4 } from "node:dns/promises"
 import { SSH_OPTS, sshPort, runProcess, meaningfulError, remoteDocRoot } from "./dbBackup.ts"
+import { pushUrl, LOAD_PUSH_SCALE } from "./uptimeKuma.ts"
+
+// The vanity convention: the site living at the server's own hostname. Every
+// feature that special-cases vanity sites (full monitoring, page re-seed) keys
+// off this ONE predicate so they can't diverge.
+export function isVanityPair(siteDomain: string, serverName: string): boolean {
+  return siteDomain === serverName
+}
 
 // Does the hostname now resolve to the server IP? Used to gate Let's Encrypt on the
 // new A record having propagated. Uses the system resolver; a fresh subdomain has no
@@ -247,16 +255,16 @@ const PUSH_CRON_MARKER = "spinup-kuma-push"
 // stopping is the signal (dead-man's switch) — so the cron itself never reports
 // "down"; it just goes quiet when the server/cron/egress dies.
 //
-// Load is sent ×100 as an INTEGER (1.64 → 164, i.e. percent-of-one-core): some
-// Kuma builds validate `ping` as an int and silently store null for floats
-// (verified live). Consumers divide by 100 (see the store's Kuma poll).
+// Load is sent ×LOAD_PUSH_SCALE as an INTEGER (1.64 → 164): some Kuma builds
+// validate `ping` as an int and silently store null for floats (verified live).
+// The store's Kuma poll divides by the same constant.
 //
 // Idempotent: a marker comment identifies our line, and the install strips any
 // previous marked line before appending. NO `%` anywhere in the line — cron
 // treats a bare % as newline (which also rules out awk printf here).
 export async function seedVanityPushCron(t: PushCronTarget): Promise<{ ok: boolean; error?: string }> {
-  const push = `${t.kumaUrl.replace(/\/+$/, "")}/api/push/${t.pushToken}`
-  const line = `* * * * * curl -fsS --max-time 20 '${push}?status=up&msg=ok&ping='$(awk '{print int($1*100)}' /proc/loadavg) >/dev/null 2>&1 # ${PUSH_CRON_MARKER}`
+  const push = pushUrl(t.kumaUrl, t.pushToken)
+  const line = `* * * * * curl -fsS --max-time 20 '${push}?status=up&msg=ok&ping='$(awk '{print int($1*${LOAD_PUSH_SCALE})}' /proc/loadavg) >/dev/null 2>&1 # ${PUSH_CRON_MARKER}`
   // The line contains quotes of both kinds once cron expands it, so ship it
   // base64'd (same trick as the index.php seed) instead of fighting nesting.
   const b64 = Buffer.from(line + "\n", "utf8").toString("base64")

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -157,6 +157,9 @@ export function App() {
     // The DNS-records overlay owns the keyboard while open.
     if (store.dnsRecordsTarget) return
 
+    // The site-monitoring (Uptime Kuma) overlay owns the keyboard while open.
+    if (store.kumaSite) return
+
     if (showHelp) {
       if (key.name === "escape" || key.name === "q" || key.name === "?") setShowHelp(false)
       return

--- a/src/ui/Details.tsx
+++ b/src/ui/Details.tsx
@@ -125,7 +125,7 @@ export function SiteDetail({ site, serverName }: { site: Site; serverName: strin
         : "no beats yet"
     : kumaMonitorFor(site.domain)
       ? "registered · awaiting poll"
-      : "not monitored · m"
+      : "not monitored · m (Servers)" // `m` means media fallback in Search — scope the teach
   const kumaColor = kuma ? (kuma.up === false ? theme.bad : kuma.up ? theme.good : theme.textDim) : theme.textFaint
   const httpsProgress = httpsToggles.get(site.id)
   const purgeProgress = purgeCacheProgress.get(site.id)

--- a/src/ui/Details.tsx
+++ b/src/ui/Details.tsx
@@ -115,7 +115,18 @@ export const SERVER_CONTROL: ActionGroup[] = [
 ]
 
 export function SiteDetail({ site, serverName }: { site: Site; serverName: string }) {
-  const { probes, probingIds, isProbeStale, phpUpgrades, httpsToggles, purgeCacheProgress, localLinks, grantedKeyKinds } = useStore()
+  const { probes, probingIds, isProbeStale, phpUpgrades, httpsToggles, purgeCacheProgress, localLinks, grantedKeyKinds, kumaStatus, kumaMonitorFor } = useStore()
+  const kuma = kumaStatus.get(site.domain)
+  const kumaValue = kuma
+    ? kuma.up === false
+      ? "DOWN"
+      : kuma.up
+        ? `up${kuma.uptime24 != null ? ` · ${(kuma.uptime24 * 100).toFixed(2)}% (24h)` : ""}`
+        : "no beats yet"
+    : kumaMonitorFor(site.domain)
+      ? "registered · awaiting poll"
+      : "not monitored · m"
+  const kumaColor = kuma ? (kuma.up === false ? theme.bad : kuma.up ? theme.good : theme.textDim) : theme.textFaint
   const httpsProgress = httpsToggles.get(site.id)
   const purgeProgress = purgeCacheProgress.get(site.id)
   const updates = (site.wp_plugin_updates || 0) + (site.wp_theme_updates || 0) + (site.wp_core_update ? 1 : 0)
@@ -172,6 +183,7 @@ export function SiteDetail({ site, serverName }: { site: Site; serverName: strin
       <Field label="User" value={site.site_user ?? "—"} />
       <Field label="Granted" value={keyValue} valueColor={keyParts.length ? theme.good : theme.textFaint} />
       <Field label="Public dir" value={site.public_folder ?? "/"} />
+      <Field label="Monitor" value={kumaValue} valueColor={kumaColor} />
       <Field label="Local" value={linkValue} valueColor={linkColor} />
       <SiteDnsSection site={site} />
       <Field

--- a/src/ui/Header.tsx
+++ b/src/ui/Header.tsx
@@ -27,7 +27,8 @@ const SUBTITLES: Record<Route, string> = {
 }
 
 export function Header() {
-  const { route, servers, sites, loading, lastUpdated, updateInfo, newServerJob, vanityJob, cloneJob, cloneServer } = useStore()
+  const { route, servers, sites, loading, lastUpdated, updateInfo, newServerJob, vanityJob, cloneJob, cloneServer, kumaStatus } = useStore()
+  const kumaDown = [...kumaStatus.values()].filter((s) => s.up === false).length
   const updateReady = updateInfo?.updateAvailable ?? false
   const building = isNewServerInFlight(newServerJob)
   const connecting = isVanityInFlight(vanityJob)
@@ -94,6 +95,8 @@ export function Header() {
             <text content={`  Cloning ${truncate(cloneJob!.sourceServerName, 20)} — press C  `} fg={theme.warn} wrapMode="none" />
           </box>
         )}
+        {/* Uptime Kuma: only bad news earns header space — silence when all up. */}
+        {kumaDown > 0 && <text content={`  ▼ ${kumaDown} monitor${kumaDown === 1 ? "" : "s"} down  `} fg={theme.bad} style={{ flexShrink: 0 }} wrapMode="none" />}
         {loading && <Spinner interval={100} />}
         <text content={`  ${servers.length} servers · ${sites.length} sites  `} fg={theme.textDim} style={{ flexShrink: 0 }} />
         <text content={lastUpdated ? `updated ${timeAgo(lastUpdated.toISOString())}` : "loading…"} fg={theme.textFaint} style={{ flexShrink: 0 }} />

--- a/src/ui/components.tsx
+++ b/src/ui/components.tsx
@@ -241,12 +241,14 @@ export function SecretInput({
   focused,
   placeholder,
   onSubmit,
+  width,
 }: {
   value: string
   onChange: (v: string) => void
   focused?: boolean
   placeholder?: string
   onSubmit?: () => void
+  width?: number // fixed box width; omit for content-sized (existing call sites)
 }) {
   // Mirror the value in a ref so a rapid burst of key events (or a paste split
   // into per-char events) accumulates instead of each handler closing over a
@@ -289,6 +291,7 @@ export function SecretInput({
         backgroundColor: theme.bgAlt,
         paddingLeft: 1,
         paddingRight: 1,
+        ...(width != null ? { width } : {}),
       }}
     >
       <text content={focused ? "❯ " : "  "} fg={focused ? theme.brand : theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -524,6 +524,7 @@ interface StoreValue extends DataState {
   connectKuma: (conn: { url: string; username: string; password: string }) => Promise<{ ok: true; version: string | null } | { ok: false; error: string }>
   kumaMonitorFor: (domain: string) => KumaMonitorRef | null // monitors Spinup registered for a domain
   startKumaSetup: (site: Site, opts?: { reseed?: boolean }) => void
+  startVanityReseed: (site: Site) => void // refresh an existing vanity page (no Kuma needed)
   kumaStatus: Map<string, KumaDomainStatus> // live per-domain status, refreshed every minute
   // Clone a server to a new server (item 5). `cloneServer` opens the wizard; `cloneJob`
   // is the (Plan-draft then running) job whose heavy work lives in its `sites[]` vector.
@@ -2920,6 +2921,38 @@ export function StoreProvider({ children }: { children: ReactNode }) {
 
   const kumaMonitorFor = useCallback((domain: string) => cfgRef.current.kumaMonitors[domain] ?? null, [])
 
+  // Push the current embedded page (with its health-endpoint modes) into an
+  // existing vanity site's docroot, minting/reusing the domain's stable health
+  // key. Shared by the standalone refresh and the Kuma setup's reseed option.
+  const reseedVanityPage = useCallback(async (site: Site, server: Server) => {
+    const domain = site.domain
+    const keys = { ...cfgRef.current.vanityHealthKeys }
+    const healthKey = keys[domain] ?? crypto.randomUUID().replace(/-/g, "")
+    if (keys[domain] !== healthKey) {
+      keys[domain] = healthKey
+      cfgRef.current.vanityHealthKeys = keys
+      void saveConfig({ vanityHealthKeys: keys })
+    }
+    return seedVanityIndex({ host: server.ip_address ?? "", user: site.site_user ?? deriveSiteUser(domain), port: server.ssh_port ?? null, domain, publicFolder: site.public_folder, healthKey })
+  }, [])
+
+  // Standalone vanity-page refresh — no Uptime Kuma involvement, works without a
+  // connection. This is how a page seeded by an older Spinup gets the current
+  // version (health endpoints included).
+  const startVanityReseed = useCallback(
+    (site: Site) => {
+      const server = servers.find((s) => s.id === site.server_id)
+      if (!server) return
+      const setOp = (op: KumaOp) => setKumaOps((prev) => new Map(prev).set(site.id, op))
+      setOp({ status: "running", detail: "Publishing the current page…" })
+      void reseedVanityPage(site, server).then((res) => {
+        if (res.ok) setOp({ status: "done", detail: "Page re-published — health endpoints are live." })
+        else setOp({ status: "error", detail: "", error: res.error || "Couldn't re-publish the page over SSH." })
+      })
+    },
+    [servers, reseedVanityPage],
+  )
+
   // Set up monitoring for an existing site. A vanity site (domain = server name)
   // gets the full treatment — optional page re-seed (the upgrade path for pages
   // published before the health-endpoint feature), healthz monitor, load push
@@ -2937,14 +2970,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           const domain = site.domain
           if (isVanity && opts.reseed && server) {
             setOp({ status: "running", detail: "Publishing the updated page…" })
-            const keys = { ...cfgRef.current.vanityHealthKeys }
-            const healthKey = keys[domain] ?? crypto.randomUUID().replace(/-/g, "")
-            if (keys[domain] !== healthKey) {
-              keys[domain] = healthKey
-              cfgRef.current.vanityHealthKeys = keys
-              void saveConfig({ vanityHealthKeys: keys })
-            }
-            const seed = await seedVanityIndex({ host: server.ip_address ?? "", user: site.site_user ?? deriveSiteUser(domain), port: server.ssh_port ?? null, domain, publicFolder: site.public_folder, healthKey })
+            const seed = await reseedVanityPage(site, server)
             if (!seed.ok) throw new Error(seed.error || "Couldn't re-seed the page over SSH.")
           }
           setOp({ status: "running", detail: "Registering monitors in Uptime Kuma…" })
@@ -2983,7 +3009,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       }
       void run()
     },
-    [servers],
+    [servers, reseedVanityPage],
   )
 
   // ---- Clone a server to a new server (item 5) -----------------------------
@@ -3719,6 +3745,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     connectKuma,
     kumaMonitorFor,
     startKumaSetup,
+    startVanityReseed,
     kumaStatus,
     cloneServer,
     setCloneServer,

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -41,7 +41,7 @@ import {
 import { ProvidersCache, type VerifiedConn } from "../lib/providersCache.ts"
 import { recordProviderFor, type DnsRecord, type RecordResult } from "../lib/dnsRecords.ts"
 import { deriveSiteUser, seedVanityIndex, seedVanityPushCron, aRecordResolves } from "../lib/vanitySite.ts"
-import { withKuma, genPushToken, healthMonitorPayload, loadPushMonitorPayload } from "../lib/uptimeKuma.ts"
+import { withKuma, KumaClient, genPushToken, healthMonitorPayload, loadPushMonitorPayload } from "../lib/uptimeKuma.ts"
 import type { StoredProviders } from "../config.ts"
 import { fetchRebootInfo, grantSiteSshKey, revokeSiteSshKey, verifySudo, ensureSpinupKey, listPersonalKeys, keyBody, type RebootInfo } from "../lib/ssh.ts"
 import { estimateSourceSiteSizes, runStandardWpPull, runBedrockPull, runFilesOnlyPull, verifyClone, verifyFilesClone, type SudoCtx, type CloneStage, type CloneExecRecord, type VerifyResult as CloneVerifyResult } from "../lib/serverClone.ts"
@@ -521,7 +521,7 @@ interface StoreValue extends DataState {
   kumaSite: Site | null // site whose Kuma overlay (m) is open
   setKumaSite: (s: Site | null) => void
   kumaOps: Map<number, KumaOp> // in-flight/settled monitor setups, by site id
-  connectKuma: (conn: { url: string; username: string; password: string }) => Promise<{ ok: true; version: string | null } | { ok: false; error: string }>
+  connectKuma: (conn: { url: string; username: string; password: string }, twofa?: string) => Promise<{ ok: true; version: string | null } | { ok: false; error: string; tokenRequired?: boolean }>
   kumaMonitorFor: (domain: string) => KumaMonitorRef | null // monitors Spinup registered for a domain
   startKumaSetup: (site: Site, opts?: { reseed?: boolean }) => void
   startVanityReseed: (site: Site) => void // refresh an existing vanity page (no Kuma needed)
@@ -2903,21 +2903,32 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   }, [kumaEpoch])
 
   // Verify a Kuma connection by actually logging in, then persist it (with the
-  // minted JWT, so later sessions use loginByToken). The env-sourced connection
-  // is never overwritten — mirrors the provider-connection convention.
-  const connectKuma = useCallback(async (conn: { url: string; username: string; password: string }): Promise<{ ok: true; version: string | null } | { ok: false; error: string }> => {
-    try {
-      const url = conn.url.trim().replace(/\/+$/, "")
-      const { jwt, version } = await withKuma({ ...conn, url }, async () => true)
-      const stored = { url, username: conn.username, password: conn.password, jwt }
-      cfgRef.current.uptimeKuma = stored
-      void saveConfig({ uptimeKuma: stored })
-      setKumaEpoch((e) => e + 1) // start the status poll loop now
-      return { ok: true, version }
-    } catch (err) {
-      return { ok: false, error: (err as Error).message }
-    }
-  }, [])
+  // minted JWT, so later sessions use loginByToken). 2FA accounts: the first
+  // attempt comes back `tokenRequired`, the view reveals a code field, and the
+  // retry carries the TOTP — needed exactly once, since every later login uses
+  // the stored JWT. The env-sourced connection is never overwritten.
+  const connectKuma = useCallback(
+    async (conn: { url: string; username: string; password: string }, twofa?: string): Promise<{ ok: true; version: string | null } | { ok: false; error: string; tokenRequired?: boolean }> => {
+      try {
+        const url = conn.url.trim().replace(/\/+$/, "")
+        const kuma = await KumaClient.connect(url)
+        try {
+          const login = await kuma.login({ username: conn.username, password: conn.password, url }, twofa)
+          if (!login.ok) return { ok: false, error: login.error, tokenRequired: login.tokenRequired }
+          const stored = { url, username: conn.username, password: conn.password, jwt: login.jwt }
+          cfgRef.current.uptimeKuma = stored
+          void saveConfig({ uptimeKuma: stored })
+          setKumaEpoch((e) => e + 1) // start the status poll loop now
+          return { ok: true, version: kuma.version }
+        } finally {
+          kuma.disconnect()
+        }
+      } catch (err) {
+        return { ok: false, error: (err as Error).message }
+      }
+    },
+    [],
+  )
 
   const kumaMonitorFor = useCallback((domain: string) => cfgRef.current.kumaMonitors[domain] ?? null, [])
 

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -71,6 +71,8 @@ export interface PhpUpgradeProgress {
 const UPGRADE_DONE = "deployed"
 const UPGRADE_FAIL = "failed"
 const UPGRADE_POLL_MS = 2500
+// Kuma status refresh — its monitors beat at 60s, so faster polling buys nothing.
+const KUMA_POLL_MS = 60_000
 
 export function isUpgradeInFlight(p: PhpUpgradeProgress | undefined): boolean {
   return p != null && p.status !== UPGRADE_DONE && p.status !== UPGRADE_FAIL
@@ -190,6 +192,17 @@ export interface KumaOp {
   status: "running" | "done" | "error"
   detail: string
   error?: string
+}
+
+// One domain's live status as Kuma sees it, refreshed by the store's poll loop.
+// `responseBeats`/`loadBeats` are ping series (ms / 1-min load) oldest-first,
+// ready for sparkline().
+export interface KumaDomainStatus {
+  up: boolean | null // last beat status; null = no beats yet
+  uptime24: number | null // 0..1 fraction from Kuma's 24h uptime event
+  responseBeats: number[]
+  loadBeats: number[]
+  lastLoad: number | null
 }
 
 // Clone a server to a new server (backlog item 5). Five server-level steps wrapping
@@ -511,6 +524,7 @@ interface StoreValue extends DataState {
   connectKuma: (conn: { url: string; username: string; password: string }) => Promise<{ ok: true; version: string | null } | { ok: false; error: string }>
   kumaMonitorFor: (domain: string) => KumaMonitorRef | null // monitors Spinup registered for a domain
   startKumaSetup: (site: Site, opts?: { reseed?: boolean }) => void
+  kumaStatus: Map<string, KumaDomainStatus> // live per-domain status, refreshed every minute
   // Clone a server to a new server (item 5). `cloneServer` opens the wizard; `cloneJob`
   // is the (Plan-draft then running) job whose heavy work lives in its `sites[]` vector.
   cloneServer: Server | null
@@ -1404,6 +1418,42 @@ export function StoreProvider({ children }: { children: ReactNode }) {
 
       const run = async () => {
         setOp(server.id, { kind, label, status: "queued" })
+
+        // Reboot only: shield this server's Kuma monitors behind a manual
+        // maintenance window so the planned outage never pages. Best-effort in
+        // both directions — Kuma being unreachable must never block a reboot.
+        let kumaMaintId: number | null = null
+        const kumaConn = cfgRef.current.uptimeKuma
+        if (kind === "reboot" && kumaConn) {
+          const domains = new Set(sitesForServer(server.id).map((s) => s.domain))
+          const monitorIds: number[] = []
+          for (const [domain, ref] of Object.entries(cfgRef.current.kumaMonitors)) {
+            if (!domains.has(domain)) continue
+            if (ref.healthId) monitorIds.push(ref.healthId)
+            if (ref.pushId) monitorIds.push(ref.pushId)
+          }
+          if (monitorIds.length) {
+            try {
+              const { result } = await withKuma(kumaConn, async (kuma) => {
+                const id = await kuma.addManualMaintenance(`Reboot ${server.name}`, "Planned reboot fired from Spinup")
+                await kuma.setMaintenanceMonitors(id, monitorIds)
+                return id
+              })
+              kumaMaintId = result
+            } catch {
+              // No window — worst case is one expected down alert.
+            }
+          }
+        }
+        const endKumaMaintenance = () => {
+          if (kumaMaintId == null || !kumaConn) return
+          const id = kumaMaintId
+          kumaMaintId = null
+          withKuma(kumaConn, (kuma) => kuma.deleteMaintenance(id)).catch(() => {
+            // Stale window left behind in Kuma — visible + deletable there.
+          })
+        }
+
         let eventId: number
         try {
           const res = kind === "reboot" ? await client.rebootServer(server.id) : await client.restartService(server.id, kind)
@@ -1411,6 +1461,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         } catch (err) {
           const msg = err instanceof ApiError ? err.message : (err as Error).message
           setOp(server.id, { kind, label, status: UPGRADE_FAIL, error: msg })
+          endKumaMaintenance()
           return
         }
 
@@ -1418,12 +1469,14 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           try {
             const ev = await client.getEvent(eventId)
             if (ev.status === UPGRADE_DONE) {
+              endKumaMaintenance()
               await refresh() // reboot clears reboot_required; status may flip too
               clearServerOp(server.id)
               // Background-completion nudge — a reboot can take minutes and the user
               // has usually closed the overlay (it tracks in the background).
               toast.success(kind === "reboot" ? `${server.name} rebooted` : `${SERVICE_NAMES[kind] ?? kind} restarted on ${server.name}`)
             } else if (ev.status === UPGRADE_FAIL) {
+              endKumaMaintenance()
               setOp(server.id, { kind, label, status: UPGRADE_FAIL, error: ev.output?.trim() || "The operation failed on SpinupWP." })
             } else {
               setOp(server.id, { kind, label, status: ev.status })
@@ -1432,13 +1485,14 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           } catch (err) {
             const msg = err instanceof ApiError ? err.message : (err as Error).message
             setOp(server.id, { kind, label, status: UPGRADE_FAIL, error: msg })
+            endKumaMaintenance()
           }
         }
         setTimeout(() => void poll(), UPGRADE_POLL_MS)
       }
       void run()
     },
-    [client, refresh, clearServerOp, serverOps],
+    [client, refresh, clearServerOp, serverOps, sitesForServer],
   )
 
   // ---- Create a server (POST /servers) ----------------------------------
@@ -2793,6 +2847,59 @@ export function StoreProvider({ children }: { children: ReactNode }) {
 
   const [kumaSite, setKumaSite] = useState<Site | null>(null)
   const [kumaOps, setKumaOps] = useState<Map<number, KumaOp>>(new Map())
+  const [kumaStatus, setKumaStatus] = useState<Map<string, KumaDomainStatus>>(new Map())
+  // Bumped when a connection is added mid-session so the poll loop (re)starts.
+  const [kumaEpoch, setKumaEpoch] = useState(0)
+
+  // Poll Kuma every minute for the registered monitors' status: one short-lived
+  // connection per tick; the post-login event burst (beats + uptime) is the
+  // snapshot. Kuma being unreachable keeps the last snapshot (stale > empty).
+  useEffect(() => {
+    const conn = cfgRef.current.uptimeKuma
+    if (!conn) return
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const tick = async () => {
+      try {
+        const { result } = await withKuma(conn, async (kuma) => {
+          const monitors = await kuma.getMonitors()
+          await kuma.waitForSnapshot()
+          const byId = new Map(monitors.map((m) => [m.id, m]))
+          const map = new Map<string, KumaDomainStatus>()
+          for (const [domain, ref] of Object.entries(cfgRef.current.kumaMonitors)) {
+            const status: KumaDomainStatus = { up: null, uptime24: null, responseBeats: [], loadBeats: [], lastLoad: null }
+            if (ref.healthId && byId.has(ref.healthId)) {
+              const beats = kuma.beatsFor(ref.healthId)
+              const last = beats[beats.length - 1]
+              status.up = last ? last.status === 1 : null
+              status.responseBeats = beats.map((b) => Number(b.ping) || 0)
+              status.uptime24 = kuma.uptimeFor(ref.healthId, 24)
+            }
+            if (ref.pushId && byId.has(ref.pushId)) {
+              const beats = kuma.beatsFor(ref.pushId)
+              // The cron pushes load ×100 as an integer (some Kuma builds drop
+              // float pings) — scale back to real load here.
+              status.loadBeats = beats.map((b) => (Number(b.ping) || 0) / 100)
+              const last = beats[beats.length - 1]
+              status.lastLoad = last?.ping != null ? Number(last.ping) / 100 : null
+              if (status.up === null && last) status.up = last.status === 1
+            }
+            map.set(domain, status)
+          }
+          return map
+        })
+        if (!cancelled) setKumaStatus(result)
+      } catch {
+        // Unreachable this tick — retry on the next one.
+      }
+      if (!cancelled) timer = setTimeout(() => void tick(), KUMA_POLL_MS)
+    }
+    void tick()
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [kumaEpoch])
 
   // Verify a Kuma connection by actually logging in, then persist it (with the
   // minted JWT, so later sessions use loginByToken). The env-sourced connection
@@ -2804,6 +2911,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       const stored = { url, username: conn.username, password: conn.password, jwt }
       cfgRef.current.uptimeKuma = stored
       void saveConfig({ uptimeKuma: stored })
+      setKumaEpoch((e) => e + 1) // start the status poll loop now
       return { ok: true, version }
     } catch (err) {
       return { ok: false, error: (err as Error).message }
@@ -3611,6 +3719,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     connectKuma,
     kumaMonitorFor,
     startKumaSetup,
+    kumaStatus,
     cloneServer,
     setCloneServer,
     cloneJob,

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -11,7 +11,7 @@ import { SpinupWPClient, ApiError, type ServerService, type SpinupWPClientLike }
 import { isDevMode } from "../dev/devMode.ts"
 import { createMockClient } from "../dev/mockClient.ts"
 import type { Server, Site, Event, ProviderMetadata, CreateServerPayload, CreateSitePayload, AdditionalDomain } from "../api/types.ts"
-import { loadConfig, saveConfig, type ServerProviderRef, type KumaMonitorRef } from "../config.ts"
+import { loadConfig, saveConfig, type ServerProviderRef, type KumaMonitorRef, type UptimeKumaConn } from "../config.ts"
 import { saveJob, removeJob } from "../lib/jobs.ts"
 import { APP_VERSION } from "../version.ts"
 import { cachedUpdateInfo, refreshUpdateInfo, type UpdateInfo } from "../lib/appUpdate.ts"
@@ -40,8 +40,8 @@ import {
 } from "../lib/providers.ts"
 import { ProvidersCache, type VerifiedConn } from "../lib/providersCache.ts"
 import { recordProviderFor, type DnsRecord, type RecordResult } from "../lib/dnsRecords.ts"
-import { deriveSiteUser, seedVanityIndex, seedVanityPushCron, aRecordResolves } from "../lib/vanitySite.ts"
-import { withKuma, KumaClient, genPushToken, healthMonitorPayload, loadPushMonitorPayload } from "../lib/uptimeKuma.ts"
+import { deriveSiteUser, seedVanityIndex, seedVanityPushCron, aRecordResolves, isVanityPair } from "../lib/vanitySite.ts"
+import { withKuma, KumaClient, registerMonitors, LOAD_PUSH_SCALE } from "../lib/uptimeKuma.ts"
 import type { StoredProviders } from "../config.ts"
 import { fetchRebootInfo, grantSiteSshKey, revokeSiteSshKey, verifySudo, ensureSpinupKey, listPersonalKeys, keyBody, type RebootInfo } from "../lib/ssh.ts"
 import { estimateSourceSiteSizes, runStandardWpPull, runBedrockPull, runFilesOnlyPull, verifyClone, verifyFilesClone, type SudoCtx, type CloneStage, type CloneExecRecord, type VerifyResult as CloneVerifyResult } from "../lib/serverClone.ts"
@@ -178,9 +178,7 @@ export interface VanityJob {
   propagateStartedAt?: number
   keepWaiting?: boolean // user chose "keep waiting" after the first timeout → poll
                         // indefinitely (count-up in the UI), no more timeout prompts
-  kumaHealthId?: number // Uptime Kuma monitor ids + push token, once registered
-  kumaPushId?: number
-  kumaPushToken?: string
+  kumaPushToken?: string // token feeding the load push monitor (cron step input)
 }
 export function isVanityInFlight(j: VanityJob | null | undefined): boolean {
   return j != null && j.step !== "done" && j.step !== "error"
@@ -1424,7 +1422,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         // maintenance window so the planned outage never pages. Best-effort in
         // both directions — Kuma being unreachable must never block a reboot.
         let kumaMaintId: number | null = null
-        const kumaConn = cfgRef.current.uptimeKuma
+        const kumaConn = isDevMode() ? null : cfgRef.current.uptimeKuma
         if (kind === "reboot" && kumaConn) {
           const domains = new Set(sitesForServer(server.id).map((s) => s.domain))
           const monitorIds: number[] = []
@@ -1437,7 +1435,14 @@ export function StoreProvider({ children }: { children: ReactNode }) {
             try {
               const { result } = await withKuma(kumaConn, async (kuma) => {
                 const id = await kuma.addManualMaintenance(`Reboot ${server.name}`, "Planned reboot fired from Spinup")
-                await kuma.setMaintenanceMonitors(id, monitorIds)
+                try {
+                  await kuma.setMaintenanceMonitors(id, monitorIds)
+                } catch (err) {
+                  // Half-created window shields nothing — remove it rather than
+                  // orphaning an active manual window in Kuma.
+                  await kuma.deleteMaintenance(id).catch(() => {})
+                  throw err
+                }
                 return id
               })
               kumaMaintId = result
@@ -1466,9 +1471,14 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           return
         }
 
+        // A reboot leaves the API briefly flaky (and 429s happen) — one transient
+        // getEvent failure must not mark the op failed and tear the maintenance
+        // window down mid-reboot. Only consecutive failures settle it.
+        let pollErrors = 0
         const poll = async () => {
           try {
             const ev = await client.getEvent(eventId)
+            pollErrors = 0
             if (ev.status === UPGRADE_DONE) {
               endKumaMaintenance()
               await refresh() // reboot clears reboot_required; status may flip too
@@ -1484,6 +1494,11 @@ export function StoreProvider({ children }: { children: ReactNode }) {
               setTimeout(() => void poll(), UPGRADE_POLL_MS)
             }
           } catch (err) {
+            pollErrors += 1
+            if (pollErrors < 3) {
+              setTimeout(() => void poll(), UPGRADE_POLL_MS)
+              return
+            }
             const msg = err instanceof ApiError ? err.message : (err as Error).message
             setOp(server.id, { kind, label, status: UPGRADE_FAIL, error: msg })
             endKumaMaintenance()
@@ -2521,6 +2536,33 @@ export function StoreProvider({ children }: { children: ReactNode }) {
 
   // ---- Vanity site (connect a fresh, empty server) ----------------------
 
+  // One stable health key per domain — a resume/re-seed must reuse it so a
+  // monitor URL built against the page's ?format=json mode never goes stale.
+  const ensureVanityHealthKey = useCallback((domain: string): string => {
+    const keys = { ...cfgRef.current.vanityHealthKeys }
+    const key = keys[domain] ?? crypto.randomUUID().replace(/-/g, "")
+    if (keys[domain] !== key) {
+      keys[domain] = key
+      cfgRef.current.vanityHealthKeys = keys
+      void saveConfig({ vanityHealthKeys: keys })
+    }
+    return key
+  }, [])
+
+  // Keep the Kuma JWT fresh so later sessions log in by token (2FA-friendly).
+  // The env-sourced connection is never overwritten.
+  const persistKumaAuth = useCallback((conn: UptimeKumaConn, jwt: string) => {
+    if (conn.env || jwt === conn.jwt) return
+    cfgRef.current.uptimeKuma = { ...conn, jwt }
+    void saveConfig({ uptimeKuma: { ...conn, jwt } })
+  }, [])
+
+  const persistKumaMonitors = useCallback((domain: string, ref: KumaMonitorRef) => {
+    const map = { ...cfgRef.current.kumaMonitors, [domain]: ref }
+    cfgRef.current.kumaMonitors = map
+    void saveConfig({ kumaMonitors: map })
+  }, [])
+
   // The step machine. Each step performs its work then hands off to the next; it
   // re-enters at job.step (so resume continues mid-flight). Steps are written to be
   // idempotent where they can't re-attach to a remote handle (site/seed), so a
@@ -2668,51 +2710,35 @@ export function StoreProvider({ children }: { children: ReactNode }) {
 
       async function doSeed(j: VanityJob) {
         persist({ ...j, step: "seed" })
-        // One stable key per domain: a resume/re-seed reuses it, so a monitor URL
-        // built against the page's ?format=json mode never goes stale.
-        const keys = { ...cfgRef.current.vanityHealthKeys }
-        const healthKey = keys[j.hostname] ?? crypto.randomUUID().replace(/-/g, "")
-        if (keys[j.hostname] !== healthKey) {
-          keys[j.hostname] = healthKey
-          cfgRef.current.vanityHealthKeys = keys
-          void saveConfig({ vanityHealthKeys: keys })
-        }
+        const healthKey = ensureVanityHealthKey(j.hostname)
         const res = await seedVanityIndex({ host: j.serverIp, user: j.siteUser, port: j.port, domain: j.hostname, publicFolder: j.publicFolder, healthKey })
         if (!res.ok) return fail(j, "seed", res.error || "Couldn't seed index.php over SSH.")
         await refresh()
         void doMonitor({ ...j, step: "monitor" })
       }
 
-      // Register the two Uptime Kuma monitors (healthz HTTP + load push). Auto-skips
-      // to done when no Kuma connection is configured. Idempotent on resume: reuses
-      // ids we already recorded, or adopts same-named monitors already in Kuma.
+      // Register the two Uptime Kuma monitors (healthz HTTP + load push) via the
+      // shared registerMonitors (same code path as the m overlay). Auto-skips to
+      // done when no Kuma connection is configured (or in Dev Mode — never touch
+      // a real Kuma from a demo).
       async function doMonitor(j: VanityJob) {
         const conn = cfgRef.current.uptimeKuma
-        if (!conn) return persist({ ...j, step: "done" })
+        if (!conn || isDevMode()) return persist({ ...j, step: "done" })
         persist({ ...j, step: "monitor" })
         try {
           const known = cfgRef.current.kumaMonitors[j.hostname] ?? {}
-          const proto = j.sslSkipped ? "http" : "https"
-          let pushToken = j.kumaPushToken ?? known.pushToken ?? genPushToken()
-          const { result, jwt } = await withKuma(conn, async (kuma) => {
-            const byName = new Map((await kuma.getMonitors()).map((m) => [m.name, m]))
-            const existingPush = byName.get(`${j.hostname} load`)
-            // A push monitor made outside Spinup keeps its own token — the cron
-            // must feed THAT one, so adopt it.
-            if (existingPush?.pushToken) pushToken = existingPush.pushToken
-            const healthId = known.healthId ?? byName.get(j.hostname)?.id ?? (await kuma.addMonitor(healthMonitorPayload(j.hostname, `${proto}://${j.hostname}/?healthz`)))
-            const pushId = known.pushId ?? existingPush?.id ?? (await kuma.addMonitor(loadPushMonitorPayload(`${j.hostname} load`, pushToken)))
-            return { healthId, pushId }
-          })
-          // Keep the JWT fresh so later sessions log in by token (2FA-friendly).
-          if (!conn.env && jwt !== conn.jwt) {
-            cfgRef.current.uptimeKuma = { ...conn, jwt }
-            void saveConfig({ uptimeKuma: { ...conn, jwt } })
-          }
-          const map = { ...cfgRef.current.kumaMonitors, [j.hostname]: { healthId: result.healthId, pushId: result.pushId, pushToken } }
-          cfgRef.current.kumaMonitors = map
-          void saveConfig({ kumaMonitors: map })
-          void doCron({ ...j, step: "cron", kumaHealthId: result.healthId, kumaPushId: result.pushId, kumaPushToken: pushToken })
+          const { result, jwt } = await withKuma(conn, (kuma) =>
+            registerMonitors(kuma, j.hostname, {
+              proto: j.sslSkipped ? "http" : "https",
+              healthzPath: "/?healthz",
+              wantPush: true,
+              known,
+              pushToken: j.kumaPushToken,
+            }),
+          )
+          persistKumaAuth(conn, jwt)
+          persistKumaMonitors(j.hostname, { healthId: result.healthId, pushId: result.pushId ?? known.pushId, pushToken: result.pushToken ?? known.pushToken })
+          void doCron({ ...j, step: "cron", kumaPushToken: result.pushToken ?? known.pushToken })
         } catch (err) {
           fail(j, "monitor", (err as Error).message)
         }
@@ -2750,7 +2776,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           return
       }
     },
-    [client, allConnections, refresh, resolveZoneConn],
+    [client, allConnections, refresh, resolveZoneConn, ensureVanityHealthKey, persistKumaAuth, persistKumaMonitors],
   )
 
   const startVanity = useCallback(
@@ -2855,35 +2881,47 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   // Poll Kuma every minute for the registered monitors' status: one short-lived
   // connection per tick; the post-login event burst (beats + uptime) is the
   // snapshot. Kuma being unreachable keeps the last snapshot (stale > empty).
+  // Never runs in Dev Mode — a demo must not touch (or leak) the real Kuma.
   useEffect(() => {
+    if (isDevMode()) return
     const conn = cfgRef.current.uptimeKuma
     if (!conn) return
     let cancelled = false
     let timer: ReturnType<typeof setTimeout> | undefined
     const tick = async () => {
+      // Nothing registered → nothing to show; skip the connection entirely
+      // (re-checked each tick, since registration doesn't bump kumaEpoch).
+      if (Object.keys(cfgRef.current.kumaMonitors).length === 0) {
+        if (!cancelled) timer = setTimeout(() => void tick(), KUMA_POLL_MS)
+        return
+      }
       try {
         const { result } = await withKuma(conn, async (kuma) => {
           const monitors = await kuma.getMonitors()
-          await kuma.waitForSnapshot()
+          await kuma.waitForSnapshot(monitors.length)
           const byId = new Map(monitors.map((m) => [m.id, m]))
           const map = new Map<string, KumaDomainStatus>()
+          // A beat is "down" only at status 0 — pending (2) and maintenance (3)
+          // must not raise the down badge (that would false-alarm during the
+          // very maintenance windows we create around reboots).
+          const beatUp = (s: number) => s !== 0
           for (const [domain, ref] of Object.entries(cfgRef.current.kumaMonitors)) {
             const status: KumaDomainStatus = { up: null, uptime24: null, responseBeats: [], loadBeats: [], lastLoad: null }
             if (ref.healthId && byId.has(ref.healthId)) {
               const beats = kuma.beatsFor(ref.healthId)
               const last = beats[beats.length - 1]
-              status.up = last ? last.status === 1 : null
+              status.up = last ? beatUp(last.status) : null
               status.responseBeats = beats.map((b) => Number(b.ping) || 0)
               status.uptime24 = kuma.uptimeFor(ref.healthId, 24)
             }
             if (ref.pushId && byId.has(ref.pushId)) {
               const beats = kuma.beatsFor(ref.pushId)
-              // The cron pushes load ×100 as an integer (some Kuma builds drop
-              // float pings) — scale back to real load here.
-              status.loadBeats = beats.map((b) => (Number(b.ping) || 0) / 100)
+              // The cron pushes load ×LOAD_PUSH_SCALE as an integer (some Kuma
+              // builds drop float pings) — scale back to real load here.
+              status.loadBeats = beats.map((b) => (Number(b.ping) || 0) / LOAD_PUSH_SCALE)
               const last = beats[beats.length - 1]
-              status.lastLoad = last?.ping != null ? Number(last.ping) / 100 : null
-              if (status.up === null && last) status.up = last.status === 1
+              status.lastLoad = last?.ping != null ? Number(last.ping) / LOAD_PUSH_SCALE : null
+              if (status.up === null && last) status.up = beatUp(last.status)
             }
             map.set(domain, status)
           }
@@ -2909,6 +2947,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   // the stored JWT. The env-sourced connection is never overwritten.
   const connectKuma = useCallback(
     async (conn: { url: string; username: string; password: string }, twofa?: string): Promise<{ ok: true; version: string | null } | { ok: false; error: string; tokenRequired?: boolean }> => {
+      if (isDevMode()) return { ok: false, error: "Dev Mode never talks to a real Uptime Kuma." }
       try {
         const url = conn.url.trim().replace(/\/+$/, "")
         const kuma = await KumaClient.connect(url)
@@ -2919,6 +2958,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           cfgRef.current.uptimeKuma = stored
           void saveConfig({ uptimeKuma: stored })
           setKumaEpoch((e) => e + 1) // start the status poll loop now
+          await kuma.waitForVersion() // `info` can land after the login ack
           return { ok: true, version: kuma.version }
         } finally {
           kuma.disconnect()
@@ -2935,17 +2975,14 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   // Push the current embedded page (with its health-endpoint modes) into an
   // existing vanity site's docroot, minting/reusing the domain's stable health
   // key. Shared by the standalone refresh and the Kuma setup's reseed option.
-  const reseedVanityPage = useCallback(async (site: Site, server: Server) => {
-    const domain = site.domain
-    const keys = { ...cfgRef.current.vanityHealthKeys }
-    const healthKey = keys[domain] ?? crypto.randomUUID().replace(/-/g, "")
-    if (keys[domain] !== healthKey) {
-      keys[domain] = healthKey
-      cfgRef.current.vanityHealthKeys = keys
-      void saveConfig({ vanityHealthKeys: keys })
-    }
-    return seedVanityIndex({ host: server.ip_address ?? "", user: site.site_user ?? deriveSiteUser(domain), port: server.ssh_port ?? null, domain, publicFolder: site.public_folder, healthKey })
-  }, [])
+  const reseedVanityPage = useCallback(
+    async (site: Site, server: Server) => {
+      const domain = site.domain
+      const healthKey = ensureVanityHealthKey(domain)
+      return seedVanityIndex({ host: server.ip_address ?? "", user: site.site_user ?? deriveSiteUser(domain), port: server.ssh_port ?? null, domain, publicFolder: site.public_folder, healthKey })
+    },
+    [ensureVanityHealthKey],
+  )
 
   // Standalone vanity-page refresh — no Uptime Kuma involvement, works without a
   // connection. This is how a page seeded by an older Spinup gets the current
@@ -2955,6 +2992,10 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       const server = servers.find((s) => s.id === site.server_id)
       if (!server) return
       const setOp = (op: KumaOp) => setKumaOps((prev) => new Map(prev).set(site.id, op))
+      if (!server.ip_address) {
+        setOp({ status: "error", detail: "", error: "The server has no IP address yet — wait for provisioning to finish." })
+        return
+      }
       setOp({ status: "running", detail: "Publishing the current page…" })
       void reseedVanityPage(site, server).then((res) => {
         if (res.ok) setOp({ status: "done", detail: "Page re-published — health endpoints are live." })
@@ -2972,10 +3013,16 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const startKumaSetup = useCallback(
     (site: Site, opts: { reseed?: boolean } = {}) => {
       const conn = cfgRef.current.uptimeKuma
-      if (!conn) return
+      if (!conn || isDevMode()) return
       const server = servers.find((s) => s.id === site.server_id)
-      const isVanity = !!server && server.name === site.domain
+      const isVanity = !!server && isVanityPair(site.domain, server.name)
       const setOp = (op: KumaOp) => setKumaOps((prev) => new Map(prev).set(site.id, op))
+      // The vanity treatment SSHes into the box (re-seed + cron) — that needs a
+      // real IP, so fail with a plain precondition instead of a cryptic ssh error.
+      if (isVanity && server && !server.ip_address) {
+        setOp({ status: "error", detail: "", error: "The server has no IP address yet — wait for provisioning to finish." })
+        return
+      }
       const run = async () => {
         try {
           const domain = site.domain
@@ -2986,31 +3033,17 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           }
           setOp({ status: "running", detail: "Registering monitors in Uptime Kuma…" })
           const known = cfgRef.current.kumaMonitors[domain] ?? {}
-          let pushToken = known.pushToken ?? genPushToken()
-          const { result, jwt } = await withKuma(conn, async (kuma) => {
-            const byName = new Map((await kuma.getMonitors()).map((m) => [m.name, m]))
-            const targetUrl = isVanity ? `https://${domain}/?healthz` : `https://${domain}/`
-            const healthId = known.healthId ?? byName.get(domain)?.id ?? (await kuma.addMonitor(healthMonitorPayload(domain, targetUrl)))
-            let pushId: number | undefined
-            if (isVanity) {
-              const existingPush = byName.get(`${domain} load`)
-              // A push monitor made outside Spinup keeps its own token — the cron
-              // must feed THAT one, so adopt it.
-              if (existingPush?.pushToken) pushToken = existingPush.pushToken
-              pushId = known.pushId ?? existingPush?.id ?? (await kuma.addMonitor(loadPushMonitorPayload(`${domain} load`, pushToken)))
-            }
-            return { healthId, pushId }
-          })
-          if (!conn.env && jwt !== conn.jwt) {
-            cfgRef.current.uptimeKuma = { ...conn, jwt }
-            void saveConfig({ uptimeKuma: { ...conn, jwt } })
-          }
-          const map = { ...cfgRef.current.kumaMonitors, [domain]: { healthId: result.healthId, pushId: result.pushId, pushToken: result.pushId ? pushToken : known.pushToken } }
-          cfgRef.current.kumaMonitors = map
-          void saveConfig({ kumaMonitors: map })
-          if (isVanity && result.pushId && server) {
+          // Monitor over the protocol the site actually serves — an https monitor
+          // on an http-only site would be permanently down.
+          const proto = site.https?.enabled ? "https" : "http"
+          const { result, jwt } = await withKuma(conn, (kuma) =>
+            registerMonitors(kuma, domain, { proto, healthzPath: isVanity ? "/?healthz" : "/", wantPush: isVanity, known }),
+          )
+          persistKumaAuth(conn, jwt)
+          persistKumaMonitors(domain, { healthId: result.healthId, pushId: result.pushId ?? known.pushId, pushToken: result.pushToken ?? known.pushToken })
+          if (isVanity && result.pushId && result.pushToken && server) {
             setOp({ status: "running", detail: "Installing the heartbeat cron…" })
-            const cron = await seedVanityPushCron({ host: server.ip_address ?? "", user: site.site_user ?? deriveSiteUser(domain), port: server.ssh_port ?? null, kumaUrl: conn.url, pushToken })
+            const cron = await seedVanityPushCron({ host: server.ip_address ?? "", user: site.site_user ?? deriveSiteUser(domain), port: server.ssh_port ?? null, kumaUrl: conn.url, pushToken: result.pushToken })
             if (!cron.ok) throw new Error(cron.error || "Couldn't install the heartbeat cron.")
           }
           setOp({ status: "done", detail: isVanity ? "Monitors live: healthz checks + load graph (cron beating every minute)." : "Monitor live: homepage checks + certificate-expiry alerts." })
@@ -3020,7 +3053,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       }
       void run()
     },
-    [servers, reseedVanityPage],
+    [servers, reseedVanityPage, persistKumaAuth, persistKumaMonitors],
   )
 
   // ---- Clone a server to a new server (item 5) -----------------------------
@@ -3749,7 +3782,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     vanitySkipKuma,
     clearVanity,
     vanityHealthKeyFor,
-    kumaConfigured: cfgRef.current.uptimeKuma != null,
+    kumaConfigured: !isDevMode() && cfgRef.current.uptimeKuma != null,
     kumaSite,
     setKumaSite,
     kumaOps,

--- a/src/ui/views/Health.tsx
+++ b/src/ui/views/Health.tsx
@@ -97,7 +97,10 @@ export function Health() {
 
   if (!server) return null
 
-  const procRows = Math.max(3, Math.min(snapshot?.processes.length ?? 0, height - 18))
+  // The conditional Kuma Monitor panel takes up to 5 rows (2 border + 3 content)
+  // out of the same right column — shrink the process budget when it renders.
+  const kumaRows = kumaStatus.get(server.name) ? 5 : 0
+  const procRows = Math.max(3, Math.min(snapshot?.processes.length ?? 0, height - 18 - kumaRows))
 
   return (
     <box

--- a/src/ui/views/Health.tsx
+++ b/src/ui/views/Health.tsx
@@ -10,7 +10,7 @@ import { theme, diskColor } from "../../lib/theme.ts"
 import { formatBytes, bar, formatUptime, sparkline, timeAgo, truncate } from "../../lib/format.ts"
 import { Panel, Spinner, Centered } from "../components.tsx"
 import { StatusBar } from "../StatusBar.tsx"
-import { useStore } from "../store.tsx"
+import { useStore, type KumaDomainStatus } from "../store.tsx"
 import { fetchServerHealth, type HealthSnapshot } from "../../lib/ssh.ts"
 
 const POLL_MS = 2500
@@ -50,7 +50,7 @@ function Gauge({
 }
 
 export function Health() {
-  const { healthServer, setHealthServer, sitesForServer, sshUser } = useStore()
+  const { healthServer, setHealthServer, sitesForServer, sshUser, kumaStatus } = useStore()
   const { height } = useTerminalDimensions()
   const server = healthServer
 
@@ -161,7 +161,7 @@ export function Health() {
           </box>
         </Centered>
       ) : snapshot ? (
-        <HealthBody snapshot={snapshot} history={history} server={server} procRows={procRows} staleError={error} />
+        <HealthBody snapshot={snapshot} history={history} server={server} procRows={procRows} staleError={error} kuma={kumaStatus.get(server.name)} />
       ) : null}
 
       <StatusBar
@@ -182,12 +182,14 @@ function HealthBody({
   server,
   procRows,
   staleError,
+  kuma,
 }: {
   snapshot: HealthSnapshot
   history: number[]
   server: { name: string }
   procRows: number
   staleError: string | null
+  kuma?: KumaDomainStatus
 }) {
   const s = snapshot
   const memPct = s.memTotal > 0 ? (s.memUsed / s.memTotal) * 100 : 0
@@ -258,6 +260,29 @@ function HealthBody({
               )}
             </box>
           </Panel>
+          {kuma && (
+            <Panel title=" Monitor (Uptime Kuma) ">
+              <box style={{ flexDirection: "column" }}>
+                <box style={{ flexDirection: "row", height: 1 }}>
+                  <text content={kuma.up === false ? "○ down" : kuma.up ? "● up" : "· no beats yet"} fg={kuma.up === false ? theme.bad : kuma.up ? theme.good : theme.textFaint} style={{ flexShrink: 0 }} />
+                  {kuma.uptime24 != null && <text content={`   ${(kuma.uptime24 * 100).toFixed(2)}% (24h)`} fg={theme.textDim} wrapMode="none" />}
+                </box>
+                {kuma.responseBeats.length > 1 && (
+                  <box style={{ flexDirection: "row", height: 1 }}>
+                    <text content="response " fg={theme.textDim} style={{ flexShrink: 0 }} />
+                    <text content={sparkline(kuma.responseBeats.slice(-40), 40)} fg={theme.brand} wrapMode="none" style={{ flexShrink: 1 }} />
+                  </box>
+                )}
+                {kuma.loadBeats.length > 1 && (
+                  <box style={{ flexDirection: "row", height: 1 }}>
+                    <text content="load     " fg={theme.textDim} style={{ flexShrink: 0 }} />
+                    <text content={sparkline(kuma.loadBeats.slice(-40), 40)} fg={theme.accent} wrapMode="none" style={{ flexShrink: 1 }} />
+                    {kuma.lastLoad != null && <text content={` ${kuma.lastLoad.toFixed(2)}`} fg={theme.textDim} style={{ flexShrink: 0 }} />}
+                  </box>
+                )}
+              </box>
+            </Panel>
+          )}
           <Panel title=" Top processes " flexGrow={1}>
             <box style={{ flexGrow: 1, flexDirection: "column" }}>
               <box style={{ flexDirection: "row", height: 1 }}>

--- a/src/ui/views/KumaSite.tsx
+++ b/src/ui/views/KumaSite.tsx
@@ -1,16 +1,17 @@
-// Uptime Kuma overlay for a site — opened with `m` in the sites pane.
+// Site monitoring overlay — opened with `m` in the sites pane.
 //
-// Two jobs in one window, taught in context:
-//   1. No Kuma connection yet → a connect form (URL / username / password). The
-//      credential is verified by actually logging in before anything persists;
-//      the minted JWT is stored so later sessions (and 2FA accounts) log in by
-//      token. Env-sourced connections (SPINUP_KUMA_*) skip this form entirely.
-//   2. Connected → monitor setup for THIS site. A vanity site (domain = server
-//      name) gets the full treatment: healthz monitor, load push monitor + the
-//      once-a-minute heartbeat cron, and `R` re-seeds the page first (the upgrade
-//      path for pages published before the health-endpoint feature). A regular
-//      site gets a homepage monitor (up/down + cert expiry) — we never touch a
-//      client site's files.
+// The monitor screen is the default; the Kuma connect form is opt-in (`c`, or
+// pressing `a` while unconnected), so the vanity-page refresh works with no
+// Uptime Kuma at all:
+//   - `R` on a vanity site (domain = server name) re-publishes the embedded page
+//     — the upgrade path for pages seeded by older Spinup versions. Without a
+//     Kuma connection that's ALL it does; with one it also registers the healthz
+//     + load push monitors and installs the heartbeat cron.
+//   - `a` registers monitors for this site (vanity: healthz + load push + cron;
+//     regular site: homepage monitor only — client site files are never touched).
+//   - The connect form verifies by actually logging in before anything persists;
+//     the minted JWT is stored so later sessions (and 2FA accounts) log in by
+//     token. Env-sourced connections (SPINUP_KUMA_*) never see the form.
 
 import { useEffect, useState } from "react"
 import { useKeyboard } from "@opentui/react"
@@ -22,19 +23,20 @@ import { useStore } from "../store.tsx"
 const FIELDS = ["url", "username", "password"] as const
 
 export function KumaSite() {
-  const { kumaSite: site, setKumaSite, kumaConfigured, connectKuma, kumaMonitorFor, kumaOps, startKumaSetup, servers, setInputMode } = useStore()
+  const { kumaSite: site, setKumaSite, kumaConfigured, connectKuma, kumaMonitorFor, kumaOps, startKumaSetup, startVanityReseed, servers, setInputMode } = useStore()
 
   const [draft, setDraft] = useState({ url: "", username: "", password: "" })
   const [fieldIdx, setFieldIdx] = useState(0)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [connectedVersion, setConnectedVersion] = useState<string | null>(null)
+  const [showConnect, setShowConnect] = useState(false)
 
   const server = site ? servers.find((s) => s.id === site.server_id) : undefined
   const isVanity = !!site && !!server && server.name === site.domain
   const registered = site ? kumaMonitorFor(site.domain) : null
   const op = site ? kumaOps.get(site.id) : undefined
-  const connecting = !kumaConfigured && !connectedVersion
+  const connecting = showConnect && !kumaConfigured
 
   // While the connect form is up, its inputs own the keyboard (suppresses the
   // global single-key shortcuts); cleared on connect/close.
@@ -60,18 +62,20 @@ export function KumaSite() {
       setBusy(false)
       if (r.ok) {
         setConnectedVersion(r.version ?? "connected")
+        setShowConnect(false)
         setInputMode(false)
       } else setError(r.error)
     })
   }
 
   useKeyboard((key) => {
-    const name = key.name ?? ""
+    const raw = key.name ?? ""
+    const name = key.shift && raw.length === 1 ? raw.toUpperCase() : raw
     if (connecting) {
       // The focused <input> consumes printable keys; only navigation reaches us.
       if (name === "escape") {
         if (busy) return
-        return close()
+        return setShowConnect(false) // back to the monitor screen, not out
       }
       if (name === "return") {
         if (busy) return
@@ -82,8 +86,15 @@ export function KumaSite() {
       if (name === "up") return setFieldIdx((i) => Math.max(i - 1, 0))
       return
     }
-    if (name === "a" && site && op?.status !== "running") return startKumaSetup(site)
-    if (name === "R" && isVanity && site && op?.status !== "running") return startKumaSetup(site, { reseed: true })
+    if (name === "c" && !kumaConfigured) return setShowConnect(true)
+    if (name === "a" && site && op?.status !== "running") {
+      if (!kumaConfigured) return setShowConnect(true) // monitors need a connection
+      return startKumaSetup(site)
+    }
+    if (name === "R" && isVanity && site && op?.status !== "running") {
+      // Connected: re-publish + monitors + cron. Unconnected: just the page.
+      return kumaConfigured ? startKumaSetup(site, { reseed: true }) : startVanityReseed(site)
+    }
     if (name === "escape" || name === "q") return close()
   })
 
@@ -92,7 +103,7 @@ export function KumaSite() {
   return (
     <box style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", flexDirection: "column", backgroundColor: theme.bg, zIndex: 215 }}>
       <box style={{ flexDirection: "row", height: 1, backgroundColor: theme.bgAlt, paddingLeft: 1, paddingRight: 1, alignItems: "center" }}>
-        <text content="◉ Uptime Kuma  " fg={theme.brand} style={{ flexShrink: 0 }} />
+        <text content="◉ Site monitoring  " fg={theme.brand} style={{ flexShrink: 0 }} />
         <text content={site.domain} fg={theme.text} wrapMode="none" style={{ flexShrink: 1 }} />
       </box>
 
@@ -134,7 +145,7 @@ export function KumaSite() {
           ) : error ? (
             <text content={`✕ ${error}`} fg={theme.bad} wrapMode="none" />
           ) : (
-            <text content="⏎ next field / connect · Esc cancel" fg={theme.textFaint} wrapMode="none" />
+            <text content="⏎ next field / connect · Esc back" fg={theme.textFaint} wrapMode="none" />
           )}
         </box>
       </Panel>
@@ -153,6 +164,7 @@ export function KumaSite() {
           )}
           <Field label="Site" value={site!.domain} />
           <Field label="Kind" value={isVanity ? "vanity page (full server monitoring)" : "site homepage (up/down + cert expiry)"} />
+          <Field label="Kuma" value={kumaConfigured ? "connected" : "not connected · c"} valueColor={kumaConfigured ? theme.good : theme.textFaint} />
           <Field label="Monitors" value={registered ? `registered${registered.pushId ? " (healthz + load push)" : ""}` : "not registered yet"} />
           <box style={{ height: 1 }} />
           {op?.status === "running" ? (
@@ -166,12 +178,19 @@ export function KumaSite() {
             <text content={`✓ ${op.detail}`} fg={theme.good} />
           ) : isVanity ? (
             <>
-              <text content="a — register monitors (healthz + load push) & install the cron" fg={theme.textDim} wrapMode="none" />
-              <text content="R — also re-publish the page first (pages seeded before the" fg={theme.textDim} wrapMode="none" />
-              <text content="    health-endpoint feature need this once)" fg={theme.textFaint} wrapMode="none" />
+              <text
+                content={kumaConfigured ? "R — re-publish the page, register monitors & install the cron" : "R — re-publish the page (current version, health endpoints)"}
+                fg={theme.textDim}
+                wrapMode="none"
+              />
+              <text
+                content={kumaConfigured ? "a — register monitors & cron without touching the page" : "a — register Kuma monitors (connects Uptime Kuma first)"}
+                fg={theme.textDim}
+                wrapMode="none"
+              />
             </>
           ) : (
-            <text content="a — register a homepage monitor in Uptime Kuma" fg={theme.textDim} wrapMode="none" />
+            <text content={kumaConfigured ? "a — register a homepage monitor in Uptime Kuma" : "a — register a homepage monitor (connects Uptime Kuma first)"} fg={theme.textDim} wrapMode="none" />
           )}
         </box>
       </Panel>
@@ -179,10 +198,12 @@ export function KumaSite() {
   }
 
   function hints() {
-    if (connecting) return [{ key: "⏎", label: "next / connect" }, { key: "esc", label: "cancel" }]
+    if (connecting) return [{ key: "⏎", label: "next / connect" }, { key: "esc", label: "back" }]
     if (op?.status === "running") return [{ key: "esc", label: "background" }]
-    const base = [{ key: "a", label: registered ? "repair monitors" : "add monitors" }]
-    if (isVanity) base.push({ key: "R", label: "re-seed + monitors" })
+    const base: { key: string; label: string }[] = []
+    if (isVanity) base.push({ key: "R", label: kumaConfigured ? "refresh page + monitors" : "refresh page" })
+    base.push({ key: "a", label: registered ? "repair monitors" : "add monitors" })
+    if (!kumaConfigured) base.push({ key: "c", label: "connect Kuma" })
     return [...base, { key: "esc", label: "close" }]
   }
 }

--- a/src/ui/views/KumaSite.tsx
+++ b/src/ui/views/KumaSite.tsx
@@ -19,6 +19,7 @@ import { theme } from "../../lib/theme.ts"
 import { Panel, Centered, Field, SecretInput, Spinner } from "../components.tsx"
 import { StatusBar } from "../StatusBar.tsx"
 import { useStore } from "../store.tsx"
+import { isVanityPair } from "../../lib/vanitySite.ts"
 
 const BASE_FIELDS = ["url", "username", "password"] as const
 // Fixed input width: the panel body is 66 wide, the label gutter is 12 ("❯ " +
@@ -41,10 +42,13 @@ export function KumaSite() {
   const fields: string[] = needsTwofa ? [...BASE_FIELDS, "2FA code"] : [...BASE_FIELDS]
 
   const server = site ? servers.find((s) => s.id === site.server_id) : undefined
-  const isVanity = !!site && !!server && server.name === site.domain
+  const isVanity = !!site && !!server && isVanityPair(site.domain, server.name)
   const registered = site ? kumaMonitorFor(site.domain) : null
   const op = site ? kumaOps.get(site.id) : undefined
-  const connecting = showConnect && !kumaConfigured
+  // Not gated on kumaConfigured: `c` must also work as a RE-connect (e.g. the
+  // stored JWT went stale after a Kuma password change on a 2FA account —
+  // without this the only fix would be hand-editing config.json).
+  const connecting = showConnect
 
   // While the connect form is up, its inputs own the keyboard (suppresses the
   // global single-key shortcuts); cleared on connect/close.
@@ -108,7 +112,7 @@ export function KumaSite() {
       if (name === "up") return setFieldIdx((i) => Math.max(i - 1, 0))
       return
     }
-    if (name === "c" && !kumaConfigured) return setShowConnect(true)
+    if (name === "c") return setShowConnect(true)
     if (name === "a" && site && op?.status !== "running") {
       if (!kumaConfigured) return setShowConnect(true) // monitors need a connection
       return startKumaSetup(site)
@@ -197,7 +201,7 @@ export function KumaSite() {
           )}
           <Field label="Site" value={site!.domain} />
           <Field label="Kind" value={isVanity ? "vanity page (full server monitoring)" : "site homepage (up/down + cert expiry)"} />
-          <Field label="Kuma" value={kumaConfigured ? "connected" : "not connected · c"} valueColor={kumaConfigured ? theme.good : theme.textFaint} />
+          <Field label="Kuma" value={kumaConfigured ? "connected · c to reconnect" : "not connected · c"} valueColor={kumaConfigured ? theme.good : theme.textFaint} />
           <Field label="Monitors" value={registered ? `registered${registered.pushId ? " (healthz + load push)" : ""}` : "not registered yet"} />
           <box style={{ height: 1 }} />
           {op?.status === "running" ? (
@@ -236,7 +240,7 @@ export function KumaSite() {
     const base: { key: string; label: string }[] = []
     if (isVanity) base.push({ key: "R", label: kumaConfigured ? "refresh page + monitors" : "refresh page" })
     base.push({ key: "a", label: registered ? "repair monitors" : "add monitors" })
-    if (!kumaConfigured) base.push({ key: "c", label: "connect Kuma" })
+    base.push({ key: "c", label: kumaConfigured ? "reconnect Kuma" : "connect Kuma" })
     return [...base, { key: "esc", label: "close" }]
   }
 }

--- a/src/ui/views/KumaSite.tsx
+++ b/src/ui/views/KumaSite.tsx
@@ -20,7 +20,7 @@ import { Panel, Centered, Field, SecretInput, Spinner } from "../components.tsx"
 import { StatusBar } from "../StatusBar.tsx"
 import { useStore } from "../store.tsx"
 
-const FIELDS = ["url", "username", "password"] as const
+const BASE_FIELDS = ["url", "username", "password"] as const
 
 export function KumaSite() {
   const { kumaSite: site, setKumaSite, kumaConfigured, connectKuma, kumaMonitorFor, kumaOps, startKumaSetup, startVanityReseed, servers, setInputMode } = useStore()
@@ -31,6 +31,11 @@ export function KumaSite() {
   const [error, setError] = useState<string | null>(null)
   const [connectedVersion, setConnectedVersion] = useState<string | null>(null)
   const [showConnect, setShowConnect] = useState(false)
+  // 2FA: revealed only after Kuma answers `tokenRequired` to a correct password.
+  // The code is used once — the stored JWT covers every later login.
+  const [needsTwofa, setNeedsTwofa] = useState(false)
+  const [twofa, setTwofa] = useState("")
+  const fields: string[] = needsTwofa ? [...BASE_FIELDS, "2FA code"] : [...BASE_FIELDS]
 
   const server = site ? servers.find((s) => s.id === site.server_id) : undefined
   const isVanity = !!site && !!server && server.name === site.domain
@@ -53,18 +58,32 @@ export function KumaSite() {
   const verify = () => {
     if (busy) return
     if (!draft.url.trim() || !draft.username.trim() || !draft.password) {
-      setError("All three fields are needed.")
+      setError("URL, username and password are all needed.")
+      return
+    }
+    if (needsTwofa && !twofa.trim()) {
+      setError("Enter the current 6-digit code from your authenticator.")
       return
     }
     setBusy(true)
     setError(null)
-    void connectKuma(draft).then((r) => {
+    void connectKuma(draft, needsTwofa ? twofa.trim() : undefined).then((r) => {
       setBusy(false)
       if (r.ok) {
         setConnectedVersion(r.version ?? "connected")
         setShowConnect(false)
         setInputMode(false)
-      } else setError(r.error)
+        return
+      }
+      if (r.tokenRequired && !needsTwofa) {
+        // Password was right; the account wants a TOTP. Reveal the field and
+        // land the cursor on it.
+        setNeedsTwofa(true)
+        setFieldIdx(BASE_FIELDS.length)
+        setError("2FA is on — enter the current code (needed once; a token is stored after).")
+        return
+      }
+      setError(r.error)
     })
   }
 
@@ -79,10 +98,10 @@ export function KumaSite() {
       }
       if (name === "return") {
         if (busy) return
-        if (fieldIdx < FIELDS.length - 1) return setFieldIdx(fieldIdx + 1)
+        if (fieldIdx < fields.length - 1) return setFieldIdx(fieldIdx + 1)
         return verify()
       }
-      if (name === "tab" || name === "down") return setFieldIdx((i) => Math.min(i + 1, FIELDS.length - 1))
+      if (name === "tab" || name === "down") return setFieldIdx((i) => Math.min(i + 1, fields.length - 1))
       if (name === "up") return setFieldIdx((i) => Math.max(i - 1, 0))
       return
     }
@@ -120,15 +139,23 @@ export function KumaSite() {
           <text content="One-time setup: your Uptime Kuma instance's URL and login." fg={theme.textDim} wrapMode="none" />
           <text content="Verified by logging in before anything is saved (config, 0600)." fg={theme.textFaint} wrapMode="none" />
           <box style={{ height: 1 }} />
-          {FIELDS.map((f, i) => (
+          {fields.map((f, i) => (
             <box key={f} style={{ flexDirection: "row" }}>
               <text content={`${i === fieldIdx ? "❯" : " "} ${f.padEnd(9)}`} fg={i === fieldIdx ? theme.brand : theme.textDim} style={{ flexShrink: 0 }} />
               {f === "password" ? (
                 <SecretInput focused={i === fieldIdx && !busy} value={draft.password} onChange={(v: string) => setDraft((d) => ({ ...d, password: v }))} onSubmit={verify} />
+              ) : f === "2FA code" ? (
+                <input
+                  focused={i === fieldIdx && !busy}
+                  value={twofa}
+                  onInput={setTwofa}
+                  placeholder="123456"
+                  style={{ backgroundColor: theme.bgAlt, focusedBackgroundColor: theme.bgAlt, textColor: theme.text }}
+                />
               ) : (
                 <input
                   focused={i === fieldIdx && !busy}
-                  value={draft[f]}
+                  value={draft[f as "url" | "username"]}
                   onInput={(v: string) => setDraft((d) => ({ ...d, [f]: v }))}
                   placeholder={f === "url" ? "https://kuma.example.com" : ""}
                   style={{ backgroundColor: theme.bgAlt, focusedBackgroundColor: theme.bgAlt, textColor: theme.text }}

--- a/src/ui/views/KumaSite.tsx
+++ b/src/ui/views/KumaSite.tsx
@@ -21,6 +21,9 @@ import { StatusBar } from "../StatusBar.tsx"
 import { useStore } from "../store.tsx"
 
 const BASE_FIELDS = ["url", "username", "password"] as const
+// Fixed input width: the panel body is 66 wide, the label gutter is 12 ("❯ " +
+// padEnd(10)), so 52 fills the row — roomy enough that long URLs stay visible.
+const INPUT_W = 52
 
 export function KumaSite() {
   const { kumaSite: site, setKumaSite, kumaConfigured, connectKuma, kumaMonitorFor, kumaOps, startKumaSetup, startVanityReseed, servers, setInputMode } = useStore()
@@ -140,27 +143,30 @@ export function KumaSite() {
           <text content="Verified by logging in before anything is saved (config, 0600)." fg={theme.textFaint} wrapMode="none" />
           <box style={{ height: 1 }} />
           {fields.map((f, i) => (
-            <box key={f} style={{ flexDirection: "row" }}>
-              <text content={`${i === fieldIdx ? "❯" : " "} ${f.padEnd(9)}`} fg={i === fieldIdx ? theme.brand : theme.textDim} style={{ flexShrink: 0 }} />
-              {f === "password" ? (
-                <SecretInput focused={i === fieldIdx && !busy} value={draft.password} onChange={(v: string) => setDraft((d) => ({ ...d, password: v }))} onSubmit={verify} />
-              ) : f === "2FA code" ? (
-                <input
-                  focused={i === fieldIdx && !busy}
-                  value={twofa}
-                  onInput={setTwofa}
-                  placeholder="123456"
-                  style={{ backgroundColor: theme.bgAlt, focusedBackgroundColor: theme.bgAlt, textColor: theme.text }}
-                />
-              ) : (
-                <input
-                  focused={i === fieldIdx && !busy}
-                  value={draft[f as "url" | "username"]}
-                  onInput={(v: string) => setDraft((d) => ({ ...d, [f]: v }))}
-                  placeholder={f === "url" ? "https://kuma.example.com" : ""}
-                  style={{ backgroundColor: theme.bgAlt, focusedBackgroundColor: theme.bgAlt, textColor: theme.text }}
-                />
-              )}
+            <box key={f} style={{ flexDirection: "column" }}>
+              <box style={{ flexDirection: "row" }}>
+                <text content={`${i === fieldIdx ? "❯" : " "} ${f.padEnd(10)}`} fg={i === fieldIdx ? theme.brand : theme.textDim} style={{ flexShrink: 0 }} />
+                {f === "password" ? (
+                  <SecretInput focused={i === fieldIdx && !busy} value={draft.password} onChange={(v: string) => setDraft((d) => ({ ...d, password: v }))} onSubmit={verify} width={INPUT_W} />
+                ) : f === "2FA code" ? (
+                  <input
+                    focused={i === fieldIdx && !busy}
+                    value={twofa}
+                    onInput={setTwofa}
+                    placeholder="123456"
+                    style={{ width: INPUT_W, backgroundColor: theme.bgAlt, focusedBackgroundColor: theme.bgAlt, textColor: theme.text }}
+                  />
+                ) : (
+                  <input
+                    focused={i === fieldIdx && !busy}
+                    value={draft[f as "url" | "username"]}
+                    onInput={(v: string) => setDraft((d) => ({ ...d, [f]: v }))}
+                    placeholder={f === "url" ? "https://kuma.example.com" : ""}
+                    style={{ width: INPUT_W, backgroundColor: theme.bgAlt, focusedBackgroundColor: theme.bgAlt, textColor: theme.text }}
+                  />
+                )}
+              </box>
+              {i < fields.length - 1 && <box style={{ height: 1 }} />}
             </box>
           ))}
           <box style={{ height: 1 }} />

--- a/src/ui/views/ServerActions.tsx
+++ b/src/ui/views/ServerActions.tsx
@@ -247,6 +247,9 @@ export function ServerActions() {
                     )}
                   </>
                 )}
+                {store.kumaConfigured && (
+                  <text content="Uptime Kuma monitors enter a maintenance window — no false alerts." fg={theme.textFaint} wrapMode="none" />
+                )}
               </>
             ) : (
               <text content="Brief interruption to that one service; sites stay up otherwise." fg={theme.textDim} wrapMode="none" />


### PR DESCRIPTION
## What

PR 3 of 3 (stacked on #15 → #14).

- **Store poll loop** (60s): one short-lived socket per tick; `KumaClient` captures the post-login `heartbeatList`/`uptime` event burst so a single connection yields status + beat history for every registered monitor. Kuma unreachable = keep last snapshot, retry next tick.
- **Health view**: new "Monitor (Uptime Kuma)" panel — up/down, 24h uptime %, response-time sparkline, and a server-load sparkline fed by the heartbeat cron (persistent history the view-local SSH CPU buffer can't provide).
- **Details pane**: per-site Monitor row; **Header**: "▼ N monitors down" badge (silent when all up).
- **Reboot maintenance windows**: `startServerOp` wraps the server's registered monitors in a manual Kuma maintenance window before firing the reboot and deletes it when the event settles or fails. Best-effort both ways — Kuma being down never blocks a reboot. The confirm screen states it.
- **Float-ping hardening**: verified live that some Kuma builds validate push `ping` as an integer and silently store null for floats — the cron now pushes load ×100 as an integer (164 = load 1.64, described on the monitor) and Spinup's views scale back.

## Testing

- Snapshot pipeline against the live local Kuma: `up=true` from its real polling of the `web1.spinuptui.com` healthz endpoint, genuine response-time beats (~215ms), centiload beats scaled back correctly (`lastLoad: 0.08`). **SNAPSHOT PASS**.
- Maintenance add/assign/delete e2e'd in PR 2's client suite; the reboot wiring is best-effort try/catch around those calls (a live reboot acceptance test can follow on the test box).
- `uptime24` is null on the dev build (it emits uptime per-beat, not on login); UI hides the stat when null — will confirm on the real instance.
- PTY frame reconstruction shows the Monitor detail row + `m` hint; typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYCqn15ypvbEjBFdzpd13u