### PR TITLE
Per-site alert wiring: toggle Kuma notification providers from the overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ versions; such changes are called out here.
   capital `M` (their lowercase `m` was taken by media fallback); the Servers tab
   keeps `m` and gains `M` as an alias, so one muscle-memory key works everywhere.
 
+### Added (unreleased, continued)
+- **Alert wiring from inside Spinup (`n` in the site-monitoring overlay).**
+  Lists the notification providers actually configured in your Uptime Kuma —
+  detected by name (e.g. "Telegram Alerts"), not assumed — and shows whether
+  each is attached to this site's Spinup monitors (`✓` all / `◐` some / `○`
+  none). `⏎` toggles a provider across all of the site's checks at once,
+  editing each monitor in place (history, tags and other notification wiring
+  survive). If Kuma has no providers yet, the overlay says so and points to
+  Kuma → Settings → Notifications — creating the provider itself (bot tokens
+  etc.) is the one step that stays in Kuma.
+
 ### Fixed
 - **Help/Explain overlays could deadlock open over a focused input.** Opening
   `?` or `i` in the beat before a view's text input grabbed focus (easy to hit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ versions; such changes are called out here.
   etc.) is the one step that stays in Kuma.
 
 ### Fixed
+- **The site-monitoring overlay no longer gets stuck on a finished op's
+  message.** A completed action's `✓`/`✕` result used to replace the action
+  menu for the rest of the session — reopening the overlay showed only the old
+  message, hiding `a`/`f`/`n` (the keys still worked, invisibly). Results now
+  render above the menu, and a settled result is forgotten when the overlay
+  closes, so it always reopens fresh.
 - **Help/Explain overlays could deadlock open over a focused input.** Opening
   `?` or `i` in the beat before a view's text input grabbed focus (easy to hit
   by typing fast right after switching to Search) left an overlay that Esc

--- a/src/lib/uptimeKuma.ts
+++ b/src/lib/uptimeKuma.ts
@@ -43,6 +43,15 @@ export interface KumaBeat {
   ping?: number | null
 }
 
+// A notification provider as configured in Kuma (Settings → Notifications) —
+// e.g. a Telegram bot. Kuma keeps the display name inside the config JSON.
+export interface KumaNotificationInfo {
+  id: number
+  name: string
+  active: boolean
+  isDefault: boolean // Kuma auto-attaches these to monitors its UI creates (we mirror that in addMonitor)
+}
+
 interface Ack {
   ok: boolean
   msg?: string
@@ -77,6 +86,10 @@ export class KumaClient {
   // Kuma pushes these as events (not ack payloads) right after login and on change.
   private monitorList: Record<string, KumaMonitor> | null = null
   private notificationList: { id: number; isDefault?: boolean; active?: boolean; config?: string }[] = []
+  // notificationList is pushed in the post-login burst (there's no request event
+  // for it) — track arrival so getNotifications can tell "none configured" apart
+  // from "hasn't landed yet".
+  private notificationsArrived = false
 
   // Kuma pushes each monitor's recent beats + uptime percentages as events right
   // after login (it's how its own dashboard populates) — capture them so one
@@ -94,6 +107,7 @@ export class KumaClient {
     })
     socket.on("notificationList", (list: typeof this.notificationList) => {
       this.notificationList = list ?? []
+      this.notificationsArrived = true
     })
     socket.on("heartbeatList", (monitorID: number | string, beats: KumaBeat[], overwrite?: boolean) => {
       const id = Number(monitorID)
@@ -214,6 +228,28 @@ export class KumaClient {
       if (!this.monitorList) await wait
     }
     return Object.values(this.monitorList ?? {})
+  }
+
+  // The notification providers configured in Kuma, with display names parsed out
+  // of the config JSON. Waits briefly for the post-login burst so an immediate
+  // call after login doesn't misread "not arrived yet" as "none configured".
+  async getNotifications(ms = 2000): Promise<KumaNotificationInfo[]> {
+    const deadline = Date.now() + ms
+    while (!this.notificationsArrived && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 100))
+    }
+    return this.notificationList.map((n) => {
+      let name = `notification #${n.id}`
+      let isDefault = !!n.isDefault
+      try {
+        const cfg = n.config ? (JSON.parse(n.config) as { name?: string; isDefault?: boolean }) : {}
+        if (cfg.name) name = cfg.name
+        if (cfg.isDefault) isDefault = true
+      } catch {
+        // Unparseable config — keep the fallback name.
+      }
+      return { id: n.id, name, active: n.active !== false, isDefault }
+    })
   }
 
   // Notifications flagged "Default enabled" in Kuma — the UI auto-attaches these
@@ -430,6 +466,17 @@ export async function registerMonitors(
     })(),
   ])
   return { healthId, pushId, pushToken: opts.wantPush ? pushToken : undefined }
+}
+
+// Attach/detach one notification provider on a set of monitors, editing each
+// row in place (getMonitor → editMonitor, Kuma's own edit-dialog round-trip) so
+// history, tags and the rest of the notification wiring survive untouched.
+export async function setMonitorNotifications(kuma: KumaClient, monitorIds: number[], providerId: number, on: boolean): Promise<void> {
+  for (const id of monitorIds) {
+    const full = await kuma.getMonitor(id)
+    const list = { ...((full.notificationIDList as Record<string, boolean> | undefined) ?? {}), [String(providerId)]: on }
+    await kuma.editMonitor({ ...full, notificationIDList: list })
+  }
 }
 
 // Swap a push monitor's token in place — the old push URL stops accepting beats

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -542,6 +542,7 @@ interface StoreValue extends DataState {
   startFingerprintSetup: (site: Site, intervalSec: number) => void // calibrate + register the front-page fingerprint monitor
   fetchKumaAlerts: (site: Site) => Promise<{ ok: true; providers: KumaAlertProvider[]; monitorIds: number[] } | { ok: false; error: string }> // live read of provider/attachment state
   toggleKumaAlert: (site: Site, providerId: number, on: boolean, monitorIds: number[]) => Promise<{ ok: true } | { ok: false; error: string }>
+  clearKumaOp: (siteId: number) => void // forget a settled op so the overlay opens fresh
   kumaStatus: Map<string, KumaDomainStatus> // live per-domain status, refreshed every minute
   // Clone a server to a new server (item 5). `cloneServer` opens the wizard; `cloneJob`
   // is the (Plan-draft then running) job whose heavy work lives in its `sites[]` vector.
@@ -3009,6 +3010,18 @@ export function StoreProvider({ children }: { children: ReactNode }) {
 
   const kumaMonitorFor = useCallback((domain: string) => cfgRef.current.kumaMonitors[domain] ?? null, [])
 
+  // Drop a site's settled (done/error) op so the overlay opens fresh next time —
+  // without this, a finished op's message replaces the action menu forever.
+  // Callers must not clear RUNNING ops (esc backgrounds those deliberately).
+  const clearKumaOp = useCallback((siteId: number) => {
+    setKumaOps((prev) => {
+      if (!prev.has(siteId)) return prev
+      const next = new Map(prev)
+      next.delete(siteId)
+      return next
+    })
+  }, [])
+
   // Push the current embedded page (with its health-endpoint modes) into an
   // existing vanity site's docroot, minting/reusing the domain's stable health
   // key. Shared by the standalone refresh and the Kuma setup's reseed option.
@@ -3991,6 +4004,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     startFingerprintSetup,
     fetchKumaAlerts,
     toggleKumaAlert,
+    clearKumaOp,
     kumaStatus,
     cloneServer,
     setCloneServer,

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -41,7 +41,7 @@ import {
 import { ProvidersCache, type VerifiedConn } from "../lib/providersCache.ts"
 import { recordProviderFor, type DnsRecord, type RecordResult } from "../lib/dnsRecords.ts"
 import { deriveSiteUser, seedVanityIndex, seedVanityPushCron, aRecordResolves, isVanityPair } from "../lib/vanitySite.ts"
-import { withKuma, KumaClient, registerMonitors, registerFingerprintMonitor, genPushToken, rotatePushToken, retargetHealthKeyMonitors, LOAD_PUSH_SCALE } from "../lib/uptimeKuma.ts"
+import { withKuma, KumaClient, registerMonitors, registerFingerprintMonitor, setMonitorNotifications, genPushToken, rotatePushToken, retargetHealthKeyMonitors, LOAD_PUSH_SCALE } from "../lib/uptimeKuma.ts"
 import { deriveFingerprint } from "../lib/siteFingerprint.ts"
 import type { StoredProviders } from "../config.ts"
 import { fetchRebootInfo, grantSiteSshKey, revokeSiteSshKey, verifySudo, ensureSpinupKey, listPersonalKeys, keyBody, type RebootInfo } from "../lib/ssh.ts"
@@ -191,6 +191,16 @@ export interface KumaOp {
   status: "running" | "done" | "error"
   detail: string
   error?: string
+}
+
+// One notification provider (Settings → Notifications in Kuma) + whether it's
+// attached to a given site's Spinup monitors — the `n` overlay's row model.
+export interface KumaAlertProvider {
+  id: number
+  name: string
+  active: boolean // paused providers exist in Kuma but never fire
+  attachedAll: boolean // attached to every one of this site's monitors
+  attachedAny: boolean // attached to at least one (partial wiring)
 }
 
 // One domain's live status as Kuma sees it, refreshed by the store's poll loop.
@@ -530,6 +540,8 @@ interface StoreValue extends DataState {
   startVanityReseed: (site: Site) => void // refresh an existing vanity page (no Kuma needed)
   startKumaRotate: (site: Site) => void // rotate the push token + health key (vanity; old URLs die immediately)
   startFingerprintSetup: (site: Site, intervalSec: number) => void // calibrate + register the front-page fingerprint monitor
+  fetchKumaAlerts: (site: Site) => Promise<{ ok: true; providers: KumaAlertProvider[]; monitorIds: number[] } | { ok: false; error: string }> // live read of provider/attachment state
+  toggleKumaAlert: (site: Site, providerId: number, on: boolean, monitorIds: number[]) => Promise<{ ok: true } | { ok: false; error: string }>
   kumaStatus: Map<string, KumaDomainStatus> // live per-domain status, refreshed every minute
   // Clone a server to a new server (item 5). `cloneServer` opens the wizard; `cloneJob`
   // is the (Plan-draft then running) job whose heavy work lives in its `sites[]` vector.
@@ -3124,6 +3136,69 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     [persistKumaAuth, persistKumaMonitors],
   )
 
+  // Load the alert wiring for one site: every notification provider configured
+  // in Kuma, and whether each is attached to this site's Spinup monitors. The
+  // view calls this on demand (`n` in the overlay) — it's a live read, not
+  // cached state, so what's shown always reflects Kuma right now.
+  const fetchKumaAlerts = useCallback(
+    async (site: Site): Promise<{ ok: true; providers: KumaAlertProvider[]; monitorIds: number[] } | { ok: false; error: string }> => {
+      const conn = cfgRef.current.uptimeKuma
+      if (isDevMode()) return { ok: false, error: "Dev Mode never talks to a real Uptime Kuma." }
+      if (!conn) return { ok: false, error: "Connect Uptime Kuma first (c)." }
+      const ref = cfgRef.current.kumaMonitors[site.domain] ?? {}
+      const candidates = [ref.healthId, ref.pushId, ref.fingerprintId].filter((n): n is number => n != null)
+      if (candidates.length === 0) return { ok: false, error: "No monitors registered for this site yet — a or f adds one." }
+      try {
+        const { result, jwt } = await withKuma(conn, async (kuma) => {
+          const monitors = await kuma.getMonitors()
+          const byId = new Map(monitors.map((m) => [m.id, m]))
+          const ids = candidates.filter((id) => byId.has(id))
+          if (ids.length === 0) throw new Error("The recorded monitors no longer exist in Kuma — a or f re-creates them.")
+          const notifs = await kuma.getNotifications()
+          const attachCount = new Map<number, number>()
+          for (const id of ids) {
+            const full = await kuma.getMonitor(id)
+            const list = (full.notificationIDList as Record<string, boolean> | undefined) ?? {}
+            for (const [pid, on] of Object.entries(list)) {
+              if (on) attachCount.set(Number(pid), (attachCount.get(Number(pid)) ?? 0) + 1)
+            }
+          }
+          const providers: KumaAlertProvider[] = notifs.map((n) => ({
+            id: n.id,
+            name: n.name,
+            active: n.active,
+            attachedAll: (attachCount.get(n.id) ?? 0) === ids.length,
+            attachedAny: (attachCount.get(n.id) ?? 0) > 0,
+          }))
+          return { providers, monitorIds: ids }
+        })
+        persistKumaAuth(conn, jwt)
+        return { ok: true, ...result }
+      } catch (err) {
+        return { ok: false, error: (err as Error).message }
+      }
+    },
+    [persistKumaAuth],
+  )
+
+  // Attach/detach one provider across all of a site's Spinup monitors — the
+  // write half of the `n` overlay step. Edit-in-place per monitor (history,
+  // tags and other notification wiring survive).
+  const toggleKumaAlert = useCallback(
+    async (site: Site, providerId: number, on: boolean, monitorIds: number[]): Promise<{ ok: true } | { ok: false; error: string }> => {
+      const conn = cfgRef.current.uptimeKuma
+      if (!conn || isDevMode()) return { ok: false, error: "Connect Uptime Kuma first (c)." }
+      try {
+        const { jwt } = await withKuma(conn, (kuma) => setMonitorNotifications(kuma, monitorIds, providerId, on))
+        persistKumaAuth(conn, jwt)
+        return { ok: true }
+      } catch (err) {
+        return { ok: false, error: (err as Error).message }
+      }
+    },
+    [persistKumaAuth],
+  )
+
   // Rotate a vanity site's monitoring secrets — the "clean up after a screencast"
   // action. A new push token is edited into the EXISTING push monitor (same row:
   // history, uptime stats and notifications survive), the heartbeat cron is
@@ -3914,6 +3989,8 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     startVanityReseed,
     startKumaRotate,
     startFingerprintSetup,
+    fetchKumaAlerts,
+    toggleKumaAlert,
     kumaStatus,
     cloneServer,
     setCloneServer,

--- a/src/ui/views/KumaSite.tsx
+++ b/src/ui/views/KumaSite.tsx
@@ -56,7 +56,7 @@ type AlertsState =
   | { kind: "ready"; providers: KumaAlertProvider[]; monitorIds: number[]; idx: number; busy: boolean; flash: string | null }
 
 export function KumaSite() {
-  const { kumaSite: site, setKumaSite, kumaConfigured, connectKuma, kumaMonitorFor, kumaOps, startKumaSetup, startVanityReseed, startKumaRotate, startFingerprintSetup, fetchKumaAlerts, toggleKumaAlert, kumaStatus, servers, setInputMode } = useStore()
+  const { kumaSite: site, setKumaSite, kumaConfigured, connectKuma, kumaMonitorFor, kumaOps, startKumaSetup, startVanityReseed, startKumaRotate, startFingerprintSetup, fetchKumaAlerts, toggleKumaAlert, clearKumaOp, kumaStatus, servers, setInputMode } = useStore()
 
   const [draft, setDraft] = useState({ url: "", username: "", password: "" })
   const [fieldIdx, setFieldIdx] = useState(0)
@@ -96,6 +96,9 @@ export function KumaSite() {
   }, [connecting, setInputMode])
 
   const close = () => {
+    // A settled result was seen — forget it so the overlay opens fresh next
+    // time (a RUNNING op stays: esc deliberately backgrounds it).
+    if (site && op && op.status !== "running") clearKumaOp(site.id)
     setInputMode(false)
     setKumaSite(null)
   }
@@ -351,12 +354,22 @@ export function KumaSite() {
               <Spinner />
               <text content={`  ${op.detail}`} fg={theme.textDim} wrapMode="none" />
             </box>
-          ) : op?.status === "error" ? (
-            <text content={`✕ ${op.error}`} fg={theme.bad} />
-          ) : op?.status === "done" ? (
-            <text content={`✓ ${op.detail}`} fg={theme.good} />
           ) : isVanity ? (
             <>
+              {/* A settled result shows ABOVE the actions, never instead of them —
+                  the overlay must always offer its next moves. */}
+              {op?.status === "error" && (
+                <>
+                  <text content={`✕ ${op.error}`} fg={theme.bad} />
+                  <box style={{ height: 1 }} />
+                </>
+              )}
+              {op?.status === "done" && (
+                <>
+                  <text content={`✓ ${op.detail}`} fg={theme.good} />
+                  <box style={{ height: 1 }} />
+                </>
+              )}
               <text
                 content={kumaConfigured ? "R — re-publish the page, register monitors & install the cron" : "R — re-publish the page (current version, health endpoints)"}
                 fg={theme.textDim}
@@ -372,6 +385,18 @@ export function KumaSite() {
             </>
           ) : (
             <>
+              {op?.status === "error" && (
+                <>
+                  <text content={`✕ ${op.error}`} fg={theme.bad} />
+                  <box style={{ height: 1 }} />
+                </>
+              )}
+              {op?.status === "done" && (
+                <>
+                  <text content={`✓ ${op.detail}`} fg={theme.good} />
+                  <box style={{ height: 1 }} />
+                </>
+              )}
               <text content={kumaConfigured ? "a — register a homepage monitor in Uptime Kuma" : "a — register a homepage monitor (connects Uptime Kuma first)"} fg={theme.textDim} wrapMode="none" />
               <text
                 content={registered?.fingerprintId ? "f — recalibrate the front-page check (e.g. after a redesign)" : "f — front-page check: alert when the wrong page is served"}

--- a/src/ui/views/KumaSite.tsx
+++ b/src/ui/views/KumaSite.tsx
@@ -14,6 +14,10 @@
 //     copy edits), and registers a Kuma keyword monitor asserting it at a chosen
 //     window. Catches "the cache is serving the wrong page" (HTTP stays 200).
 //     Re-running recalibrates in place (monitor history survives a redesign).
+//   - `n` (alerts) lists Kuma's notification providers by name (Telegram, email,
+//     …) and toggles them per site across all of the site's Spinup monitors —
+//     detection is real (providers ride the post-login event burst), only the
+//     provider's own setup (bot token etc.) stays in Kuma's settings.
 //   - `r` (vanity, confirm-gated) rotates the monitoring secrets: new push token
 //     edited into the existing monitor (history kept), cron rewritten, new health
 //     key re-seeded — so secrets shown on a screencast can be killed right after.
@@ -26,7 +30,7 @@ import { useKeyboard } from "@opentui/react"
 import { theme } from "../../lib/theme.ts"
 import { Panel, Centered, Field, SecretInput, Spinner } from "../components.tsx"
 import { StatusBar } from "../StatusBar.tsx"
-import { useStore } from "../store.tsx"
+import { useStore, type KumaAlertProvider } from "../store.tsx"
 import { isVanityPair } from "../../lib/vanitySite.ts"
 
 const BASE_FIELDS = ["url", "username", "password"] as const
@@ -44,8 +48,15 @@ const FP_WINDOWS = [
   { label: "1h", sec: 3600 },
 ] as const
 
+// The `n` (alerts) step's state machine: load → list providers → toggle.
+type AlertsState =
+  | null
+  | { kind: "loading" }
+  | { kind: "error"; error: string }
+  | { kind: "ready"; providers: KumaAlertProvider[]; monitorIds: number[]; idx: number; busy: boolean; flash: string | null }
+
 export function KumaSite() {
-  const { kumaSite: site, setKumaSite, kumaConfigured, connectKuma, kumaMonitorFor, kumaOps, startKumaSetup, startVanityReseed, startKumaRotate, startFingerprintSetup, kumaStatus, servers, setInputMode } = useStore()
+  const { kumaSite: site, setKumaSite, kumaConfigured, connectKuma, kumaMonitorFor, kumaOps, startKumaSetup, startVanityReseed, startKumaRotate, startFingerprintSetup, fetchKumaAlerts, toggleKumaAlert, kumaStatus, servers, setInputMode } = useStore()
 
   const [draft, setDraft] = useState({ url: "", username: "", password: "" })
   const [fieldIdx, setFieldIdx] = useState(0)
@@ -59,6 +70,9 @@ export function KumaSite() {
   // `f` opens the front-page check-window picker; ⏎ calibrates & registers.
   const [fpPick, setFpPick] = useState(false)
   const [fpIdx, setFpIdx] = useState(0)
+  // `n` opens the alerts step — a live read of Kuma's notification providers and
+  // which are attached to this site's monitors; ⏎ toggles the selected one.
+  const [alerts, setAlerts] = useState<AlertsState>(null)
   // 2FA: revealed only after Kuma answers `tokenRequired` to a correct password.
   // The code is used once — the stored JWT covers every later login.
   const [needsTwofa, setNeedsTwofa] = useState(false)
@@ -144,6 +158,29 @@ export function KumaSite() {
       if (name === "escape" || name === "n" || name === "q") return setConfirmRotate(false)
       return
     }
+    if (alerts) {
+      if (alerts.kind === "ready" && alerts.busy) return // a toggle is mid-flight
+      if (name === "escape" || name === "q") return setAlerts(null)
+      if (alerts.kind !== "ready") return
+      if (name === "up" || name === "k") return setAlerts({ ...alerts, idx: Math.max(alerts.idx - 1, 0), flash: null })
+      if (name === "down" || name === "j") return setAlerts({ ...alerts, idx: Math.min(alerts.idx + 1, alerts.providers.length - 1), flash: null })
+      if ((name === "return" || name === "space" || name === " ") && site && alerts.providers.length > 0) {
+        const p = alerts.providers[alerts.idx]!
+        const on = !p.attachedAll
+        setAlerts({ ...alerts, busy: true, flash: null })
+        void toggleKumaAlert(site, p.id, on, alerts.monitorIds).then((r) => {
+          setAlerts((prev) => {
+            if (!prev || prev.kind !== "ready") return prev
+            if (!r.ok) return { ...prev, busy: false, flash: `✕ ${r.error}` }
+            const providers = prev.providers.map((q) => (q.id === p.id ? { ...q, attachedAll: on, attachedAny: on } : q))
+            const n = prev.monitorIds.length
+            return { ...prev, providers, busy: false, flash: `✓ ${p.name} ${on ? "now alerts" : "no longer alerts"} for ${n} monitor${n === 1 ? "" : "s"}` }
+          })
+        })
+        return
+      }
+      return
+    }
     if (fpPick) {
       if (name === "left" || name === "up" || name === "h" || name === "k") return setFpIdx((i) => Math.max(i - 1, 0))
       if (name === "right" || name === "down" || name === "l" || name === "j" || name === "tab") return setFpIdx((i) => Math.min(i + 1, FP_WINDOWS.length - 1))
@@ -163,6 +200,14 @@ export function KumaSite() {
       const idx = FP_WINDOWS.findIndex((w) => w.sec === storedSec)
       setFpIdx(idx >= 0 ? idx : 0)
       return setFpPick(true)
+    }
+    if (name === "n" && site && op?.status !== "running") {
+      if (!kumaConfigured) return setShowConnect(true) // alert wiring lives in Kuma
+      setAlerts({ kind: "loading" })
+      void fetchKumaAlerts(site).then((r) => {
+        setAlerts(r.ok ? { kind: "ready", providers: r.providers, monitorIds: r.monitorIds, idx: 0, busy: false, flash: null } : { kind: "error", error: r.error })
+      })
+      return
     }
     if (name === "r" && isVanity && site && op?.status !== "running") return setConfirmRotate(true)
     if (name === "a" && site && op?.status !== "running") {
@@ -275,7 +320,9 @@ export function KumaSite() {
           />
           {!isVanity && <Field label="Front page" value={fpValue} valueColor={fpColor} />}
           <box style={{ height: 1 }} />
-          {fpPick ? (
+          {alerts ? (
+            renderAlerts()
+          ) : fpPick ? (
             <>
               <text content="Front-page check — alerts when the wrong page is served." fg={theme.text} wrapMode="none" />
               <text content="Reads the live page now (while it's healthy), derives a template" fg={theme.textDim} wrapMode="none" />
@@ -321,6 +368,7 @@ export function KumaSite() {
                 wrapMode="none"
               />
               <text content="r — rotate secrets: new push URL + health key (old ones die)" fg={theme.textDim} wrapMode="none" />
+              <text content="n — alerts: choose where this server's checks notify" fg={theme.textDim} wrapMode="none" />
             </>
           ) : (
             <>
@@ -330,6 +378,7 @@ export function KumaSite() {
                 fg={theme.textDim}
                 wrapMode="none"
               />
+              <text content="n — alerts: choose where this site's checks notify" fg={theme.textDim} wrapMode="none" />
             </>
           )}
         </box>
@@ -337,9 +386,72 @@ export function KumaSite() {
     )
   }
 
+  function renderAlerts() {
+    if (!alerts) return null
+    if (alerts.kind === "loading") {
+      return (
+        <box style={{ flexDirection: "row" }}>
+          <Spinner />
+          <text content="  Reading notification providers from Kuma…" fg={theme.textDim} wrapMode="none" />
+        </box>
+      )
+    }
+    if (alerts.kind === "error") {
+      return (
+        <>
+          <text content={`✕ ${alerts.error}`} fg={theme.bad} wrapMode="none" />
+          <box style={{ height: 1 }} />
+          <text content="esc back" fg={theme.textFaint} wrapMode="none" />
+        </>
+      )
+    }
+    if (alerts.providers.length === 0) {
+      return (
+        <>
+          <text content="No notification providers in Uptime Kuma yet." fg={theme.text} wrapMode="none" />
+          <text content="Add one in Kuma → Settings → Notifications (Telegram, email, …)," fg={theme.textDim} wrapMode="none" />
+          <text content="then press n again — Spinup wires it to this site's checks." fg={theme.textDim} wrapMode="none" />
+          <box style={{ height: 1 }} />
+          <text content="esc back" fg={theme.textFaint} wrapMode="none" />
+        </>
+      )
+    }
+    const n = alerts.monitorIds.length
+    return (
+      <>
+        <text content={`Alerts — where this site's ${n} check${n === 1 ? "" : "s"} notify:`} fg={theme.text} wrapMode="none" />
+        <box style={{ height: 1 }} />
+        {alerts.providers.map((p, i) => {
+          const glyph = p.attachedAll ? "✓" : p.attachedAny ? "◐" : "○"
+          const glyphColor = p.attachedAll ? theme.good : p.attachedAny ? theme.warn : theme.textFaint
+          const suffix = p.attachedAny && !p.attachedAll ? " (some monitors only — ⏎ attaches to all)" : !p.active ? " (paused in Kuma)" : ""
+          return (
+            <box key={p.id} style={{ flexDirection: "row" }}>
+              <text content={i === alerts.idx ? "❯ " : "  "} fg={theme.brand} style={{ flexShrink: 0 }} />
+              <text content={glyph} fg={glyphColor} style={{ flexShrink: 0 }} />
+              <text content={` ${p.name}${suffix}`} fg={i === alerts.idx ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 1 }} />
+            </box>
+          )
+        })}
+        <box style={{ height: 1 }} />
+        {alerts.busy ? (
+          <box style={{ flexDirection: "row" }}>
+            <Spinner />
+            <text content="  Rewiring…" fg={theme.textDim} wrapMode="none" />
+          </box>
+        ) : alerts.flash ? (
+          <text content={alerts.flash} fg={alerts.flash.startsWith("✓") ? theme.good : theme.bad} wrapMode="none" />
+        ) : (
+          <text content="↑↓ select · ⏎ toggle on/off · esc done" fg={theme.textFaint} wrapMode="none" />
+        )}
+      </>
+    )
+  }
+
   function hints() {
     if (connecting) return [{ key: "⏎", label: "next / connect" }, { key: "esc", label: "back" }]
     if (confirmRotate) return [{ key: "y/⏎", label: "rotate" }, { key: "esc", label: "cancel" }]
+    if (alerts) return alerts.kind === "ready" && alerts.providers.length > 0 ? [{ key: "↑↓", label: "select" }, { key: "⏎", label: "toggle" }, { key: "esc", label: "done" }] : [{ key: "esc", label: "back" }]
     if (fpPick) return [{ key: "←/→", label: "window" }, { key: "⏎", label: "calibrate" }, { key: "esc", label: "cancel" }]
     if (op?.status === "running") return [{ key: "esc", label: "background" }]
     const base: { key: string; label: string }[] = []
@@ -347,6 +459,7 @@ export function KumaSite() {
     if (isVanity) base.push({ key: "r", label: "rotate secrets" })
     base.push({ key: "a", label: registered ? "repair monitors" : "add monitors" })
     if (!isVanity) base.push({ key: "f", label: registered?.fingerprintId ? "recalibrate front page" : "front-page check" })
+    base.push({ key: "n", label: "alerts" })
     base.push({ key: "c", label: kumaConfigured ? "reconnect Kuma" : "connect Kuma" })
     return [...base, { key: "esc", label: "close" }]
   }


### PR DESCRIPTION
## What it does

**`n` in the site-monitoring overlay** (`M`/`m`) answers "where do this site's checks notify?" from inside Spinup:

- **Detects, doesn't assume.** Kuma pushes its configured notification providers in the post-login event burst; Spinup parses each provider's display name out of its config ("Telegram Alerts", email, whatever you've set up) and lists them by name. No hardcoded Telegram anything — build-tool-agnostic by construction.
- **Shows real attachment state** per provider across all of the site's Spinup monitors: `✓` attached to all, `◐` some (partial wiring), `○` none.
- **`⏎` toggles** the selected provider on/off across every one of the site's checks at once (up/down + front page + load push where present), editing each monitor in place — history, tags, and other notification wiring survive untouched.
- **No providers yet?** The overlay says so and points to Kuma → Settings → Notifications. Creating the provider (bot token + chat ID) is the one step that genuinely stays in Kuma.

Works on regular sites and vanity/server monitors alike.

## Tested

- Live against the real Kuma: provider detected by name, attach writes `{"1": true}` into the monitor's `notificationIDList`, detach normalizes back to `{}`, tags confirmed untouched by the round-trip.
- Full UI pass under pilotty: `M` → `n` → provider list renders with live state → `⏎` on (`✓ … now alerts for 2 monitors`) → `⏎` off — test site left exactly as found.
- `bun run typecheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqXtnR4wjLEk94GscsFb4H