### PR TITLE
Front-page fingerprint monitor (site monitoring Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,33 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+### Added
+- **Front-page check (`f` in the site-monitoring overlay) — site monitoring
+  Phase 1.** Catches the failure plain up/down monitors sleep through: the page
+  cache serving the *wrong page* while HTTP stays 200 (two real incidents showed
+  a search-results template where the home page belonged). Instead of a
+  hand-picked headline keyword — which breaks the day someone edits the copy —
+  Spinup reads the live front page while it's healthy and derives a
+  *template-identity* fingerprint (WP's `body_class()` output: `home` /
+  `page-id-N` / `front-page`, falling back to the canonical link), validates it
+  against a throwaway search render to prove it actually discriminates, and
+  registers an Uptime Kuma keyword monitor asserting it. Check window is
+  selectable (5m default · 15m · 30m · 1h — the fetch is served straight from
+  the page cache, so even 5m costs the site nothing). Re-running `f`
+  recalibrates the *existing* monitor row in place (history and notification
+  wiring survive a redesign). A failing check surfaces as `WRONG PAGE SERVED`
+  in the site's Details pane and the overlay.
+- **`M` opens site monitoring from every site view.** Search and Stacks now bind
+  capital `M` (their lowercase `m` was taken by media fallback); the Servers tab
+  keeps `m` and gains `M` as an alias, so one muscle-memory key works everywhere.
+
+### Fixed
+- **Help/Explain overlays could deadlock open over a focused input.** Opening
+  `?` or `i` in the beat before a view's text input grabbed focus (easy to hit
+  by typing fast right after switching to Search) left an overlay that Esc
+  couldn't close — the global handler bailed on `inputMode` before reaching the
+  overlay's dismiss keys. Dismissal is now checked first.
+
 ## [0.15.0] - 2026-07-04
 
 ### Added

--- a/src/config.ts
+++ b/src/config.ts
@@ -109,6 +109,11 @@ export interface KumaMonitorRef {
   healthId?: number // HTTP monitor on /?healthz
   pushId?: number // push monitor fed by the server-side load cron
   pushToken?: string
+  fingerprintId?: number // keyword monitor asserting the front page serves its own template
+  // What fingerprint calibration derived (lib/siteFingerprint.ts) — shown in the
+  // overlay and kept so a recalibration can explain what it's replacing.
+  // `interval` is the check window in seconds.
+  fingerprint?: { keyword: string; kind: string; detail: string; interval: number; derivedAt: string }
 }
 
 // A long-running, fire-and-forget job persisted across restarts so the app can

--- a/src/lib/siteFingerprint.ts
+++ b/src/lib/siteFingerprint.ts
@@ -1,0 +1,108 @@
+// Derive a template-identity fingerprint from a site's LIVE front page — the
+// calibration step behind the front-page Kuma monitor (site monitoring Phase 1).
+//
+// Why not a hand-picked headline keyword: content is the one thing a site owner
+// is allowed to change, so a headline monitor breaks the day someone edits the
+// copy. WordPress instead stamps the winning template into body_class() on every
+// request (`home` / `page-id-N` / `front-page` vs `search` / `error404`), so a
+// template-derived token catches "the page cache is serving the wrong page" —
+// verified live 2026-07-04: a page-cache incident served `class="search …"`
+// where `class="home …"` belonged, with HTTP 200 the whole time.
+//
+// The candidate ladder (most → least distinctive) is read from what the page
+// ACTUALLY serves right now — the page is presumed healthy at calibration time:
+//   1. body class starting with `home`/`blog` → `class="home` (prefix-anchored,
+//      can't false-match in prose)
+//   2. a `page-id-N` token → `page-id-N`
+//   3. a `front-page` token → `front-page`
+//   4. the canonical <link> tag → its exact text
+// Non-WP sites and body_class-less themes fall down the ladder naturally
+// (canonical), and a page with none of these reports WHY instead of registering
+// a junk monitor.
+//
+// Validation: a throwaway search URL (`?s=…` — bypasses the page cache and, on
+// WP, renders a different template) is fetched and the chosen keyword must be
+// ABSENT there; a keyword that also matches the search template couldn't
+// discriminate. Sites that ignore `?s=` (serve the same page back) make the
+// probe inconclusive — the fingerprint is then accepted unvalidated, with a note.
+
+export interface Fingerprint {
+  kind: "body-class" | "canonical"
+  keyword: string // the literal substring the Kuma keyword monitor asserts
+  detail: string // human-readable description for the overlay / done message
+}
+
+export type DeriveResult = { ok: true; fingerprint: Fingerprint; validated: boolean; note?: string } | { ok: false; error: string }
+
+const FETCH_TIMEOUT_MS = 20_000
+// The body tag and canonical link live near the top of the document; capping the
+// read keeps a pathological page from ballooning memory.
+const MAX_HTML_BYTES = 512 * 1024
+
+async function fetchHtml(url: string): Promise<{ ok: true; html: string } | { ok: false; error: string }> {
+  try {
+    const res = await fetch(url, {
+      redirect: "follow",
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { "user-agent": "spinup-tui (front-page fingerprint calibration)" },
+    })
+    if (!res.ok) return { ok: false, error: `The page answered ${res.status} — calibrate while it's healthy.` }
+    return { ok: true, html: (await res.text()).slice(0, MAX_HTML_BYTES) }
+  } catch (err) {
+    return { ok: false, error: `Couldn't fetch ${url}: ${(err as Error).message}` }
+  }
+}
+
+function bodyClassOf(html: string): { quote: string; tokens: string[] } | null {
+  const body = html.match(/<body[^>]*>/i)?.[0]
+  if (!body) return null
+  const cls = body.match(/class\s*=\s*(?:"([^"]*)"|'([^']*)')/i)
+  if (!cls) return null
+  const value = (cls[1] ?? cls[2] ?? "").trim()
+  if (!value) return null
+  return { quote: cls[1] != null ? '"' : "'", tokens: value.split(/\s+/) }
+}
+
+function candidatesFrom(html: string): Fingerprint[] {
+  const out: Fingerprint[] = []
+  const cls = bodyClassOf(html)
+  if (cls) {
+    const first = cls.tokens[0]
+    if (first === "home" || first === "blog") {
+      out.push({ kind: "body-class", keyword: `class=${cls.quote}${first}`, detail: `body class “${first}”` })
+    }
+    const pageId = cls.tokens.find((t) => /^page-id-\d+$/.test(t))
+    if (pageId) out.push({ kind: "body-class", keyword: pageId, detail: `body class “${pageId}”` })
+    if (cls.tokens.includes("front-page")) out.push({ kind: "body-class", keyword: "front-page", detail: "body class “front-page”" })
+  }
+  const canonical = html.match(/<link[^>]*rel=["']canonical["'][^>]*>/i)?.[0]
+  // A canonical tag is only a usable keyword when it's a sane length (some SEO
+  // plugins emit data-bloated tags that would make a brittle, unreadable match).
+  if (canonical && canonical.length <= 300) out.push({ kind: "canonical", keyword: canonical, detail: "canonical link tag" })
+  return out
+}
+
+export async function deriveFingerprint(homeUrl: string): Promise<DeriveResult> {
+  const home = await fetchHtml(homeUrl)
+  if (!home.ok) return { ok: false, error: home.error }
+  const candidates = candidatesFrom(home.html)
+  if (candidates.length === 0) {
+    return { ok: false, error: "No template fingerprint on the front page (no WP body classes or canonical link) — this site would need a hand-made keyword monitor in Kuma." }
+  }
+
+  const sep = homeUrl.includes("?") ? "&" : "?"
+  const probe = await fetchHtml(`${homeUrl}${sep}s=spinup-fingerprint-probe`)
+  if (!probe.ok) return { ok: true, fingerprint: candidates[0]!, validated: false, note: "comparison probe unreachable — fingerprint unvalidated" }
+
+  const homeCls = bodyClassOf(home.html)
+  const probeCls = bodyClassOf(probe.html)
+  if (homeCls && probeCls && homeCls.tokens.join(" ") === probeCls.tokens.join(" ")) {
+    // The site serves the same page for `?s=` (no search feature) — the probe
+    // can't tell a distinctive keyword from a useless one.
+    return { ok: true, fingerprint: candidates[0]!, validated: false, note: "site ignores search URLs — fingerprint unvalidated" }
+  }
+
+  const distinct = candidates.find((c) => !probe.html.includes(c.keyword))
+  if (distinct) return { ok: true, fingerprint: distinct, validated: true }
+  return { ok: false, error: "Every candidate fingerprint also appears on a non-front page — nothing distinctive to monitor." }
+}

--- a/src/lib/uptimeKuma.ts
+++ b/src/lib/uptimeKuma.ts
@@ -349,6 +349,56 @@ export function loadPushMonitorPayload(name: string, pushToken: string): Record<
   }
 }
 
+// The front-page fingerprint monitor (site monitoring Phase 1): a `keyword`
+// monitor asserting the front page still carries the template-identity string
+// calibration derived (lib/siteFingerprint.ts). Catches "the page cache is
+// serving the wrong template" — a failure plain up/down monitors sleep through
+// (the real incidents answered 200 throughout). `interval` is the user-chosen
+// check window; the fetch is served straight from nginx's page cache, so even
+// the tightest window costs the site nothing.
+export function fingerprintMonitorPayload(name: string, url: string, keyword: string, interval: number): Record<string, unknown> {
+  return {
+    type: "keyword",
+    name,
+    url,
+    keyword,
+    method: "GET",
+    interval,
+    retryInterval: 60, // once suspect, confirm quickly regardless of the window
+    resendInterval: 0,
+    maxretries: 2, // two confirming failures before alerting — ride out one flaky fetch
+    timeout: 48,
+    accepted_statuscodes: ["200-299"],
+    expiryNotification: false, // the plain health monitor already owns cert expiry
+    ignoreTls: false,
+    upsideDown: false,
+    maxredirects: 10,
+  }
+}
+
+// Adopt-or-EDIT-or-create the fingerprint monitor for a domain. Unlike
+// registerMonitors (adopt-or-create only), an existing row is edited in place:
+// recalibrating after a redesign updates keyword/interval while the monitor id,
+// heartbeat history and notification wiring all survive (same philosophy as
+// rotatePushToken).
+export async function registerFingerprintMonitor(
+  kuma: KumaClient,
+  domain: string,
+  opts: { proto: "http" | "https"; keyword: string; interval: number; knownId?: number | null },
+): Promise<number> {
+  const name = `${domain} front page`
+  const url = `${opts.proto}://${domain}/`
+  const monitors = await kuma.getMonitors()
+  const byId = new Map(monitors.map((m) => [m.id, m]))
+  const existingId = (opts.knownId != null && byId.has(opts.knownId) ? opts.knownId : undefined) ?? monitors.find((m) => m.name === name)?.id
+  if (existingId != null) {
+    const full = await kuma.getMonitor(existingId)
+    await kuma.editMonitor({ ...full, type: "keyword", url, keyword: opts.keyword, interval: opts.interval })
+    return existingId
+  }
+  return kuma.addMonitor(fingerprintMonitorPayload(name, url, opts.keyword, opts.interval))
+}
+
 // Adopt-or-create the monitors for one domain — THE single implementation shared
 // by the vanity wizard's monitor step and the `m` overlay's add/repair, so the
 // two paths cannot drift. Rules:

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -94,6 +94,20 @@ export function App() {
     // Ctrl+C always quits, even while typing.
     if (key.ctrl && key.name === "c") return quit()
 
+    // Help/Explain must close even while a text field is focused (they can open
+    // a beat BEFORE a view's input grabs focus — e.g. `4` then typing a name
+    // containing `i` faster than Search mounts — and the inputMode gate below
+    // would otherwise deadlock them open, since the overlay also deactivates the
+    // view's own handler).
+    if (showHelp) {
+      if (key.name === "escape" || key.name === "q" || key.name === "?") setShowHelp(false)
+      return
+    }
+    if (showExplain) {
+      if (key.name === "escape" || key.name === "q" || key.name === "i") setShowExplain(false)
+      return
+    }
+
     // While a text field is focused, let it consume everything else.
     if (store.inputMode) return
 
@@ -159,16 +173,6 @@ export function App() {
 
     // The site-monitoring (Uptime Kuma) overlay owns the keyboard while open.
     if (store.kumaSite) return
-
-    if (showHelp) {
-      if (key.name === "escape" || key.name === "q" || key.name === "?") setShowHelp(false)
-      return
-    }
-
-    if (showExplain) {
-      if (key.name === "escape" || key.name === "q" || key.name === "i") setShowExplain(false)
-      return
-    }
 
     switch (key.name) {
       case "q":

--- a/src/ui/Details.tsx
+++ b/src/ui/Details.tsx
@@ -117,16 +117,21 @@ export const SERVER_CONTROL: ActionGroup[] = [
 export function SiteDetail({ site, serverName }: { site: Site; serverName: string }) {
   const { probes, probingIds, isProbeStale, phpUpgrades, httpsToggles, purgeCacheProgress, localLinks, grantedKeyKinds, kumaStatus, kumaMonitorFor } = useStore()
   const kuma = kumaStatus.get(site.domain)
+  // The fingerprint check failing while HTTP is up means the site is answering
+  // 200 with the WRONG page (stale/corrupt page cache) — a distinct, worse state
+  // than down, so it outranks the plain up/down wording.
   const kumaValue = kuma
     ? kuma.up === false
       ? "DOWN"
-      : kuma.up
-        ? `up${kuma.uptime24 != null ? ` · ${(kuma.uptime24 * 100).toFixed(2)}% (24h)` : ""}`
-        : "no beats yet"
+      : kuma.fingerprintUp === false
+        ? "up · WRONG PAGE SERVED (M)"
+        : kuma.up
+          ? `up${kuma.uptime24 != null ? ` · ${(kuma.uptime24 * 100).toFixed(2)}% (24h)` : ""}`
+          : "no beats yet"
     : kumaMonitorFor(site.domain)
       ? "registered · awaiting poll"
-      : "not monitored · m (Servers)" // `m` means media fallback in Search — scope the teach
-  const kumaColor = kuma ? (kuma.up === false ? theme.bad : kuma.up ? theme.good : theme.textDim) : theme.textFaint
+      : "not monitored · M"
+  const kumaColor = kuma ? (kuma.up === false || kuma.fingerprintUp === false ? theme.bad : kuma.up ? theme.good : theme.textDim) : theme.textFaint
   const httpsProgress = httpsToggles.get(site.id)
   const purgeProgress = purgeCacheProgress.get(site.id)
   const updates = (site.wp_plugin_updates || 0) + (site.wp_theme_updates || 0) + (site.wp_core_update ? 1 : 0)

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -41,7 +41,8 @@ import {
 import { ProvidersCache, type VerifiedConn } from "../lib/providersCache.ts"
 import { recordProviderFor, type DnsRecord, type RecordResult } from "../lib/dnsRecords.ts"
 import { deriveSiteUser, seedVanityIndex, seedVanityPushCron, aRecordResolves, isVanityPair } from "../lib/vanitySite.ts"
-import { withKuma, KumaClient, registerMonitors, genPushToken, rotatePushToken, retargetHealthKeyMonitors, LOAD_PUSH_SCALE } from "../lib/uptimeKuma.ts"
+import { withKuma, KumaClient, registerMonitors, registerFingerprintMonitor, genPushToken, rotatePushToken, retargetHealthKeyMonitors, LOAD_PUSH_SCALE } from "../lib/uptimeKuma.ts"
+import { deriveFingerprint } from "../lib/siteFingerprint.ts"
 import type { StoredProviders } from "../config.ts"
 import { fetchRebootInfo, grantSiteSshKey, revokeSiteSshKey, verifySudo, ensureSpinupKey, listPersonalKeys, keyBody, type RebootInfo } from "../lib/ssh.ts"
 import { estimateSourceSiteSizes, runStandardWpPull, runBedrockPull, runFilesOnlyPull, verifyClone, verifyFilesClone, type SudoCtx, type CloneStage, type CloneExecRecord, type VerifyResult as CloneVerifyResult } from "../lib/serverClone.ts"
@@ -201,6 +202,10 @@ export interface KumaDomainStatus {
   responseBeats: number[]
   loadBeats: number[]
   lastLoad: number | null
+  // The front-page fingerprint monitor's last beat. Kept separate from `up`:
+  // false means "answering 200 but serving the WRONG page" — a distinct, worse
+  // signal than down, and it must not be averaged away by a healthy up/down beat.
+  fingerprintUp: boolean | null
 }
 
 // Clone a server to a new server (backlog item 5). Five server-level steps wrapping
@@ -524,6 +529,7 @@ interface StoreValue extends DataState {
   startKumaSetup: (site: Site, opts?: { reseed?: boolean }) => void
   startVanityReseed: (site: Site) => void // refresh an existing vanity page (no Kuma needed)
   startKumaRotate: (site: Site) => void // rotate the push token + health key (vanity; old URLs die immediately)
+  startFingerprintSetup: (site: Site, intervalSec: number) => void // calibrate + register the front-page fingerprint monitor
   kumaStatus: Map<string, KumaDomainStatus> // live per-domain status, refreshed every minute
   // Clone a server to a new server (item 5). `cloneServer` opens the wizard; `cloneJob`
   // is the (Plan-draft then running) job whose heavy work lives in its `sites[]` vector.
@@ -2920,7 +2926,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           // very maintenance windows we create around reboots).
           const beatUp = (s: number) => s !== 0
           for (const [domain, ref] of Object.entries(cfgRef.current.kumaMonitors)) {
-            const status: KumaDomainStatus = { up: null, uptime24: null, responseBeats: [], loadBeats: [], lastLoad: null }
+            const status: KumaDomainStatus = { up: null, uptime24: null, responseBeats: [], loadBeats: [], lastLoad: null, fingerprintUp: null }
             if (ref.healthId && byId.has(ref.healthId)) {
               const beats = kuma.beatsFor(ref.healthId)
               const last = beats[beats.length - 1]
@@ -2936,6 +2942,11 @@ export function StoreProvider({ children }: { children: ReactNode }) {
               const last = beats[beats.length - 1]
               status.lastLoad = last?.ping != null ? Number(last.ping) / LOAD_PUSH_SCALE : null
               if (status.up === null && last) status.up = beatUp(last.status)
+            }
+            if (ref.fingerprintId && byId.has(ref.fingerprintId)) {
+              const beats = kuma.beatsFor(ref.fingerprintId)
+              const last = beats[beats.length - 1]
+              status.fingerprintUp = last ? beatUp(last.status) : null
             }
             map.set(domain, status)
           }
@@ -3068,6 +3079,49 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       void run()
     },
     [servers, reseedVanityPage, persistKumaAuth, persistKumaMonitors],
+  )
+
+  // Calibrate + register the front-page fingerprint monitor (site monitoring
+  // Phase 1). Reads the LIVE front page — presumed healthy right now — derives a
+  // template-identity keyword (body class / canonical; survives copy edits,
+  // unlike hand-picked headline keywords), and registers a Kuma keyword monitor
+  // asserting it at the chosen check window. Re-running recalibrates: the
+  // existing monitor row is edited in place, so its history survives a redesign.
+  const startFingerprintSetup = useCallback(
+    (site: Site, intervalSec: number) => {
+      const conn = cfgRef.current.uptimeKuma
+      if (!conn || isDevMode()) return
+      const setOp = (op: KumaOp) => setKumaOps((prev) => new Map(prev).set(site.id, op))
+      const run = async () => {
+        try {
+          const domain = site.domain
+          const proto = site.https?.enabled ? "https" : "http"
+          setOp({ status: "running", detail: "Reading the live front page…" })
+          const derived = await deriveFingerprint(`${proto}://${domain}/`)
+          if (!derived.ok) throw new Error(derived.error)
+          setOp({ status: "running", detail: "Registering the front-page monitor…" })
+          const known = cfgRef.current.kumaMonitors[domain] ?? {}
+          const { result: fingerprintId, jwt } = await withKuma(conn, (kuma) =>
+            registerFingerprintMonitor(kuma, domain, { proto, keyword: derived.fingerprint.keyword, interval: intervalSec, knownId: known.fingerprintId }),
+          )
+          persistKumaAuth(conn, jwt)
+          persistKumaMonitors(domain, {
+            ...known,
+            fingerprintId,
+            fingerprint: { ...derived.fingerprint, interval: intervalSec, derivedAt: new Date().toISOString() },
+          })
+          const win = intervalSec % 3600 === 0 ? `${intervalSec / 3600}h` : `${Math.round(intervalSec / 60)}m`
+          setOp({
+            status: "done",
+            detail: `Front-page check live — asserts ${derived.fingerprint.detail} every ${win}${derived.validated ? "" : ` (${derived.note ?? "unvalidated"})`}.`,
+          })
+        } catch (err) {
+          setOp({ status: "error", detail: "", error: (err as Error).message })
+        }
+      }
+      void run()
+    },
+    [persistKumaAuth, persistKumaMonitors],
   )
 
   // Rotate a vanity site's monitoring secrets — the "clean up after a screencast"
@@ -3859,6 +3913,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     startKumaSetup,
     startVanityReseed,
     startKumaRotate,
+    startFingerprintSetup,
     kumaStatus,
     cloneServer,
     setCloneServer,

--- a/src/ui/views/Browser.tsx
+++ b/src/ui/views/Browser.tsx
@@ -111,7 +111,10 @@ export function Browser({ rows }: { rows: number }) {
         if (focus === "sites" && sites[siteIndex]) setPurgeCacheSite(sites[siteIndex])
         return
       case "m":
+      case "M":
         // Uptime Kuma monitoring for the selected site (connect on first use).
+        // M is an alias: it's the binding Search/Stacks use (their lowercase m
+        // is taken), so the capital works everywhere.
         if (focus === "sites" && sites[siteIndex]) setKumaSite(sites[siteIndex])
         return
       case "K":

--- a/src/ui/views/KumaSite.tsx
+++ b/src/ui/views/KumaSite.tsx
@@ -9,6 +9,11 @@
 //     + load push monitors and installs the heartbeat cron.
 //   - `a` registers monitors for this site (vanity: healthz + load push + cron;
 //     regular site: homepage monitor only — client site files are never touched).
+//   - `f` (regular sites) calibrates the front-page check: reads the live front
+//     page, derives a template fingerprint (body class / canonical — survives
+//     copy edits), and registers a Kuma keyword monitor asserting it at a chosen
+//     window. Catches "the cache is serving the wrong page" (HTTP stays 200).
+//     Re-running recalibrates in place (monitor history survives a redesign).
 //   - `r` (vanity, confirm-gated) rotates the monitoring secrets: new push token
 //     edited into the existing monitor (history kept), cron rewritten, new health
 //     key re-seeded — so secrets shown on a screencast can be killed right after.
@@ -29,8 +34,18 @@ const BASE_FIELDS = ["url", "username", "password"] as const
 // padEnd(10)), so 52 fills the row — roomy enough that long URLs stay visible.
 const INPUT_W = 52
 
+// Check windows for the front-page fingerprint monitor. The check is one GET
+// served straight from nginx's page cache (no PHP), so even 5m costs the site
+// nothing — the window is really "how long a wrong page may go unnoticed".
+const FP_WINDOWS = [
+  { label: "5m", sec: 300 },
+  { label: "15m", sec: 900 },
+  { label: "30m", sec: 1800 },
+  { label: "1h", sec: 3600 },
+] as const
+
 export function KumaSite() {
-  const { kumaSite: site, setKumaSite, kumaConfigured, connectKuma, kumaMonitorFor, kumaOps, startKumaSetup, startVanityReseed, startKumaRotate, servers, setInputMode } = useStore()
+  const { kumaSite: site, setKumaSite, kumaConfigured, connectKuma, kumaMonitorFor, kumaOps, startKumaSetup, startVanityReseed, startKumaRotate, startFingerprintSetup, kumaStatus, servers, setInputMode } = useStore()
 
   const [draft, setDraft] = useState({ url: "", username: "", password: "" })
   const [fieldIdx, setFieldIdx] = useState(0)
@@ -41,6 +56,9 @@ export function KumaSite() {
   // `r` arms a confirm (rotation kills the live push URL / health key the moment
   // it fires — never do that on a stray keypress); y/⏎ fires, Esc disarms.
   const [confirmRotate, setConfirmRotate] = useState(false)
+  // `f` opens the front-page check-window picker; ⏎ calibrates & registers.
+  const [fpPick, setFpPick] = useState(false)
+  const [fpIdx, setFpIdx] = useState(0)
   // 2FA: revealed only after Kuma answers `tokenRequired` to a correct password.
   // The code is used once — the stored JWT covers every later login.
   const [needsTwofa, setNeedsTwofa] = useState(false)
@@ -126,7 +144,26 @@ export function KumaSite() {
       if (name === "escape" || name === "n" || name === "q") return setConfirmRotate(false)
       return
     }
+    if (fpPick) {
+      if (name === "left" || name === "up" || name === "h" || name === "k") return setFpIdx((i) => Math.max(i - 1, 0))
+      if (name === "right" || name === "down" || name === "l" || name === "j" || name === "tab") return setFpIdx((i) => Math.min(i + 1, FP_WINDOWS.length - 1))
+      if (/^[1-4]$/.test(name)) return setFpIdx(Number(name) - 1)
+      if (name === "return" && site) {
+        setFpPick(false)
+        return startFingerprintSetup(site, FP_WINDOWS[fpIdx]!.sec)
+      }
+      if (name === "escape" || name === "q") return setFpPick(false)
+      return
+    }
     if (name === "c") return setShowConnect(true)
+    if (name === "f" && !isVanity && site && op?.status !== "running") {
+      if (!kumaConfigured) return setShowConnect(true) // the check lives in Kuma
+      // Preselect the stored window on recalibration so ⏎⏎ keeps it.
+      const storedSec = registered?.fingerprint?.interval
+      const idx = FP_WINDOWS.findIndex((w) => w.sec === storedSec)
+      setFpIdx(idx >= 0 ? idx : 0)
+      return setFpPick(true)
+    }
     if (name === "r" && isVanity && site && op?.status !== "running") return setConfirmRotate(true)
     if (name === "a" && site && op?.status !== "running") {
       if (!kumaConfigured) return setShowConnect(true) // monitors need a connection
@@ -205,6 +242,15 @@ export function KumaSite() {
   }
 
   function renderMonitor() {
+    const fp = registered?.fingerprint
+    const fpUp = site ? (kumaStatus.get(site.domain)?.fingerprintUp ?? null) : null
+    const win = (sec: number) => (sec % 3600 === 0 ? `${sec / 3600}h` : `${Math.round(sec / 60)}m`)
+    const fpValue = fp
+      ? `${fp.detail} · every ${win(fp.interval)}${fpUp === false ? " · WRONG PAGE SERVED" : fpUp === true ? " · ok" : ""}`
+      : registered?.fingerprintId
+        ? "registered (details unknown) · f recalibrates"
+        : "not calibrated · f"
+    const fpColor = fpUp === false ? theme.bad : fp ? (fpUp === true ? theme.good : theme.text) : theme.textFaint
     return (
       <Panel title=" Site monitoring " active>
         <box style={{ flexDirection: "column", width: 68, paddingTop: 1, paddingBottom: 1 }}>
@@ -217,9 +263,35 @@ export function KumaSite() {
           <Field label="Site" value={site!.domain} />
           <Field label="Kind" value={isVanity ? "vanity page (full server monitoring)" : "site homepage (up/down + cert expiry)"} />
           <Field label="Kuma" value={kumaConfigured ? "connected · c to reconnect" : "not connected · c"} valueColor={kumaConfigured ? theme.good : theme.textFaint} />
-          <Field label="Monitors" value={registered ? `registered${registered.pushId ? " (healthz + load push)" : ""}` : "not registered yet"} />
+          <Field
+            label="Monitors"
+            value={
+              registered?.healthId
+                ? `registered${registered.pushId ? " (healthz + load push)" : ""}`
+                : registered?.fingerprintId
+                  ? "front-page check only · a adds the up/down monitor"
+                  : "not registered yet"
+            }
+          />
+          {!isVanity && <Field label="Front page" value={fpValue} valueColor={fpColor} />}
           <box style={{ height: 1 }} />
-          {confirmRotate ? (
+          {fpPick ? (
+            <>
+              <text content="Front-page check — alerts when the wrong page is served." fg={theme.text} wrapMode="none" />
+              <text content="Reads the live page now (while it's healthy), derives a template" fg={theme.textDim} wrapMode="none" />
+              <text content="fingerprint (body class / canonical — survives copy edits), and" fg={theme.textDim} wrapMode="none" />
+              <text content="registers a Kuma keyword monitor asserting it." fg={theme.textDim} wrapMode="none" />
+              <box style={{ height: 1 }} />
+              <box style={{ flexDirection: "row" }}>
+                <text content="Check window:" fg={theme.textDim} style={{ flexShrink: 0 }} />
+                {FP_WINDOWS.map((w, i) => (
+                  <text key={w.label} content={i === fpIdx ? `  ▸${w.label}` : `   ${w.label}`} fg={i === fpIdx ? theme.brand : theme.textFaint} style={{ flexShrink: 0 }} />
+                ))}
+              </box>
+              <box style={{ height: 1 }} />
+              <text content="←/→ or 1-4 window · ⏎ calibrate & register · esc cancel" fg={theme.textFaint} wrapMode="none" />
+            </>
+          ) : confirmRotate ? (
             <>
               <text content="Rotate this site's monitoring secrets?" fg={theme.warn} wrapMode="none" />
               <text content="A new push URL and health key are minted; the old ones stop" fg={theme.textDim} wrapMode="none" />
@@ -251,7 +323,14 @@ export function KumaSite() {
               <text content="r — rotate secrets: new push URL + health key (old ones die)" fg={theme.textDim} wrapMode="none" />
             </>
           ) : (
-            <text content={kumaConfigured ? "a — register a homepage monitor in Uptime Kuma" : "a — register a homepage monitor (connects Uptime Kuma first)"} fg={theme.textDim} wrapMode="none" />
+            <>
+              <text content={kumaConfigured ? "a — register a homepage monitor in Uptime Kuma" : "a — register a homepage monitor (connects Uptime Kuma first)"} fg={theme.textDim} wrapMode="none" />
+              <text
+                content={registered?.fingerprintId ? "f — recalibrate the front-page check (e.g. after a redesign)" : "f — front-page check: alert when the wrong page is served"}
+                fg={theme.textDim}
+                wrapMode="none"
+              />
+            </>
           )}
         </box>
       </Panel>
@@ -261,11 +340,13 @@ export function KumaSite() {
   function hints() {
     if (connecting) return [{ key: "⏎", label: "next / connect" }, { key: "esc", label: "back" }]
     if (confirmRotate) return [{ key: "y/⏎", label: "rotate" }, { key: "esc", label: "cancel" }]
+    if (fpPick) return [{ key: "←/→", label: "window" }, { key: "⏎", label: "calibrate" }, { key: "esc", label: "cancel" }]
     if (op?.status === "running") return [{ key: "esc", label: "background" }]
     const base: { key: string; label: string }[] = []
     if (isVanity) base.push({ key: "R", label: kumaConfigured ? "refresh page + monitors" : "refresh page" })
     if (isVanity) base.push({ key: "r", label: "rotate secrets" })
     base.push({ key: "a", label: registered ? "repair monitors" : "add monitors" })
+    if (!isVanity) base.push({ key: "f", label: registered?.fingerprintId ? "recalibrate front page" : "front-page check" })
     base.push({ key: "c", label: kumaConfigured ? "reconnect Kuma" : "connect Kuma" })
     return [...base, { key: "esc", label: "close" }]
   }

--- a/src/ui/views/Search.tsx
+++ b/src/ui/views/Search.tsx
@@ -34,7 +34,7 @@ function score(haystack: string, q: string): number | null {
 
 export function Search({ rows }: { rows: number }) {
   const store = useStore()
-  const { servers, sites, serverById, setInputMode, setRoute, route, overlayOpen, setHealthServer, setPhpUpgradeSite, setHttpsToggleSite, setPurgeCacheSite, setServerActionsServer, accountSlug, localLinks, setLocalLinkSite, openLocalTerminal, openLocalUrl, sshSite, setDnsInventoryServer, setDbBackupSite, dbBackups, setDbSyncSite, dbSyncs, localSync, setMediaFallbackSite, beginClone, setSudoConnectServer } = store
+  const { servers, sites, serverById, setInputMode, setRoute, route, overlayOpen, setHealthServer, setPhpUpgradeSite, setHttpsToggleSite, setPurgeCacheSite, setServerActionsServer, accountSlug, localLinks, setLocalLinkSite, openLocalTerminal, openLocalUrl, sshSite, setDnsInventoryServer, setDbBackupSite, dbBackups, setDbSyncSite, dbSyncs, localSync, setMediaFallbackSite, beginClone, setSudoConnectServer, setKumaSite } = store
   const [query, setQuery] = useState("")
   const [selected, setSelected] = useState(0)
   // "query" = typing/filtering (input focused); "actions" = input blurred so the
@@ -190,6 +190,11 @@ export function Search({ rows }: { rows: number }) {
           else setMediaFallbackSite(current.site)
         }
         return
+      case "M":
+        // Site monitoring (Uptime Kuma) — capital because lowercase m is media
+        // fallback here; M matches the same overlay's binding in Stacks.
+        if (current?.kind === "site") setKumaSite(current.site)
+        return
       case "n":
         // DNS inventory scoped to this site (its domains + records) — the migrate
         // lens for moving one site to another server.
@@ -256,6 +261,7 @@ export function Search({ rows }: { rows: number }) {
             { key: "d", label: "DB backup" },
             ...(localSync ? [{ key: "p", label: "pull to local" }] : []),
             ...(current?.kind === "site" && current.site.is_wordpress && localLinks.has(current.site.id) ? [{ key: "m", label: "media fallback" }] : []),
+            { key: "M", label: "monitoring" },
             { key: "a", label: "server actions" },
             { key: "←/esc", label: "back" },
           ]
@@ -395,6 +401,7 @@ function siteGroups(isWordpress: boolean, localSync: boolean): ActionGroup[] {
   remote.push(["u", "Upgrade PHP version"])
   remote.push(["H", "Enable/disable HTTPS"])
   remote.push(["P", "Purge page + object cache"])
+  remote.push(["M", "Monitoring (Uptime Kuma + front-page check)"])
   return [
     { title: "Open", items: [["o", "Open site in browser"], ["w", "Open in SpinupWP"]] },
     { title: "Remote", items: remote },

--- a/src/ui/views/Stacks.tsx
+++ b/src/ui/views/Stacks.tsx
@@ -49,7 +49,7 @@ const NONWP_SUBS: { kind: ProbeKind | null; label: string }[] = [
 
 export function Stacks({ rows }: { rows: number }) {
   const store = useStore()
-  const { sites, serverById, route, inputMode, overlayOpen, probes, probingIds, probeErrors, runProbe, runProbeMany, isProbeStale, isPhpEol, accountSlug, setPhpUpgradeSite, phpUpgrades, setHttpsToggleSite, setPurgeCacheSite, setLocalLinkSite, openLocalTerminal, openLocalUrl, localLinks, setDiscoverOpen, setForgottenOpen, setForgottenStack, sshSite } =
+  const { sites, serverById, route, inputMode, overlayOpen, probes, probingIds, probeErrors, runProbe, runProbeMany, isProbeStale, isPhpEol, accountSlug, setPhpUpgradeSite, phpUpgrades, setHttpsToggleSite, setPurgeCacheSite, setLocalLinkSite, openLocalTerminal, openLocalUrl, localLinks, setDiscoverOpen, setForgottenOpen, setForgottenStack, sshSite, setKumaSite } =
     store
 
   const [groupIndex, setGroupIndex] = useState(0)
@@ -177,6 +177,11 @@ export function Stacks({ rows }: { rows: number }) {
       case "P":
         // Purge page cache + object cache on the selected site (sites pane only).
         if (focus === "sites" && groupSites[siteIndex]) setPurgeCacheSite(groupSites[siteIndex])
+        return
+      case "M":
+        // Site monitoring (Uptime Kuma) — capital to match Search, where
+        // lowercase m means media fallback.
+        if (focus === "sites" && groupSites[siteIndex]) setKumaSite(groupSites[siteIndex])
         return
       case "t":
         // Open the selected site's local working copy in a terminal (inline; no


### PR DESCRIPTION
## What this catches

The page cache serving the **wrong page while HTTP stays 200** — two real production incidents showed a search-results template where the home page belonged, and every up/down monitor stayed green. The Kuma keyword monitors that catch it today assert a *headline*, which breaks the day someone edits the copy.

## What it does

**`f` in the site-monitoring overlay** (open with `M` from any site view, or `m` in Servers):

1. **Calibrates**: reads the live front page (presumed healthy right now) and derives a *template-identity* fingerprint from WP's `body_class()` output — `class="home`, `page-id-N`, `front-page` — falling back to the canonical `<link>` for body-class-less themes. Nothing derivable → an honest error, no junk monitor.
2. **Validates**: fetches a throwaway `?s=` render (different template on WP, bypasses the page cache) and requires the keyword to be *absent* there, proving it discriminates. Sites that ignore search URLs accept the fingerprint unvalidated, with a note.
3. **Registers**: an Uptime Kuma `keyword` monitor at a chosen check window (**5m default · 15m · 30m · 1h**). The check is one GET served straight from nginx's page cache — no PHP — so even 5m costs the site nothing.
4. **Recalibrates in place**: re-running `f` edits the existing monitor row (same id — history and notification wiring survive a redesign), same philosophy as the v0.15.0 secret rotation.

A failing check surfaces as **`WRONG PAGE SERVED`** in the site's Details pane (kept separate from up/down — "answering 200 with the wrong page" must not be averaged away by a healthy heartbeat).

Also included:
- **`M` binding everywhere**: Search and Stacks (their lowercase `m` = media fallback), plus an alias in Servers — one muscle-memory key for site monitoring across all three views.
- **Drive-by fix**: help/explain overlays could deadlock open when triggered in the beat before a view's input grabbed focus (the `inputMode` gate ran before their dismiss keys). Found by hitting it during PTY testing; dismissal now runs first.

## Zero footprint

Phase 1 puts nothing on the monitored site — no cron, no plugin, no file. Kuma polls outward; Spinup's footprint is one row in Kuma.

## Tested

- Calibration validated (read-only) against the two incident-prone production sites and the test site — all derive `class="home` and pass the discrimination probe.
- Live end-to-end on `wp.spinuptui.com` against the real Kuma: derive → register → adopt-don't-duplicate confirmed → recalibrate edits in place (same id, new interval) → first beats green (`200 - OK, keyword is found`) → the overlay's status poll shows `· ok`.
- PTY-driven UI pass (pilotty): Search → `M` → `f` → window picker → running op → done state, all rendering as designed.
- `bun run typecheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqXtnR4wjLEk94GscsFb4H