### PR TITLE
Rotate monitoring secrets in place + vanity-site marker in Servers tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+### Added
+- **Rotate monitoring secrets (`r` in the `m` overlay, vanity sites).** Made for
+  screencasts: record with the push URL or metrics-JSON key on screen, then press
+  `r` right after and both secrets die. A new push token is edited into the
+  *existing* Kuma push monitor — same monitor row, so heartbeat history, uptime
+  stats and notification wiring all survive (no delete/re-create) — the heartbeat
+  cron is rewritten to the new URL over SSH, a new health key is re-seeded into
+  the vanity page, and any Kuma monitor URL still carrying the old key (the
+  JSON-query recipe) is re-keyed automatically. Confirm-gated; works without a
+  Kuma connection too (then just the health key rotates).
+- **Vanity sites stand out in the Servers tab.** The server's own vanity/health
+  page is marked with a `⌂` glyph and brand-green tint in the sites list — with
+  servers named like domains (the vanity convention), it otherwise hides among
+  regular sites.
+
 ## [0.14.0] - 2026-07-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ Once you're in, the dashboard looks like this:
   Health view, and reboots automatically open a Kuma maintenance window so
   planned downtime never pages you. Regular sites get a homepage monitor
   (up/down + cert-expiry alerts) — client site files are never touched.
+  Showed a push URL or health key on a screencast? `r` in the `m` overlay
+  **rotates both secrets in place** — the old ones die immediately, the Kuma
+  monitor (and its history) survives. Vanity sites are marked `⌂` in the
+  Servers tab so they never hide among domain-named servers' sites.
   (See `docs/uptime-kuma.md` for recipes.)
 - **Completion toasts** — background writes that take a while (a PHP upgrade, a
   server reboot/restart, resolving your fleet's DNS) raise a non-focus-stealing
@@ -284,7 +288,7 @@ These can be set in `config.json` or via an environment variable:
 | `u` | Upgrade a site's PHP version (Servers / Stacks / Search; needs a Read/Write token) |
 | `H` | Enable / disable HTTPS on a site (Servers / Stacks / Search; needs a Read/Write token) |
 | `P` | Purge a site's page cache + object cache (Servers / Stacks / Search; needs a Read/Write token) |
-| `m` | Site monitoring via Uptime Kuma — connect, add monitors, refresh a vanity page (Servers tab, sites pane) |
+| `m` | Site monitoring via Uptime Kuma — connect, add monitors, refresh a vanity page, rotate secrets (Servers tab, sites pane) |
 | `a` | Server actions: reboot / restart a service (Servers / Search; needs a Read/Write token) |
 | `c` | Create a new server (Servers tab; needs a Read/Write token) |
 | `V` | Add a vanity site at the server's own hostname — DNS + site + HTTPS + SSH-key handoff (Servers tab; offered when no hostname site exists; needs a Read/Write token) |

--- a/docs/uptime-kuma.md
+++ b/docs/uptime-kuma.md
@@ -95,3 +95,25 @@ Connect your Kuma instance once and Spinup registers monitors itself:
 
 Spinup adopts same-named monitors rather than duplicating them, so hand-made
 monitors survive; a hand-made push monitor keeps its token (the cron adopts it).
+
+## Rotating leaked secrets (screencast cleanup)
+
+Two secrets can leak by simply being on screen: the push monitor's URL (Kuma
+shows it in full on the monitor page) and the health key in a
+`?format=json&key=…` monitor URL. Neither lets anyone *read* your metrics —
+the push token only lets a sender **write** beats (fake "up"s masking a real
+outage), and the health key gates the metrics JSON. If either has been shown
+in a recording or screenshot, press **`r` in the `m` overlay** right after:
+
+- A fresh push token is **edited into the existing push monitor** — same
+  monitor row, so heartbeat history, uptime stats, and notification wiring
+  survive (nothing is deleted or re-created) — and the heartbeat cron is
+  rewritten to the new URL. The old push URL stops accepting beats immediately.
+- A fresh health key is re-seeded into the vanity page (the old key starts
+  returning `403`), and any Kuma monitor whose URL still embeds the old key
+  (recipe 4 above) is re-keyed automatically.
+
+Rotation is confirm-gated and works without a Kuma connection too — then only
+the health key rotates, and the push token is left for when you connect.
+Expect at most one or two missed heartbeats during the swap; the push
+monitor's retries absorb them without alerting.

--- a/src/lib/uptimeKuma.ts
+++ b/src/lib/uptimeKuma.ts
@@ -50,6 +50,7 @@ interface Ack {
   maintenanceID?: number
   token?: string
   tokenRequired?: boolean
+  monitor?: KumaMonitor // getMonitor's payload
   data?: unknown
 }
 
@@ -245,6 +246,21 @@ export class KumaClient {
     return res.monitorID
   }
 
+  // The full monitor row (getMonitor returns more fields than the monitorList
+  // broadcast) — the shape editMonitor expects back, so rotate flows round-trip it.
+  async getMonitor(id: number): Promise<KumaMonitor> {
+    const res = await this.must("getMonitor", id)
+    if (!res.monitor) throw new KumaError("Kuma didn't return the monitor.")
+    return res.monitor
+  }
+
+  // Save changes to an existing monitor IN PLACE — same id, so heartbeat history,
+  // uptime stats and notification wiring all survive. Callers pass a full monitor
+  // object from getMonitor (Kuma's own edit dialog does the same round-trip).
+  async editMonitor(monitor: Record<string, unknown>): Promise<void> {
+    await this.must("editMonitor", monitor)
+  }
+
   async pauseMonitor(id: number): Promise<void> {
     await this.must("pauseMonitor", id)
   }
@@ -364,6 +380,29 @@ export async function registerMonitors(
     })(),
   ])
   return { healthId, pushId, pushToken: opts.wantPush ? pushToken : undefined }
+}
+
+// Swap a push monitor's token in place — the old push URL stops accepting beats
+// the moment this lands, but the monitor row (and its history) is untouched.
+export async function rotatePushToken(kuma: KumaClient, pushId: number, newToken: string): Promise<void> {
+  const mon = await kuma.getMonitor(pushId)
+  await kuma.editMonitor({ ...mon, pushToken: newToken })
+}
+
+// Repoint any monitor whose URL embeds the old health key (the JSON-query recipe
+// in docs/uptime-kuma.md bakes it into the query string) at the new key, so a
+// key rotation doesn't silently kill hand-made threshold monitors. Returns how
+// many were updated. Keys shorter than 8 chars are refused — too much risk of
+// matching an unrelated URL fragment.
+export async function retargetHealthKeyMonitors(kuma: KumaClient, oldKey: string, newKey: string): Promise<number> {
+  if (oldKey.length < 8) return 0
+  const monitors = await kuma.getMonitors()
+  const hits = monitors.filter((m) => typeof m.url === "string" && m.url.includes(oldKey))
+  for (const m of hits) {
+    const full = await kuma.getMonitor(m.id)
+    await kuma.editMonitor({ ...full, url: String(full.url).split(oldKey).join(newKey) })
+  }
+  return hits.length
 }
 
 // Connect → login → run → always disconnect. Returns the (possibly refreshed) JWT

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -41,7 +41,7 @@ import {
 import { ProvidersCache, type VerifiedConn } from "../lib/providersCache.ts"
 import { recordProviderFor, type DnsRecord, type RecordResult } from "../lib/dnsRecords.ts"
 import { deriveSiteUser, seedVanityIndex, seedVanityPushCron, aRecordResolves, isVanityPair } from "../lib/vanitySite.ts"
-import { withKuma, KumaClient, registerMonitors, LOAD_PUSH_SCALE } from "../lib/uptimeKuma.ts"
+import { withKuma, KumaClient, registerMonitors, genPushToken, rotatePushToken, retargetHealthKeyMonitors, LOAD_PUSH_SCALE } from "../lib/uptimeKuma.ts"
 import type { StoredProviders } from "../config.ts"
 import { fetchRebootInfo, grantSiteSshKey, revokeSiteSshKey, verifySudo, ensureSpinupKey, listPersonalKeys, keyBody, type RebootInfo } from "../lib/ssh.ts"
 import { estimateSourceSiteSizes, runStandardWpPull, runBedrockPull, runFilesOnlyPull, verifyClone, verifyFilesClone, type SudoCtx, type CloneStage, type CloneExecRecord, type VerifyResult as CloneVerifyResult } from "../lib/serverClone.ts"
@@ -523,6 +523,7 @@ interface StoreValue extends DataState {
   kumaMonitorFor: (domain: string) => KumaMonitorRef | null // monitors Spinup registered for a domain
   startKumaSetup: (site: Site, opts?: { reseed?: boolean }) => void
   startVanityReseed: (site: Site) => void // refresh an existing vanity page (no Kuma needed)
+  startKumaRotate: (site: Site) => void // rotate the push token + health key (vanity; old URLs die immediately)
   kumaStatus: Map<string, KumaDomainStatus> // live per-domain status, refreshed every minute
   // Clone a server to a new server (item 5). `cloneServer` opens the wizard; `cloneJob`
   // is the (Plan-draft then running) job whose heavy work lives in its `sites[]` vector.
@@ -2549,6 +2550,19 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     return key
   }, [])
 
+  // Deliberately break the stable-key rule above: mint a NEW key (the rotate
+  // action's whole point — a key shown on a screencast must stop working).
+  // Callers re-seed the page and retarget key-bearing monitor URLs afterwards.
+  const rotateVanityHealthKey = useCallback((domain: string): { oldKey: string | null; newKey: string } => {
+    const keys = { ...cfgRef.current.vanityHealthKeys }
+    const oldKey = keys[domain] ?? null
+    const newKey = crypto.randomUUID().replace(/-/g, "")
+    keys[domain] = newKey
+    cfgRef.current.vanityHealthKeys = keys
+    void saveConfig({ vanityHealthKeys: keys })
+    return { oldKey, newKey }
+  }, [])
+
   // Keep the Kuma JWT fresh so later sessions log in by token (2FA-friendly).
   // The env-sourced connection is never overwritten.
   const persistKumaAuth = useCallback((conn: UptimeKumaConn, jwt: string) => {
@@ -3054,6 +3068,60 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       void run()
     },
     [servers, reseedVanityPage, persistKumaAuth, persistKumaMonitors],
+  )
+
+  // Rotate a vanity site's monitoring secrets — the "clean up after a screencast"
+  // action. A new push token is edited into the EXISTING push monitor (same row:
+  // history, uptime stats and notifications survive), the heartbeat cron is
+  // rewritten to the new URL, a new health key is re-seeded into the page, and any
+  // monitor URL still carrying the old key is retargeted. Each old secret is dead
+  // the moment its step lands. Works without a Kuma connection too — then only
+  // the health key rotates (there's no push monitor to edit).
+  const startKumaRotate = useCallback(
+    (site: Site) => {
+      const server = servers.find((s) => s.id === site.server_id)
+      if (!server || !isVanityPair(site.domain, server.name)) return
+      const setOp = (op: KumaOp) => setKumaOps((prev) => new Map(prev).set(site.id, op))
+      if (!server.ip_address) {
+        setOp({ status: "error", detail: "", error: "The server has no IP address yet — wait for provisioning to finish." })
+        return
+      }
+      const conn = cfgRef.current.uptimeKuma
+      const domain = site.domain
+      const known = cfgRef.current.kumaMonitors[domain] ?? {}
+      const ssh = { host: server.ip_address ?? "", user: site.site_user ?? deriveSiteUser(domain), port: server.ssh_port ?? null }
+      const run = async () => {
+        try {
+          setOp({ status: "running", detail: "Minting a new health key + re-publishing the page…" })
+          const { oldKey, newKey } = rotateVanityHealthKey(domain)
+          const seed = await seedVanityIndex({ ...ssh, domain, publicFolder: site.public_folder, healthKey: newKey })
+          if (!seed.ok) throw new Error(seed.error || "Couldn't re-seed the page over SSH.")
+          if (!conn || isDevMode() || known.pushId == null) {
+            setOp({
+              status: "done",
+              detail: conn && !isDevMode() ? "Health key rotated (no push monitor registered — a adds one)." : "Health key rotated. Connect Uptime Kuma to rotate the push token too.",
+            })
+            return
+          }
+          setOp({ status: "running", detail: "Rotating the push token in Uptime Kuma…" })
+          const newToken = genPushToken()
+          const { result: retargeted, jwt } = await withKuma(conn, async (kuma) => {
+            await rotatePushToken(kuma, known.pushId!, newToken)
+            return oldKey ? retargetHealthKeyMonitors(kuma, oldKey, newKey) : 0
+          })
+          persistKumaAuth(conn, jwt)
+          persistKumaMonitors(domain, { ...known, pushToken: newToken })
+          setOp({ status: "running", detail: "Rewriting the heartbeat cron…" })
+          const cron = await seedVanityPushCron({ ...ssh, kumaUrl: conn.url, pushToken: newToken })
+          if (!cron.ok) throw new Error(cron.error || "Couldn't rewrite the heartbeat cron.")
+          setOp({ status: "done", detail: `Secrets rotated — the old push URL & health key are dead${retargeted ? ` (${retargeted} monitor URL${retargeted === 1 ? "" : "s"} re-keyed)` : ""}.` })
+        } catch (err) {
+          setOp({ status: "error", detail: "", error: (err as Error).message })
+        }
+      }
+      void run()
+    },
+    [servers, rotateVanityHealthKey, persistKumaAuth, persistKumaMonitors],
   )
 
   // ---- Clone a server to a new server (item 5) -----------------------------
@@ -3790,6 +3858,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     kumaMonitorFor,
     startKumaSetup,
     startVanityReseed,
+    startKumaRotate,
     kumaStatus,
     cloneServer,
     setCloneServer,

--- a/src/ui/views/Browser.tsx
+++ b/src/ui/views/Browser.tsx
@@ -17,6 +17,7 @@ import { StatusBar } from "../StatusBar.tsx"
 import { openUrl } from "../../lib/open.ts"
 import { serverWebUrl, siteWebUrl } from "../../lib/spinupweb.ts"
 import { useStore, isServerOpInFlight } from "../store.tsx"
+import { isVanityPair } from "../../lib/vanitySite.ts"
 
 type Focus = "servers" | "sites"
 
@@ -293,10 +294,18 @@ export function Browser({ rows }: { rows: number }) {
               const updates = (s.wp_plugin_updates || 0) + (s.wp_theme_updates || 0) + (s.wp_core_update ? 1 : 0)
               const stack = classifyStack(s)
               const keyKinds = grantedKeyKinds(s.id)
+              // The server's own vanity/health page blends in perfectly when servers
+              // are named like domains — mark it (⌂ + brand tint) so it can't hide.
+              const vanity = !!server && isVanityPair(s.domain, server.name)
               return (
                 <>
                   <text content={statusDot(s.status) + " "} fg={statusColor(s.status)} style={{ flexShrink: 0 }} />
-                  <text content={truncate(s.domain, 40)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
+                  <text
+                    content={truncate((vanity ? "⌂ " : "") + s.domain, 40)}
+                    fg={selected ? theme.text : vanity ? theme.brand : theme.textDim}
+                    wrapMode="none"
+                    style={{ flexGrow: 1, flexShrink: 1 }}
+                  />
                   <SiteMetaCell linked={localLinks.has(s.id)} updates={updates} personalKey={keyKinds.personal > 0} machineKey={keyKinds.machine > 0} selected={selected} />
                   <text content={stackTag(stack) + " "} fg={stackColor(stack, selected)} style={{ flexShrink: 0 }} />
                   <PhpVersionCell version={s.php_version} upgrade={phpUpgrades.get(s.id)} selected={selected} />

--- a/src/ui/views/KumaSite.tsx
+++ b/src/ui/views/KumaSite.tsx
@@ -9,6 +9,9 @@
 //     + load push monitors and installs the heartbeat cron.
 //   - `a` registers monitors for this site (vanity: healthz + load push + cron;
 //     regular site: homepage monitor only — client site files are never touched).
+//   - `r` (vanity, confirm-gated) rotates the monitoring secrets: new push token
+//     edited into the existing monitor (history kept), cron rewritten, new health
+//     key re-seeded — so secrets shown on a screencast can be killed right after.
 //   - The connect form verifies by actually logging in before anything persists;
 //     the minted JWT is stored so later sessions (and 2FA accounts) log in by
 //     token. Env-sourced connections (SPINUP_KUMA_*) never see the form.
@@ -27,7 +30,7 @@ const BASE_FIELDS = ["url", "username", "password"] as const
 const INPUT_W = 52
 
 export function KumaSite() {
-  const { kumaSite: site, setKumaSite, kumaConfigured, connectKuma, kumaMonitorFor, kumaOps, startKumaSetup, startVanityReseed, servers, setInputMode } = useStore()
+  const { kumaSite: site, setKumaSite, kumaConfigured, connectKuma, kumaMonitorFor, kumaOps, startKumaSetup, startVanityReseed, startKumaRotate, servers, setInputMode } = useStore()
 
   const [draft, setDraft] = useState({ url: "", username: "", password: "" })
   const [fieldIdx, setFieldIdx] = useState(0)
@@ -35,6 +38,9 @@ export function KumaSite() {
   const [error, setError] = useState<string | null>(null)
   const [connectedVersion, setConnectedVersion] = useState<string | null>(null)
   const [showConnect, setShowConnect] = useState(false)
+  // `r` arms a confirm (rotation kills the live push URL / health key the moment
+  // it fires — never do that on a stray keypress); y/⏎ fires, Esc disarms.
+  const [confirmRotate, setConfirmRotate] = useState(false)
   // 2FA: revealed only after Kuma answers `tokenRequired` to a correct password.
   // The code is used once — the stored JWT covers every later login.
   const [needsTwofa, setNeedsTwofa] = useState(false)
@@ -112,7 +118,16 @@ export function KumaSite() {
       if (name === "up") return setFieldIdx((i) => Math.max(i - 1, 0))
       return
     }
+    if (confirmRotate) {
+      if ((name === "y" || name === "return") && site) {
+        setConfirmRotate(false)
+        return startKumaRotate(site)
+      }
+      if (name === "escape" || name === "n" || name === "q") return setConfirmRotate(false)
+      return
+    }
     if (name === "c") return setShowConnect(true)
+    if (name === "r" && isVanity && site && op?.status !== "running") return setConfirmRotate(true)
     if (name === "a" && site && op?.status !== "running") {
       if (!kumaConfigured) return setShowConnect(true) // monitors need a connection
       return startKumaSetup(site)
@@ -204,7 +219,15 @@ export function KumaSite() {
           <Field label="Kuma" value={kumaConfigured ? "connected · c to reconnect" : "not connected · c"} valueColor={kumaConfigured ? theme.good : theme.textFaint} />
           <Field label="Monitors" value={registered ? `registered${registered.pushId ? " (healthz + load push)" : ""}` : "not registered yet"} />
           <box style={{ height: 1 }} />
-          {op?.status === "running" ? (
+          {confirmRotate ? (
+            <>
+              <text content="Rotate this site's monitoring secrets?" fg={theme.warn} wrapMode="none" />
+              <text content="A new push URL and health key are minted; the old ones stop" fg={theme.textDim} wrapMode="none" />
+              <text content="working immediately. Kuma monitor history is kept." fg={theme.textDim} wrapMode="none" />
+              <box style={{ height: 1 }} />
+              <text content="y / ⏎ rotate · esc cancel" fg={theme.textFaint} wrapMode="none" />
+            </>
+          ) : op?.status === "running" ? (
             <box style={{ flexDirection: "row" }}>
               <Spinner />
               <text content={`  ${op.detail}`} fg={theme.textDim} wrapMode="none" />
@@ -225,6 +248,7 @@ export function KumaSite() {
                 fg={theme.textDim}
                 wrapMode="none"
               />
+              <text content="r — rotate secrets: new push URL + health key (old ones die)" fg={theme.textDim} wrapMode="none" />
             </>
           ) : (
             <text content={kumaConfigured ? "a — register a homepage monitor in Uptime Kuma" : "a — register a homepage monitor (connects Uptime Kuma first)"} fg={theme.textDim} wrapMode="none" />
@@ -236,9 +260,11 @@ export function KumaSite() {
 
   function hints() {
     if (connecting) return [{ key: "⏎", label: "next / connect" }, { key: "esc", label: "back" }]
+    if (confirmRotate) return [{ key: "y/⏎", label: "rotate" }, { key: "esc", label: "cancel" }]
     if (op?.status === "running") return [{ key: "esc", label: "background" }]
     const base: { key: string; label: string }[] = []
     if (isVanity) base.push({ key: "R", label: kumaConfigured ? "refresh page + monitors" : "refresh page" })
+    if (isVanity) base.push({ key: "r", label: "rotate secrets" })
     base.push({ key: "a", label: registered ? "repair monitors" : "add monitors" })
     base.push({ key: "c", label: kumaConfigured ? "reconnect Kuma" : "connect Kuma" })
     return [...base, { key: "esc", label: "close" }]


### PR DESCRIPTION
## What

- **`r` in the `m` overlay (vanity sites, confirm-gated): rotate monitoring secrets in place.** A fresh push token is edited into the EXISTING Kuma push monitor via a new `KumaClient.editMonitor` call — same monitor row, so heartbeat history, uptime stats and notification wiring survive — the heartbeat cron is rewritten over SSH, a fresh health key is re-seeded into the vanity page, and any Kuma monitor URL still embedding the old key is re-keyed (`retargetHealthKeyMonitors`). Old secrets die the moment their step lands. Works without a Kuma connection too (health key only).
- **Vanity-site marker in the Servers tab:** the server's own vanity site shows a `⌂` glyph + brand tint in the sites pane — with servers named like domains it otherwise blends into the list.

## Why

Screencasts. Kuma's monitor page shows the full push URL, and the JSON-metrics recipe embeds the health key in a monitor URL — recording either means rotating afterwards. Doing that by hand is three Kuma UI steps plus an SSH cron edit, and forgetting the cron half silently flatlines the load graph. Now it's one confirmed keypress, and the naive alternative (delete + re-create the monitor) would have destroyed monitor history.

## Testing

- `bun run typecheck` green.
- UI driven in Dev Mode via pilotty: `⌂` marker renders in the sites list; `r` arms the confirm, Esc disarms.
- **Live acceptance test** against a real Uptime Kuma instance + the dedicated test box (`web1.spinuptui.com`), full path: rotate fired from the real TUI → old health key 403s, new key 200s; old push URL rejected ("Monitor not found or not active"); cron line rewritten with the new token; push monitor kept its id and history across rotation (842 → 846 beats) with the new-token beat arriving on the next cron cycle; a deliberately created key-bearing monitor URL was re-keyed automatically (then removed).
- Kuma version-shape caveat (notificationIDList round-trip) covered by the live test: `getMonitor` → `editMonitor` round-trip verified against the real instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRKxkao5PvJahpy6xCws32