### PR TITLE
Server-wide Redis sentinel via the heartbeat cron (Phase 3a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,20 @@ versions; such changes are called out here.
   or protect their login answer 401/403/404 and are reported as "can't judge",
   never false-alarmed. Both produce the `partial-outage` verdict with a runbook
   pointing at the site's error logs and the server's Redis monitor.
+- **Server-wide Redis sentinel — site monitoring Phase 3a.** The vanity
+  heartbeat cron gains a second marker-managed line: `redis-cli ping` every
+  minute, pushed to a new `{server} redis` monitor in Kuma that alerts
+  independently (and rides the `r` secret rotation like everything else).
+  Registered automatically by `a`/`R` on a vanity site — after probing that
+  Redis actually answers on that box, so a Redis-less server never gets a
+  permanently-red monitor. A red sentinel while the server beats fine surfaces
+  as `REDIS DOWN` on the server's Details row. Live-verified the full cycle on
+  the test box: stop redis → down beat within the minute → restart → recovery
+  beat. That test also surfaced why this matters more than expected: with
+  SpinupWP's default object-cache drop-in, Redis being down is **fatal (HTTP
+  500) for every request that misses the page cache** — cached pages keep
+  serving 200, so page-watching monitors sleep through a real partial outage
+  that this sentinel catches in a minute.
 
 ### Fixed
 - **The site-monitoring overlay no longer gets stuck on a finished op's

--- a/src/config.ts
+++ b/src/config.ts
@@ -109,6 +109,8 @@ export interface KumaMonitorRef {
   healthId?: number // HTTP monitor on /?healthz
   pushId?: number // push monitor fed by the server-side load cron
   pushToken?: string
+  redisId?: number // "{server} redis" push monitor fed by the cron's redis-cli ping (vanity/server domains)
+  redisToken?: string
   fingerprintId?: number // keyword monitor asserting the front page serves its own template
   // What fingerprint calibration derived (lib/siteFingerprint.ts) — shown in the
   // overlay and kept so a recalibration can explain what it's replacing.

--- a/src/lib/uptimeKuma.ts
+++ b/src/lib/uptimeKuma.ts
@@ -385,6 +385,24 @@ export function loadPushMonitorPayload(name: string, pushToken: string): Record<
   }
 }
 
+// The server-wide Redis sentinel: the same heartbeat cron runs `redis-cli ping`
+// once a minute and pushes status=up/down here. One per SERVER (Redis is one
+// daemon per box), not per site — the per-site silent-fallback story is the
+// Phase-3b health endpoint's job.
+export function redisPushMonitorPayload(name: string, pushToken: string): Record<string, unknown> {
+  return {
+    type: "push",
+    name,
+    pushToken,
+    description: "Server-wide Redis sentinel: Spinup's heartbeat cron pings Redis every minute and reports up/down. Silence = the server (not Redis) is the problem.",
+    interval: 60,
+    retryInterval: 60,
+    maxretries: 2,
+    upsideDown: false,
+    accepted_statuscodes: ["200-299"],
+  }
+}
+
 // The front-page fingerprint monitor (site monitoring Phase 1): a `keyword`
 // monitor asserting the front page still carries the template-identity string
 // calibration derived (lib/siteFingerprint.ts). Catches "the page cache is
@@ -446,8 +464,8 @@ export async function registerFingerprintMonitor(
 export async function registerMonitors(
   kuma: KumaClient,
   domain: string,
-  opts: { proto: "http" | "https"; healthzPath: string; wantPush: boolean; known?: KumaMonitorRef | null; pushToken?: string | null },
-): Promise<{ healthId: number; pushId?: number; pushToken?: string }> {
+  opts: { proto: "http" | "https"; healthzPath: string; wantPush: boolean; wantRedis?: boolean; known?: KumaMonitorRef | null; pushToken?: string | null },
+): Promise<{ healthId: number; pushId?: number; pushToken?: string; redisId?: number; redisToken?: string }> {
   const monitors = await kuma.getMonitors()
   const byId = new Map(monitors.map((m) => [m.id, m]))
   const byName = new Map(monitors.map((m) => [m.name, m]))
@@ -458,14 +476,30 @@ export async function registerMonitors(
   const existingPush = opts.wantPush && live(known.pushId) == null ? byName.get(`${domain} load`) : undefined
   if (existingPush?.pushToken) pushToken = existingPush.pushToken
 
-  const [healthId, pushId] = await Promise.all([
+  // The Redis sentinel gets its OWN token — the cron feeds two distinct push
+  // URLs so the monitors alert independently.
+  let redisToken = known.redisToken ?? genPushToken()
+  const existingRedis = opts.wantRedis && live(known.redisId) == null ? byName.get(`${domain} redis`) : undefined
+  if (existingRedis?.pushToken) redisToken = existingRedis.pushToken
+
+  const [healthId, pushId, redisId] = await Promise.all([
     (async () => live(known.healthId) ?? byName.get(domain)?.id ?? (await kuma.addMonitor(healthMonitorPayload(domain, `${opts.proto}://${domain}${opts.healthzPath}`))))(),
     (async () => {
       if (!opts.wantPush) return undefined
       return live(known.pushId) ?? existingPush?.id ?? (await kuma.addMonitor(loadPushMonitorPayload(`${domain} load`, pushToken)))
     })(),
+    (async () => {
+      if (!opts.wantRedis) return undefined
+      return live(known.redisId) ?? existingRedis?.id ?? (await kuma.addMonitor(redisPushMonitorPayload(`${domain} redis`, redisToken)))
+    })(),
   ])
-  return { healthId, pushId, pushToken: opts.wantPush ? pushToken : undefined }
+  return {
+    healthId,
+    pushId,
+    pushToken: opts.wantPush ? pushToken : undefined,
+    redisId,
+    redisToken: opts.wantRedis ? redisToken : undefined,
+  }
 }
 
 // Attach/detach one notification provider on a set of monitors, editing each

--- a/src/lib/vanitySite.ts
+++ b/src/lib/vanitySite.ts
@@ -246,9 +246,25 @@ export interface PushCronTarget {
   port: number | null
   kumaUrl: string // Uptime Kuma base URL
   pushToken: string
+  // When set, a second marker-managed cron line feeds the server's Redis
+  // sentinel monitor (`{server} redis`): redis-cli ping → status=up/down.
+  // Unlike the load heartbeat (dead-man's switch), this line ACTIVELY reports
+  // down — Redis being dead while the server is fine is exactly the state it
+  // exists to catch. Server dead ⇒ both monitors go silent anyway.
+  redisToken?: string | null
 }
 
 const PUSH_CRON_MARKER = "spinup-kuma-push"
+const REDIS_CRON_MARKER = "spinup-kuma-redis"
+
+// Is Redis answerable from this box's shell? Run BEFORE creating the sentinel
+// monitor: a server without redis-cli (or with auth in the way) would otherwise
+// get a monitor that's red forever. Fail loudly at setup time instead.
+export async function probeServerRedis(t: { host: string; user: string; port: number | null }): Promise<{ ok: boolean; error?: string }> {
+  const r = await runProcess(["ssh", ...SSH_OPTS, ...sshPort(t.port), `${t.user}@${t.host}`, `[ "$(redis-cli ping 2>/dev/null)" = "PONG" ]`], 30_000)
+  if (r.code === 0) return { ok: true }
+  return { ok: false, error: "redis-cli didn't answer PONG on the server — Redis sentinel skipped." }
+}
 
 // Install (or refresh) the once-a-minute heartbeat cron that feeds the Kuma push
 // monitor: status=up plus the 1-min load in `ping`, which Kuma graphs. The beat
@@ -264,11 +280,17 @@ const PUSH_CRON_MARKER = "spinup-kuma-push"
 // treats a bare % as newline (which also rules out awk printf here).
 export async function seedVanityPushCron(t: PushCronTarget): Promise<{ ok: boolean; error?: string }> {
   const push = pushUrl(t.kumaUrl, t.pushToken)
-  const line = `* * * * * curl -fsS --max-time 20 '${push}?status=up&msg=ok&ping='$(awk '{print int($1*${LOAD_PUSH_SCALE})}' /proc/loadavg) >/dev/null 2>&1 # ${PUSH_CRON_MARKER}`
-  // The line contains quotes of both kinds once cron expands it, so ship it
+  const lines = [`* * * * * curl -fsS --max-time 20 '${push}?status=up&msg=ok&ping='$(awk '{print int($1*${LOAD_PUSH_SCALE})}' /proc/loadavg) >/dev/null 2>&1 # ${PUSH_CRON_MARKER}`]
+  if (t.redisToken) {
+    const redisPush = pushUrl(t.kumaUrl, t.redisToken)
+    lines.push(`* * * * * s=down; [ "$(redis-cli ping 2>/dev/null)" = "PONG" ] && s=up; curl -fsS --max-time 20 "${redisPush}?status=$s&msg=redis-$s&ping=" >/dev/null 2>&1 # ${REDIS_CRON_MARKER}`)
+  }
+  // The lines contain quotes of both kinds once cron expands them, so ship them
   // base64'd (same trick as the index.php seed) instead of fighting nesting.
-  const b64 = Buffer.from(line + "\n", "utf8").toString("base64")
-  const remote = `( crontab -l 2>/dev/null | grep -v '${PUSH_CRON_MARKER}' ; printf '%s' '${b64}' | base64 -d ) | crontab -`
+  // Both markers are always stripped first, so seeding WITHOUT a redisToken also
+  // removes a previously installed sentinel line (idempotent uninstall).
+  const b64 = Buffer.from(lines.join("\n") + "\n", "utf8").toString("base64")
+  const remote = `( crontab -l 2>/dev/null | grep -v -e '${PUSH_CRON_MARKER}' -e '${REDIS_CRON_MARKER}' ; printf '%s' '${b64}' | base64 -d ) | crontab -`
   const r = await runProcess(["ssh", ...SSH_OPTS, ...sshPort(t.port), `${t.user}@${t.host}`, remote], 60_000)
   if (r.code !== 0) return { ok: false, error: meaningfulError(r.stderr, "Couldn't install the heartbeat cron over SSH.") }
   return { ok: true }

--- a/src/ui/Details.tsx
+++ b/src/ui/Details.tsx
@@ -125,13 +125,15 @@ export function SiteDetail({ site, serverName }: { site: Site; serverName: strin
       ? "DOWN"
       : kuma.fingerprintUp === false
         ? "up · WRONG PAGE SERVED (M)"
-        : kuma.up
-          ? `up${kuma.uptime24 != null ? ` · ${(kuma.uptime24 * 100).toFixed(2)}% (24h)` : ""}`
-          : "no beats yet"
+        : kuma.redisUp === false
+          ? "up · REDIS DOWN (M)"
+          : kuma.up
+            ? `up${kuma.uptime24 != null ? ` · ${(kuma.uptime24 * 100).toFixed(2)}% (24h)` : ""}`
+            : "no beats yet"
     : kumaMonitorFor(site.domain)
       ? "registered · awaiting poll"
       : "not monitored · M"
-  const kumaColor = kuma ? (kuma.up === false || kuma.fingerprintUp === false ? theme.bad : kuma.up ? theme.good : theme.textDim) : theme.textFaint
+  const kumaColor = kuma ? (kuma.up === false || kuma.fingerprintUp === false || kuma.redisUp === false ? theme.bad : kuma.up ? theme.good : theme.textDim) : theme.textFaint
   const httpsProgress = httpsToggles.get(site.id)
   const purgeProgress = purgeCacheProgress.get(site.id)
   const updates = (site.wp_plugin_updates || 0) + (site.wp_theme_updates || 0) + (site.wp_core_update ? 1 : 0)

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -40,7 +40,7 @@ import {
 } from "../lib/providers.ts"
 import { ProvidersCache, type VerifiedConn } from "../lib/providersCache.ts"
 import { recordProviderFor, type DnsRecord, type RecordResult } from "../lib/dnsRecords.ts"
-import { deriveSiteUser, seedVanityIndex, seedVanityPushCron, aRecordResolves, isVanityPair } from "../lib/vanitySite.ts"
+import { deriveSiteUser, seedVanityIndex, seedVanityPushCron, probeServerRedis, aRecordResolves, isVanityPair } from "../lib/vanitySite.ts"
 import { withKuma, KumaClient, registerMonitors, registerFingerprintMonitor, setMonitorNotifications, genPushToken, rotatePushToken, retargetHealthKeyMonitors, LOAD_PUSH_SCALE } from "../lib/uptimeKuma.ts"
 import { deriveFingerprint } from "../lib/siteFingerprint.ts"
 import type { StoredProviders } from "../config.ts"
@@ -216,6 +216,9 @@ export interface KumaDomainStatus {
   // false means "answering 200 but serving the WRONG page" — a distinct, worse
   // signal than down, and it must not be averaged away by a healthy up/down beat.
   fingerprintUp: boolean | null
+  // The server's Redis sentinel (vanity domains only): false = the cron reports
+  // Redis unreachable while the server itself is beating fine.
+  redisUp: boolean | null
 }
 
 // Clone a server to a new server (backlog item 5). Five server-level steps wrapping
@@ -2939,7 +2942,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           // very maintenance windows we create around reboots).
           const beatUp = (s: number) => s !== 0
           for (const [domain, ref] of Object.entries(cfgRef.current.kumaMonitors)) {
-            const status: KumaDomainStatus = { up: null, uptime24: null, responseBeats: [], loadBeats: [], lastLoad: null, fingerprintUp: null }
+            const status: KumaDomainStatus = { up: null, uptime24: null, responseBeats: [], loadBeats: [], lastLoad: null, fingerprintUp: null, redisUp: null }
             if (ref.healthId && byId.has(ref.healthId)) {
               const beats = kuma.beatsFor(ref.healthId)
               const last = beats[beats.length - 1]
@@ -2960,6 +2963,11 @@ export function StoreProvider({ children }: { children: ReactNode }) {
               const beats = kuma.beatsFor(ref.fingerprintId)
               const last = beats[beats.length - 1]
               status.fingerprintUp = last ? beatUp(last.status) : null
+            }
+            if (ref.redisId && byId.has(ref.redisId)) {
+              const beats = kuma.beatsFor(ref.redisId)
+              const last = beats[beats.length - 1]
+              status.redisUp = last ? beatUp(last.status) : null
             }
             map.set(domain, status)
           }
@@ -3076,10 +3084,22 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       const run = async () => {
         try {
           const domain = site.domain
+          const ssh = { host: server?.ip_address ?? "", user: site.site_user ?? deriveSiteUser(domain), port: server?.ssh_port ?? null }
           if (isVanity && opts.reseed && server) {
             setOp({ status: "running", detail: "Publishing the updated page…" })
             const seed = await reseedVanityPage(site, server)
             if (!seed.ok) throw new Error(seed.error || "Couldn't re-seed the page over SSH.")
+          }
+          // The Redis sentinel is server-wide, so it rides the vanity treatment.
+          // Probe redis-cli BEFORE creating its monitor: a box where Redis isn't
+          // answerable would otherwise get a monitor that's red forever.
+          let wantRedis = false
+          let redisNote: string | null = null
+          if (isVanity && server) {
+            setOp({ status: "running", detail: "Checking Redis on the server…" })
+            const probe = await probeServerRedis(ssh)
+            wantRedis = probe.ok
+            if (!probe.ok) redisNote = probe.error ?? "Redis sentinel skipped."
           }
           setOp({ status: "running", detail: "Registering monitors in Uptime Kuma…" })
           const known = cfgRef.current.kumaMonitors[domain] ?? {}
@@ -3087,16 +3107,28 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           // on an http-only site would be permanently down.
           const proto = site.https?.enabled ? "https" : "http"
           const { result, jwt } = await withKuma(conn, (kuma) =>
-            registerMonitors(kuma, domain, { proto, healthzPath: isVanity ? "/?healthz" : "/", wantPush: isVanity, known }),
+            registerMonitors(kuma, domain, { proto, healthzPath: isVanity ? "/?healthz" : "/", wantPush: isVanity, wantRedis, known }),
           )
           persistKumaAuth(conn, jwt)
-          persistKumaMonitors(domain, { healthId: result.healthId, pushId: result.pushId ?? known.pushId, pushToken: result.pushToken ?? known.pushToken })
+          persistKumaMonitors(domain, {
+            ...known,
+            healthId: result.healthId,
+            pushId: result.pushId ?? known.pushId,
+            pushToken: result.pushToken ?? known.pushToken,
+            redisId: result.redisId ?? known.redisId,
+            redisToken: result.redisToken ?? known.redisToken,
+          })
           if (isVanity && result.pushId && result.pushToken && server) {
             setOp({ status: "running", detail: "Installing the heartbeat cron…" })
-            const cron = await seedVanityPushCron({ host: server.ip_address ?? "", user: site.site_user ?? deriveSiteUser(domain), port: server.ssh_port ?? null, kumaUrl: conn.url, pushToken: result.pushToken })
+            const cron = await seedVanityPushCron({ ...ssh, kumaUrl: conn.url, pushToken: result.pushToken, redisToken: result.redisId != null ? (result.redisToken ?? known.redisToken ?? null) : null })
             if (!cron.ok) throw new Error(cron.error || "Couldn't install the heartbeat cron.")
           }
-          setOp({ status: "done", detail: isVanity ? "Monitors live: healthz checks + load graph (cron beating every minute)." : "Monitor live: homepage checks + certificate-expiry alerts." })
+          setOp({
+            status: "done",
+            detail: isVanity
+              ? `Monitors live: healthz checks + load graph${result.redisId != null ? " + Redis sentinel" : ""} (cron beating every minute).${redisNote ? ` ${redisNote}` : ""}`
+              : "Monitor live: homepage checks + certificate-expiry alerts.",
+          })
         } catch (err) {
           setOp({ status: "error", detail: "", error: (err as Error).message })
         }
@@ -3247,14 +3279,18 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           }
           setOp({ status: "running", detail: "Rotating the push token in Uptime Kuma…" })
           const newToken = genPushToken()
+          // The Redis sentinel has its own push URL — rotate it in the same pass
+          // so no cron-embedded secret survives the rotation.
+          const newRedisToken = known.redisId != null ? genPushToken() : null
           const { result: retargeted, jwt } = await withKuma(conn, async (kuma) => {
             await rotatePushToken(kuma, known.pushId!, newToken)
+            if (known.redisId != null && newRedisToken) await rotatePushToken(kuma, known.redisId, newRedisToken)
             return oldKey ? retargetHealthKeyMonitors(kuma, oldKey, newKey) : 0
           })
           persistKumaAuth(conn, jwt)
-          persistKumaMonitors(domain, { ...known, pushToken: newToken })
+          persistKumaMonitors(domain, { ...known, pushToken: newToken, redisToken: newRedisToken ?? known.redisToken })
           setOp({ status: "running", detail: "Rewriting the heartbeat cron…" })
-          const cron = await seedVanityPushCron({ ...ssh, kumaUrl: conn.url, pushToken: newToken })
+          const cron = await seedVanityPushCron({ ...ssh, kumaUrl: conn.url, pushToken: newToken, redisToken: newRedisToken })
           if (!cron.ok) throw new Error(cron.error || "Couldn't rewrite the heartbeat cron.")
           setOp({ status: "done", detail: `Secrets rotated — the old push URL & health key are dead${retargeted ? ` (${retargeted} monitor URL${retargeted === 1 ? "" : "s"} re-keyed)` : ""}.` })
         } catch (err) {


### PR DESCRIPTION
## What it does

Redis is one daemon per box, so the server-wide check rides the **existing heartbeat cron** instead of per-site HTTP polling: a second marker-managed crontab line runs `redis-cli ping` once a minute and pushes `status=up/down` to a new **`{server} redis`** push monitor (slots into the `Servers` + `Health` tag scheme). Unlike the load heartbeat (dead-man's switch), this line *actively* reports down — Redis dead while the server is fine is exactly the state it exists to catch; a dead server silences both monitors anyway.

- Registered automatically by `a`/`R` on a vanity site — **after probing that Redis actually answers on that box**, so a Redis-less server never gets a permanently-red monitor (the done message says the sentinel was skipped, and why).
- The sentinel's token **rides `r` secret rotation** in the same pass as the load token — no cron-embedded secret survives a rotation.
- A red sentinel while the server beats fine shows as **`REDIS DOWN`** on the server's Details row.
- Idempotent cron management: both marker lines are stripped before every seed, so re-seeding without a token also cleanly removes the line.

## Live-verified on the test box (full cycle)

probe PONG → monitor created (existing health/load monitors adopted, not duplicated) → two-line crontab installed with SpinupWP's WP-cron line untouched → `redis-up` beats → `systemctl stop redis-server` → **`redis-down` beat within the minute** → restart → recovery beat. Redis left running, site healthy.

## Finding from the live test

With SpinupWP's default object-cache drop-in config, Redis being down is **fatal — HTTP 500 — for every request that misses the page cache**, not a silent fallback (`fail_gracefully` is off by default; the test site answered 500 the moment Redis stopped and recovered instantly on restart). Cached pages keep serving 200, which means page-watching monitors sleep through a real partial outage (admin, logged-in users, checkouts). The one-minute sentinel is therefore the primary detector for this failure class, and Phase 3b's per-site endpoint shifts toward config-drift and graceful-mode detection.

`bun run typecheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqXtnR4wjLEk94GscsFb4H