### PR TITLE
Site doctor: read-only cache-differential diagnosis (Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,9 +54,21 @@ versions; such changes are called out here.
   `wp elementor flush_css` appears only when Elementor is positively detected
   in the served markup, and that one command also purges SpinupWP's caches via
   the plugin's compat hook) · recalibrate (the page changed, not the cache —
-  `f` jumps straight there) · down · inconclusive. Works without a Kuma
-  connection, degrades honestly when the page cache is off, and never writes
-  anything — diagnosis ends at the runbook by design.
+  `f` jumps straight there) · **partial-outage** · down · inconclusive. Works
+  without a Kuma connection, degrades honestly when the page cache is off, and
+  never writes anything — diagnosis ends at the runbook by design.
+- **The doctor catches partial outages cached-page monitors sleep through.**
+  Two probes, two real failure shapes: (1) cached page 200 but a **fresh render
+  throws 5xx** — verified live: with SpinupWP's default object-cache drop-in a
+  dead Redis is *fatal* on every page-cache miss, and a plugin/theme fatal
+  looks identical, so visitors see cached pages while admins, logged-in users
+  and everything uncached fails; (2) the **wp-admin door probe** — the "site
+  serves fine but wp-admin shows the critical-error screen" incident shape —
+  fetches the login page (never page-cached; Bedrock's relocated `/wp/` login
+  handled), where a 5xx means an admin-facing fatal. Hardened sites that hide
+  or protect their login answer 401/403/404 and are reported as "can't judge",
+  never false-alarmed. Both produce the `partial-outage` verdict with a runbook
+  pointing at the site's error logs and the server's Redis monitor.
 
 ### Fixed
 - **The site-monitoring overlay no longer gets stuck on a finished op's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,22 @@ versions; such changes are called out here.
   Kuma → Settings → Notifications — creating the provider itself (bot tokens
   etc.) is the one step that stays in Kuma.
 
+- **The site doctor (`d` in the site-monitoring overlay) — site monitoring
+  Phase 2.** A read-only, zero-setup diagnosis of the "200 OK but wrong page"
+  failure class, built on the cache differential: the page is fetched twice —
+  once normally (cache-eligible) and once with the default
+  `wordpress_no_cache` bypass cookie — and WP's template identity is compared
+  between the two. SpinupWP's `fastcgi-cache: HIT/BYPASS` headers prove which
+  layer answered each request, so a mismatch is *proof* the page cache is
+  serving a different template than PHP renders (the purge-fixable condition),
+  not a guess. Verdicts: healthy · stale-cache (with a copyable runbook —
+  `wp elementor flush_css` appears only when Elementor is positively detected
+  in the served markup, and that one command also purges SpinupWP's caches via
+  the plugin's compat hook) · recalibrate (the page changed, not the cache —
+  `f` jumps straight there) · down · inconclusive. Works without a Kuma
+  connection, degrades honestly when the page cache is off, and never writes
+  anything — diagnosis ends at the runbook by design.
+
 ### Fixed
 - **The site-monitoring overlay no longer gets stuck on a finished op's
   message.** A completed action's `✓`/`✕` result used to replace the action

--- a/src/lib/siteDoctor.ts
+++ b/src/lib/siteDoctor.ts
@@ -14,11 +14,11 @@
 // rather than guessed. The headers tell us which layer answered each request,
 // so the differential asserts its own validity instead of assuming it.
 //
-// Verdict precedence: down > stale-cache > recalibrate > healthy, with
-// "inconclusive" when the evidence doesn't support any of them. The doctor
-// ends at diagnosis + a copyable runbook — deliberately no auto-heal (the
-// operator does the surgery; builder-specific lines appear only on positive
-// evidence in the served markup).
+// Verdict precedence: down > partial-outage > stale-cache > recalibrate >
+// healthy, with "inconclusive" when the evidence doesn't support any of them.
+// The doctor ends at diagnosis + a copyable runbook — deliberately no auto-heal
+// (the operator does the surgery; builder-specific lines appear only on
+// positive evidence in the served markup).
 
 import { bodyClassOf } from "./siteFingerprint.ts"
 
@@ -28,7 +28,14 @@ export interface DoctorCheck {
   detail: string
 }
 
-export type DoctorVerdict = "healthy" | "stale-cache" | "recalibrate" | "down" | "inconclusive"
+// "partial-outage" is the nastiest verdict: cached pages serve 200 while fresh
+// renders (or the wp-admin door) throw 5xx — anonymous visitors look fine, but
+// admins, logged-in users and everything uncached is failing. Verified real:
+// SpinupWP's default object-cache drop-in makes a dead Redis FATAL on every
+// page-cache miss, and a plugin/theme fatal produces the same signature.
+// Page-watching monitors sleep straight through it; this is where the doctor
+// catches it.
+export type DoctorVerdict = "healthy" | "stale-cache" | "recalibrate" | "partial-outage" | "down" | "inconclusive"
 
 export interface DoctorReport {
   verdict: DoctorVerdict
@@ -94,9 +101,18 @@ export async function runSiteDoctor(opts: {
   expectedKeyword?: string | null // the calibrated fingerprint, when one exists
   pageCacheEnabled?: boolean | null // from the SpinupWP API; null = unknown
   sshTarget?: string | null // "site_user@host" for the runbook's ssh line
+  isWordPress?: boolean // enables the wp-login.php door probe
+  loginPath?: string // where the login lives (Bedrock relocates it to /wp/wp-login.php)
 }): Promise<DoctorReport> {
   const checks: DoctorCheck[] = []
   const runbook: string[] = []
+
+  const partialOutageRunbook = (why: string) => {
+    if (opts.sshTarget) runbook.push(`ssh ${opts.sshTarget}`)
+    runbook.push("tail -n 50 ~/logs/*error*.log   # the fatal will be here")
+    runbook.push(`# ${why}`)
+    runbook.push("# front pages are cached, so visitors look fine — admins and logged-in users are not")
+  }
 
   const cached = await probe(opts.url)
   if (!cached.ok) {
@@ -129,8 +145,20 @@ export async function runSiteDoctor(opts: {
     checks.push({ label: "bypass", status: "info", detail: "page cache off — every render is already fresh" })
   } else if (fresh.ok) {
     checks.push({ label: "bypass", status: "warn", detail: `couldn't confirm a fresh render (${fresh.cache ?? "no cache header"}) — differential unverified` })
+  } else if (fresh.status >= 500 || fresh.status === 0) {
+    // Cached 200 + fresh 5xx IS the partial outage (verified live: a dead Redis
+    // is fatal on cache misses with SpinupWP's default drop-in; a plugin/theme
+    // fatal looks identical). Nothing further is measurable — diagnose and stop.
+    checks.push({ label: "fresh render", status: "bad", detail: fresh.error ?? `PHP fails when the cache is bypassed (HTTP ${fresh.status})` })
+    partialOutageRunbook("if the server's redis monitor is red, Redis is the cause; otherwise it's a PHP fatal")
+    return {
+      verdict: "partial-outage",
+      summary: "Cached pages serve fine, but fresh renders are failing — a partial outage the cached-page monitors can't see.",
+      checks,
+      runbook,
+    }
   } else {
-    checks.push({ label: "bypass", status: "warn", detail: fresh.error ?? `bypass request answered ${fresh.status}` })
+    checks.push({ label: "bypass", status: "warn", detail: `bypass request answered ${fresh.status} — differential unverified` })
   }
 
   // The differential: cached template identity vs freshly rendered identity.
@@ -166,6 +194,35 @@ export async function runSiteDoctor(opts: {
     }
   }
 
+  // The wp-admin door. A fatal confined to admin-facing code produces "site
+  // serves fine, wp-admin shows the critical-error screen" — a real incident
+  // shape. /wp-login.php is never page-cached (default `wp-.*.php` path
+  // exclusion) and renders through a full WP load, so a 5xx here is unambiguous.
+  // Anything else non-200 (basic auth, relocated login, hardening) is normal
+  // protection — report it, judge nothing.
+  let loginFatal = false
+  if (opts.isWordPress) {
+    let loginUrl: string | null = null
+    try {
+      loginUrl = new URL(opts.loginPath ?? "/wp-login.php", opts.url).toString()
+    } catch {
+      // Unparseable base URL — skip the probe.
+    }
+    if (loginUrl) {
+      const login = await probe(loginUrl)
+      if (login.ok) {
+        checks.push({ label: "wp-admin door", status: "ok", detail: `login page renders (${login.ms}ms)` })
+      } else if (login.status >= 500) {
+        loginFatal = true
+        checks.push({ label: "wp-admin door", status: "bad", detail: `login page throws HTTP ${login.status} — admin-facing fatal` })
+      } else if (login.status > 0) {
+        checks.push({ label: "wp-admin door", status: "info", detail: `answered ${login.status} — protected or relocated; can't judge` })
+      } else {
+        checks.push({ label: "wp-admin door", status: "warn", detail: login.error ?? "login probe failed" })
+      }
+    }
+  }
+
   if (fresh.ok) {
     checks.push({
       label: "timing",
@@ -174,6 +231,15 @@ export async function runSiteDoctor(opts: {
     })
   }
 
+  if (loginFatal) {
+    partialOutageRunbook("the front end renders fine — the fatal is in admin-facing code (a plugin's admin hooks, most likely)")
+    return {
+      verdict: "partial-outage",
+      summary: "The site serves fine, but wp-admin is throwing a fatal — visitors won't notice; you can't log in.",
+      checks,
+      runbook,
+    }
+  }
   if (staleCache) {
     // Builder-specific runbook lines only on positive evidence in the markup.
     const elementor = /wp-content\/plugins\/elementor\/|elementor-kit-\d/.test(fresh.ok ? fresh.html : cached.html)

--- a/src/lib/siteDoctor.ts
+++ b/src/lib/siteDoctor.ts
@@ -1,0 +1,194 @@
+// The site doctor (site monitoring Phase 2) — an on-demand, READ-ONLY diagnosis
+// of the "200 OK but wrong page" failure class. Pure HTTP: no SSH, no Kuma, no
+// writes, so it works on any site with zero setup.
+//
+// The centerpiece is the cache differential. SpinupWP's nginx page cache
+// answers with `fastcgi-cache: HIT|MISS|BYPASS` and honors the default
+// `wordpress_no_cache` cookie exclusion (both verified live on production
+// boxes, and the header set is what the spinupwp plugin registers with WP
+// core's Site Health page-cache test). So the doctor fetches the page twice —
+// once normally (cache-eligible) and once with the bypass cookie (same URL,
+// only the cache layer differs) — and compares WP's body_class() template
+// tokens between the two. A mismatch is PROOF the cache is serving a different
+// template than PHP renders right now: the purge-fixable condition, diagnosed
+// rather than guessed. The headers tell us which layer answered each request,
+// so the differential asserts its own validity instead of assuming it.
+//
+// Verdict precedence: down > stale-cache > recalibrate > healthy, with
+// "inconclusive" when the evidence doesn't support any of them. The doctor
+// ends at diagnosis + a copyable runbook — deliberately no auto-heal (the
+// operator does the surgery; builder-specific lines appear only on positive
+// evidence in the served markup).
+
+import { bodyClassOf } from "./siteFingerprint.ts"
+
+export interface DoctorCheck {
+  label: string
+  status: "ok" | "warn" | "bad" | "info"
+  detail: string
+}
+
+export type DoctorVerdict = "healthy" | "stale-cache" | "recalibrate" | "down" | "inconclusive"
+
+export interface DoctorReport {
+  verdict: DoctorVerdict
+  summary: string
+  checks: DoctorCheck[]
+  runbook: string[] // shell lines (plus comments) when something is fixable; empty otherwise
+}
+
+interface Probe {
+  ok: boolean
+  status: number
+  ms: number
+  html: string
+  cache: string | null // fastcgi-cache header, uppercased
+  bypassReason: string | null
+  error?: string
+}
+
+const FETCH_TIMEOUT_MS = 20_000
+const MAX_HTML_BYTES = 512 * 1024
+
+// The body_class() tokens that identify WHICH template won — the set the
+// differential compares. Cosmetic/theme classes are deliberately excluded so a
+// plugin adding a class doesn't read as a template change.
+const TEMPLATE_TOKEN =
+  /^(home|blog|front-page|search|search-results|search-no-results|error404|single|singular|page|archive|category|tag|author|date|attachment|page-id-\d+|postid-\d+|single-[a-z0-9_-]+)$/
+
+async function probe(url: string, cookie?: string): Promise<Probe> {
+  const started = performance.now()
+  try {
+    const res = await fetch(url, {
+      redirect: "follow",
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: {
+        "user-agent": "spinup-tui (site doctor)",
+        "cache-control": "no-store",
+        ...(cookie ? { cookie } : {}),
+      },
+    })
+    const html = (await res.text()).slice(0, MAX_HTML_BYTES)
+    return {
+      ok: res.ok,
+      status: res.status,
+      ms: Math.round(performance.now() - started),
+      html,
+      cache: res.headers.get("fastcgi-cache")?.toUpperCase() ?? null,
+      bypassReason: res.headers.get("fastcgi-cache-bypass-reason"),
+    }
+  } catch (err) {
+    return { ok: false, status: 0, ms: Math.round(performance.now() - started), html: "", cache: null, bypassReason: null, error: (err as Error).message }
+  }
+}
+
+function templateTokens(html: string): string[] | null {
+  const cls = bodyClassOf(html)
+  if (!cls) return null
+  const tokens = cls.tokens.filter((t) => TEMPLATE_TOKEN.test(t)).sort()
+  return tokens.length > 0 ? tokens : null
+}
+
+export async function runSiteDoctor(opts: {
+  url: string
+  expectedKeyword?: string | null // the calibrated fingerprint, when one exists
+  pageCacheEnabled?: boolean | null // from the SpinupWP API; null = unknown
+  sshTarget?: string | null // "site_user@host" for the runbook's ssh line
+}): Promise<DoctorReport> {
+  const checks: DoctorCheck[] = []
+  const runbook: string[] = []
+
+  const cached = await probe(opts.url)
+  if (!cached.ok) {
+    checks.push({ label: "reachability", status: "bad", detail: cached.error ?? `answered ${cached.status}` })
+    return { verdict: "down", summary: "The site isn't answering — this isn't a cache problem.", checks, runbook }
+  }
+  checks.push({ label: "reachability", status: "ok", detail: `200 in ${cached.ms}ms` })
+
+  const fresh = await probe(opts.url, "wordpress_no_cache=1")
+
+  // What layer served the plain request?
+  if (cached.cache === "HIT") {
+    checks.push({ label: "page cache", status: "ok", detail: "served from the page cache (HIT)" })
+  } else if (cached.cache) {
+    checks.push({ label: "page cache", status: "info", detail: `${cached.cache} — freshly rendered, nothing stale to compare` })
+  } else if (opts.pageCacheEnabled === false) {
+    checks.push({ label: "page cache", status: "info", detail: "disabled for this site (per SpinupWP)" })
+  } else {
+    checks.push({ label: "page cache", status: "warn", detail: "no fastcgi-cache header — cache layer not verifiable here" })
+  }
+
+  // Did the bypass actually bypass? The header proves it either way. With the
+  // page cache off, every render is fresh and there's nothing to bypass — that
+  // is expected state, not a warning.
+  const cacheOff = opts.pageCacheEnabled === false && !cached.cache
+  const bypassConfirmed = fresh.ok && fresh.cache === "BYPASS"
+  if (bypassConfirmed) {
+    checks.push({ label: "bypass", status: "ok", detail: `fresh render confirmed (BYPASS: ${fresh.bypassReason ?? "cookie"}) in ${fresh.ms}ms` })
+  } else if (cacheOff && fresh.ok) {
+    checks.push({ label: "bypass", status: "info", detail: "page cache off — every render is already fresh" })
+  } else if (fresh.ok) {
+    checks.push({ label: "bypass", status: "warn", detail: `couldn't confirm a fresh render (${fresh.cache ?? "no cache header"}) — differential unverified` })
+  } else {
+    checks.push({ label: "bypass", status: "warn", detail: fresh.error ?? `bypass request answered ${fresh.status}` })
+  }
+
+  // The differential: cached template identity vs freshly rendered identity.
+  const cachedTokens = templateTokens(cached.html)
+  const freshTokens = fresh.ok ? templateTokens(fresh.html) : null
+  let staleCache = false
+  if (cached.cache === "HIT" && bypassConfirmed && cachedTokens && freshTokens) {
+    if (cachedTokens.join(" ") === freshTokens.join(" ")) {
+      checks.push({ label: "template", status: "ok", detail: `cached and fresh renders agree (${freshTokens.slice(0, 3).join(" ")})` })
+    } else {
+      staleCache = true
+      checks.push({ label: "template", status: "bad", detail: `cached says “${cachedTokens.join(" ")}” but PHP renders “${freshTokens.join(" ")}”` })
+    }
+  } else if (cachedTokens && freshTokens) {
+    checks.push({ label: "template", status: "info", detail: `both renders show “${freshTokens.slice(0, 3).join(" ")}” (differential not provable this pass)` })
+  } else {
+    checks.push({ label: "template", status: "info", detail: "no body_class() tokens to compare — theme doesn't emit them" })
+  }
+
+  // The calibrated fingerprint, when the site has one.
+  let recalibrate = false
+  if (opts.expectedKeyword) {
+    const inCached = cached.html.includes(opts.expectedKeyword)
+    const inFresh = fresh.ok ? fresh.html.includes(opts.expectedKeyword) : null
+    if (inCached) {
+      checks.push({ label: "fingerprint", status: "ok", detail: "calibrated fingerprint present on the live page" })
+    } else if (inFresh) {
+      staleCache = true
+      checks.push({ label: "fingerprint", status: "bad", detail: "missing from the cached page but present in a fresh render" })
+    } else {
+      recalibrate = true
+      checks.push({ label: "fingerprint", status: "warn", detail: "gone from the live site entirely — the page changed, not the cache" })
+    }
+  }
+
+  if (fresh.ok) {
+    checks.push({
+      label: "timing",
+      status: "info",
+      detail: cached.cache === "HIT" ? `cached ${cached.ms}ms · uncached ${fresh.ms}ms` : `renders: ${cached.ms}ms · ${fresh.ms}ms`,
+    })
+  }
+
+  if (staleCache) {
+    // Builder-specific runbook lines only on positive evidence in the markup.
+    const elementor = /wp-content\/plugins\/elementor\/|elementor-kit-\d/.test(fresh.ok ? fresh.html : cached.html)
+    if (opts.sshTarget) runbook.push(`ssh ${opts.sshTarget}`)
+    if (elementor) runbook.push("wp elementor flush_css   # elementor detected — this also purges SpinupWP's caches")
+    else runbook.push("wp spinupwp cache purge-site")
+    runbook.push("# or: press P on this site (purge via API), then re-run d")
+    return { verdict: "stale-cache", summary: "The page cache is serving a different page than PHP renders — purge it.", checks, runbook }
+  }
+  if (recalibrate) {
+    return { verdict: "recalibrate", summary: "The site renders fine but no longer matches its calibrated fingerprint — press f to recalibrate.", checks, runbook }
+  }
+  if (cachedTokens || opts.expectedKeyword) {
+    const proved = cached.cache === "HIT" && bypassConfirmed
+    return { verdict: "healthy", summary: proved ? "Serving the right page, and the cache agrees with a fresh render." : "Serving the right page.", checks, runbook }
+  }
+  return { verdict: "inconclusive", summary: "Reachable, but there's no template identity or fingerprint to judge against.", checks, runbook }
+}

--- a/src/lib/siteFingerprint.ts
+++ b/src/lib/siteFingerprint.ts
@@ -53,7 +53,7 @@ async function fetchHtml(url: string): Promise<{ ok: true; html: string } | { ok
   }
 }
 
-function bodyClassOf(html: string): { quote: string; tokens: string[] } | null {
+export function bodyClassOf(html: string): { quote: string; tokens: string[] } | null {
   const body = html.match(/<body[^>]*>/i)?.[0]
   if (!body) return null
   const cls = body.match(/class\s*=\s*(?:"([^"]*)"|'([^']*)')/i)

--- a/src/ui/views/KumaSite.tsx
+++ b/src/ui/views/KumaSite.tsx
@@ -33,6 +33,7 @@ import { StatusBar } from "../StatusBar.tsx"
 import { useStore, type KumaAlertProvider } from "../store.tsx"
 import { isVanityPair } from "../../lib/vanitySite.ts"
 import { runSiteDoctor, type DoctorReport } from "../../lib/siteDoctor.ts"
+import { classifyStack } from "../../lib/stack.ts"
 
 const BASE_FIELDS = ["url", "username", "password"] as const
 // Fixed input width: the panel body is 66 wide, the label gutter is 12 ("❯ " +
@@ -107,6 +108,9 @@ export function KumaSite() {
       expectedKeyword: registered?.fingerprint?.keyword ?? null,
       pageCacheEnabled: site.page_cache?.enabled ?? null,
       sshTarget: site.site_user && server ? `${site.site_user}@${server.name}` : null,
+      isWordPress: !!site.is_wordpress,
+      // Bedrock relocates the login under /wp/ — aim the door probe there.
+      loginPath: classifyStack(site) === "Bedrock" ? "/wp/wp-login.php" : "/wp-login.php",
     }).then((report) => setDoctor((prev) => (prev ? { kind: "ready", report } : prev)))
   }
 
@@ -460,7 +464,7 @@ export function KumaSite() {
     const r = doctor.report
     const glyph = { ok: "✓", warn: "!", bad: "✕", info: "·" } as const
     const gColor = { ok: theme.good, warn: theme.warn, bad: theme.bad, info: theme.textFaint } as const
-    const vColor = r.verdict === "healthy" ? theme.good : r.verdict === "stale-cache" || r.verdict === "down" ? theme.bad : theme.warn
+    const vColor = r.verdict === "healthy" ? theme.good : r.verdict === "stale-cache" || r.verdict === "down" || r.verdict === "partial-outage" ? theme.bad : theme.warn
     return (
       <>
         {r.checks.map((c, i) => (

--- a/src/ui/views/KumaSite.tsx
+++ b/src/ui/views/KumaSite.tsx
@@ -32,6 +32,7 @@ import { Panel, Centered, Field, SecretInput, Spinner } from "../components.tsx"
 import { StatusBar } from "../StatusBar.tsx"
 import { useStore, type KumaAlertProvider } from "../store.tsx"
 import { isVanityPair } from "../../lib/vanitySite.ts"
+import { runSiteDoctor, type DoctorReport } from "../../lib/siteDoctor.ts"
 
 const BASE_FIELDS = ["url", "username", "password"] as const
 // Fixed input width: the panel body is 66 wide, the label gutter is 12 ("❯ " +
@@ -73,6 +74,8 @@ export function KumaSite() {
   // `n` opens the alerts step — a live read of Kuma's notification providers and
   // which are attached to this site's monitors; ⏎ toggles the selected one.
   const [alerts, setAlerts] = useState<AlertsState>(null)
+  // `d` runs the doctor — read-only HTTP diagnosis (works without Kuma).
+  const [doctor, setDoctor] = useState<null | { kind: "loading" } | { kind: "ready"; report: DoctorReport }>(null)
   // 2FA: revealed only after Kuma answers `tokenRequired` to a correct password.
   // The code is used once — the stored JWT covers every later login.
   const [needsTwofa, setNeedsTwofa] = useState(false)
@@ -94,6 +97,18 @@ export function KumaSite() {
     setInputMode(connecting)
     return () => setInputMode(false)
   }, [connecting, setInputMode])
+
+  const runDoctor = () => {
+    if (!site) return
+    setDoctor({ kind: "loading" })
+    const proto = site.https?.enabled ? "https" : "http"
+    void runSiteDoctor({
+      url: `${proto}://${site.domain}/`,
+      expectedKeyword: registered?.fingerprint?.keyword ?? null,
+      pageCacheEnabled: site.page_cache?.enabled ?? null,
+      sshTarget: site.site_user && server ? `${site.site_user}@${server.name}` : null,
+    }).then((report) => setDoctor((prev) => (prev ? { kind: "ready", report } : prev)))
+  }
 
   const close = () => {
     // A settled result was seen — forget it so the overlay opens fresh next
@@ -161,6 +176,20 @@ export function KumaSite() {
       if (name === "escape" || name === "n" || name === "q") return setConfirmRotate(false)
       return
     }
+    if (doctor) {
+      if (name === "escape" || name === "q") return setDoctor(null)
+      if (doctor.kind !== "ready") return
+      if (name === "d") return runDoctor()
+      if (name === "f" && !isVanity && doctor.report.verdict === "recalibrate") {
+        // The doctor's own suggestion — jump straight into recalibration.
+        setDoctor(null)
+        const storedSec = registered?.fingerprint?.interval
+        const idx = FP_WINDOWS.findIndex((w) => w.sec === storedSec)
+        setFpIdx(idx >= 0 ? idx : 0)
+        return setFpPick(true)
+      }
+      return
+    }
     if (alerts) {
       if (alerts.kind === "ready" && alerts.busy) return // a toggle is mid-flight
       if (name === "escape" || name === "q") return setAlerts(null)
@@ -203,6 +232,10 @@ export function KumaSite() {
       const idx = FP_WINDOWS.findIndex((w) => w.sec === storedSec)
       setFpIdx(idx >= 0 ? idx : 0)
       return setFpPick(true)
+    }
+    if (name === "d" && !isVanity && site && op?.status !== "running") {
+      // Pure HTTP — deliberately NOT gated on a Kuma connection.
+      return runDoctor()
     }
     if (name === "n" && site && op?.status !== "running") {
       if (!kumaConfigured) return setShowConnect(true) // alert wiring lives in Kuma
@@ -323,7 +356,9 @@ export function KumaSite() {
           />
           {!isVanity && <Field label="Front page" value={fpValue} valueColor={fpColor} />}
           <box style={{ height: 1 }} />
-          {alerts ? (
+          {doctor ? (
+            renderDoctor()
+          ) : alerts ? (
             renderAlerts()
           ) : fpPick ? (
             <>
@@ -404,10 +439,49 @@ export function KumaSite() {
                 wrapMode="none"
               />
               <text content="n — alerts: choose where this site's checks notify" fg={theme.textDim} wrapMode="none" />
+              <text content="d — doctor: prove whether the cache is serving the wrong page" fg={theme.textDim} wrapMode="none" />
             </>
           )}
         </box>
       </Panel>
+    )
+  }
+
+  function renderDoctor() {
+    if (!doctor) return null
+    if (doctor.kind === "loading") {
+      return (
+        <box style={{ flexDirection: "row" }}>
+          <Spinner />
+          <text content="  Examining the live site (cached vs fresh render)…" fg={theme.textDim} wrapMode="none" />
+        </box>
+      )
+    }
+    const r = doctor.report
+    const glyph = { ok: "✓", warn: "!", bad: "✕", info: "·" } as const
+    const gColor = { ok: theme.good, warn: theme.warn, bad: theme.bad, info: theme.textFaint } as const
+    const vColor = r.verdict === "healthy" ? theme.good : r.verdict === "stale-cache" || r.verdict === "down" ? theme.bad : theme.warn
+    return (
+      <>
+        {r.checks.map((c, i) => (
+          <box key={i} style={{ flexDirection: "row" }}>
+            <text content={`${glyph[c.status]} ${c.label.padEnd(13)}`} fg={gColor[c.status]} style={{ flexShrink: 0 }} />
+            <text content={c.detail} fg={c.status === "bad" ? theme.bad : theme.textDim} wrapMode="none" style={{ flexShrink: 1 }} />
+          </box>
+        ))}
+        <box style={{ height: 1 }} />
+        <text content={r.summary} fg={vColor} wrapMode="none" />
+        {r.runbook.length > 0 && (
+          <>
+            <box style={{ height: 1 }} />
+            {r.runbook.map((line, i) => (
+              <text key={i} content={`  ${line}`} fg={line.startsWith("#") ? theme.textFaint : theme.text} wrapMode="none" />
+            ))}
+          </>
+        )}
+        <box style={{ height: 1 }} />
+        <text content={`d re-run${r.verdict === "recalibrate" ? " · f recalibrate" : ""} · esc back`} fg={theme.textFaint} wrapMode="none" />
+      </>
     )
   }
 
@@ -476,6 +550,7 @@ export function KumaSite() {
   function hints() {
     if (connecting) return [{ key: "⏎", label: "next / connect" }, { key: "esc", label: "back" }]
     if (confirmRotate) return [{ key: "y/⏎", label: "rotate" }, { key: "esc", label: "cancel" }]
+    if (doctor) return doctor.kind === "ready" ? [{ key: "d", label: "re-run" }, { key: "esc", label: "back" }] : [{ key: "esc", label: "back" }]
     if (alerts) return alerts.kind === "ready" && alerts.providers.length > 0 ? [{ key: "↑↓", label: "select" }, { key: "⏎", label: "toggle" }, { key: "esc", label: "done" }] : [{ key: "esc", label: "back" }]
     if (fpPick) return [{ key: "←/→", label: "window" }, { key: "⏎", label: "calibrate" }, { key: "esc", label: "cancel" }]
     if (op?.status === "running") return [{ key: "esc", label: "background" }]
@@ -484,6 +559,7 @@ export function KumaSite() {
     if (isVanity) base.push({ key: "r", label: "rotate secrets" })
     base.push({ key: "a", label: registered ? "repair monitors" : "add monitors" })
     if (!isVanity) base.push({ key: "f", label: registered?.fingerprintId ? "recalibrate front page" : "front-page check" })
+    if (!isVanity) base.push({ key: "d", label: "doctor" })
     base.push({ key: "n", label: "alerts" })
     base.push({ key: "c", label: kumaConfigured ? "reconnect Kuma" : "connect Kuma" })
     return [...base, { key: "esc", label: "close" }]


### PR DESCRIPTION
## What it does

**`d` in the site-monitoring overlay** diagnoses the "200 OK but wrong page" failure class — read-only, zero setup, works without a Kuma connection.

The centerpiece is the **cache differential**: fetch the page twice — once normally (cache-eligible), once with the default `wordpress_no_cache` bypass cookie (identical URL; only the cache layer differs) — and compare WP's `body_class()` *template* tokens between the two. SpinupWP's `fastcgi-cache: HIT/BYPASS` (+ `fastcgi-cache-bypass-reason`) headers prove which layer answered each request, so the differential **asserts its own validity**: a template mismatch on a confirmed HIT-vs-BYPASS pair is proof the page cache is serving a different template than PHP renders right now — the purge-fixable condition, diagnosed rather than guessed.

## Verdicts

- **healthy** — right page, and (when provable) the cache agrees with a fresh render
- **stale-cache** — cached template ≠ freshly rendered template → copyable runbook. `wp elementor flush_css` appears **only when Elementor is positively detected in the served markup** (and the note explains that one command also purges SpinupWP's caches via the plugin's compat hook — no second purge needed)
- **recalibrate** — the calibrated fingerprint is gone from *both* renders: the page changed, not the cache. `f` jumps straight into recalibration
- **down** — not a cache problem at all
- **inconclusive** — reachable but nothing to judge against; says so instead of guessing

Checks surfaced: reachability, cache layer, bypass proof, template differential, calibrated fingerprint, cached-vs-uncached timing. With the page cache off (per the API's `site.page_cache`), everything degrades honestly — "every render is already fresh" as info, not a false warning.

Diagnosis deliberately ends at the runbook — no auto-heal, per the detection-first decision.

## Tested

- Read-only against two production sites: full differential ran (HIT vs BYPASS: COOKIE), templates agree, fingerprint present, verdict healthy.
- Test site with page cache disabled: honest degradation; a deliberately wrong keyword produced the recalibrate verdict.
- UI pass under pilotty (`M` → `d` → report renders with per-check glyphs, summary, hints).
- `bun run typecheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqXtnR4wjLEk94GscsFb4H