### PR TITLE
fix: alert toggle (n) covers all site monitors, incl. the Redis sentinel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+### Fixed
+- **Alert wiring (`n`) now really covers *all* of a site's monitors.** The
+  toggle attached/detached providers on a hardcoded list (healthz, load push,
+  front-page check) that predated the Redis sentinel, so `⏎` silently skipped
+  the `{server} redis` monitor. The site's monitors are now collected by
+  convention from the saved monitor refs, so the Redis sentinel — and any
+  monitor kind added in the future — is wired automatically. If you toggled a
+  provider on before this fix, open `n` again: it shows `◐ some monitors only`
+  and one `⏎` attaches it to the rest.
+- The server-create wizard's monitor step no longer drops previously saved
+  Redis/front-page monitor references from the config when re-run.
+
 ## [0.16.0] - 2026-07-04
 
 ### Added

--- a/src/config.ts
+++ b/src/config.ts
@@ -105,6 +105,11 @@ export interface UptimeKumaConn {
   env?: boolean // creds came from the environment — read-only in the UI
 }
 
+// CONVENTION: every numeric field ending in `Id` is a Kuma monitor id belonging
+// to this site, and the alert wiring (`n` in the monitoring overlay) attaches/
+// detaches notification providers across ALL of them by that naming rule — a
+// new monitor kind only needs a `fooId?: number` field here to be included.
+// Don't add a numeric `*Id` field that isn't a monitor id.
 export interface KumaMonitorRef {
   healthId?: number // HTTP monitor on /?healthz
   pushId?: number // push monitor fed by the server-side load cron

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -2773,7 +2773,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
             }),
           )
           persistKumaAuth(conn, jwt)
-          persistKumaMonitors(j.hostname, { healthId: result.healthId, pushId: result.pushId ?? known.pushId, pushToken: result.pushToken ?? known.pushToken })
+          persistKumaMonitors(j.hostname, { ...known, healthId: result.healthId, pushId: result.pushId ?? known.pushId, pushToken: result.pushToken ?? known.pushToken })
           void doCron({ ...j, step: "cron", kumaPushToken: result.pushToken ?? known.pushToken })
         } catch (err) {
           fail(j, "monitor", (err as Error).message)
@@ -3191,7 +3191,13 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       if (isDevMode()) return { ok: false, error: "Dev Mode never talks to a real Uptime Kuma." }
       if (!conn) return { ok: false, error: "Connect Uptime Kuma first (c)." }
       const ref = cfgRef.current.kumaMonitors[site.domain] ?? {}
-      const candidates = [ref.healthId, ref.pushId, ref.fingerprintId].filter((n): n is number => n != null)
+      // Every monitor registered for this site: any numeric `*Id` field on the
+      // ref (healthId, pushId, redisId, fingerprintId, …). Collected by
+      // convention rather than by name so new monitor kinds are alert-wired
+      // automatically — see the KumaMonitorRef note in config.ts.
+      const candidates = Object.entries(ref)
+        .filter((e): e is [string, number] => e[0].endsWith("Id") && typeof e[1] === "number")
+        .map(([, id]) => id)
       if (candidates.length === 0) return { ok: false, error: "No monitors registered for this site yet — a or f adds one." }
       try {
         const { result, jwt } = await withKuma(conn, async (kuma) => {


### PR DESCRIPTION
## Why

Toggling a notification provider in the site-monitoring overlay (`n`) attached/detached it on a hardcoded monitor list — healthz, load push, front-page check — that predates the Phase 3a Redis sentinel (#22). The `{server} redis` monitor was silently skipped, so a freshly toggled provider showed "now alerts for 2 monitors" on a server that has 3.

## What

- `fetchKumaAlerts` now collects the site's monitors **by convention**: every numeric `*Id` field on the saved `KumaMonitorRef`. The Redis sentinel — and any future monitor kind — is included in both the read (attached ✓/◐/○) and the toggle write automatically. The convention is documented on the interface in `config.ts`.
- The vanity server-create job's monitor step now merges into the saved ref instead of replacing it, so a re-run no longer drops a previously saved `redisId`/`fingerprintId`.

## Testing

- `bun run typecheck` green.
- Verified live against a real fleet: after the fix, `n` showed the previously toggled provider as `◐ some monitors only`; one `⏎` attached it to all 3 monitors including the Redis sentinel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174tnk5MZiQaCdt6ghrUJgi