### PR TITLE
Site status column + plugins/themes view (v0.18.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-07-07
+
+### Added
+- **At-a-glance status column in the Servers list.** Each site row now carries a
+  fixed-width capability strip — `👤🔑` granted SSH keys, `H` HTTPS, `C` page cache,
+  `B` backups (lit when on, faint `·` when off), plus `◆` linked and `↑N` pending
+  updates — aligned into clean columns across every row (the site stack tag is now
+  fixed-width so nothing jitters). A compact key sits in the Sites panel title.
+- **Installed plugins & themes (`p`).** Press `p` on a site to list its real
+  `wp plugin list` / `wp theme list` over SSH: every plugin and theme with its
+  status, current version, and available update (`→ 1.2.3`) — the detail the API
+  only exposes as bare counts. Read-only, combined scrollable list with per-section
+  update badges. Detects the WordPress directory itself, so it works on `/public/`
+  and Bedrock installs alike. (See "Installed plugins & themes" in the README.)
+
+### Fixed
+- **Site stack & type now follow the `d`-identify probe, not SpinupWP's flag.**
+  SpinupWP's `is_wordpress` is unreliable — false for Bedrock/git sites and for
+  Standard-WP `/public/` installs it imported as "Generic" — so a real WordPress
+  site could show as `app` in the Servers list, and its Details "Type" as Generic,
+  even after `d` detected WordPress. The row stack tag and the Details "Stack" /
+  "Type" fields now reflect the **detected** stack, and the plugins/themes view no
+  longer refuses a misclassified WordPress site (it confirms WordPress core over
+  SSH instead of trusting the flag).
+
 ## [0.17.0] - 2026-07-06
 
 ### Changed
@@ -853,7 +878,8 @@ Initial tagged release.
 ### Notes
 - Read-only release: works with a SpinupWP **Read Only** API token.
 
-[Unreleased]: https://github.com/mwender/spinupwp-tui/compare/v0.17.0...HEAD
+[Unreleased]: https://github.com/mwender/spinupwp-tui/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/mwender/spinupwp-tui/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/mwender/spinupwp-tui/compare/v0.16.1...v0.17.0
 [0.16.1]: https://github.com/mwender/spinupwp-tui/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/mwender/spinupwp-tui/compare/v0.15.0...v0.16.0

--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ Once you're in, the dashboard looks like this:
   attention" list pointing at the clone wizard (`C`).
 - **Server & site browser** — a three-pane navigator. Pick a server, see its
   sites, drill into full details (PHP version, HTTPS, page cache, backups, Git
-  deployment, WP updates, and more).
+  deployment, WP updates, and more). Each site row carries an at-a-glance **status
+  column** — `👤🔑` granted SSH keys, `H` HTTPS, `C` page cache, `B` backups (lit
+  when on, faint `·` when off), plus `◆` linked and `↑N` pending updates — aligned
+  into columns across every row, with a compact key in the Sites panel title.
 - **Stack detection & fleet composition** — the Stacks tab classifies every site
   as Standard WP, Bedrock, or Non-WP, with a fleet-wide PHP version breakdown
   (EOL versions flagged). Press `d` to SSH-probe a site's actual stack — naming
@@ -51,6 +54,13 @@ Once you're in, the dashboard looks like this:
 - **Live server health** — press `h` on any server for a real-time view over
   SSH: CPU (aggregate + per-core + sparkline), load, memory/swap, disk mounts,
   and top processes. Polls every few seconds. (See "Server health" below.)
+- **Installed plugins & themes** — press `p` on a site for its real `wp plugin
+  list` / `wp theme list` over SSH: every plugin and theme with its status,
+  current version, and available update — the detail the API only exposes as bare
+  counts. Read-only, combined scrollable list with per-section update badges.
+  Detects the WordPress directory itself, so it works on `/public/` and Bedrock
+  installs alike (even sites SpinupWP misclassifies as non-WordPress). (See
+  "Installed plugins & themes" below.)
 - **Open in browser** — press `o` on any site to open it in your default browser.
 - **Link local working copies** — press `L` on a site to link its local checkout
   (a path plus the local URL where you serve it), then open it with `t` (a
@@ -297,6 +307,7 @@ These can be set in `config.json` or via an environment variable:
 | `n` | DNS migration view for a site — its records + TTLs (`⏎` edits a TTL; `p` repoints the record; `a` shows the whole server) |
 | `N` | DNS migration view for the whole server |
 | `h` | Live server health (CPU/mem/disk over SSH) |
+| `p` | List a site's installed plugins & themes over SSH — version + updates (Servers tab, sites pane) |
 | `d` | Detect a site's stack via SSH (Servers / Stacks tabs) |
 | `D` | Detect every site in the selected stack (Stacks tab) |
 | `S` | Auto-discover & batch-link local copies (Stacks tab) |
@@ -365,6 +376,25 @@ Probes reuse the same SSH access as the health view (`site_user@ip`, your local
 keys, `BatchMode`) and are **read-only**. Results are cached to
 `~/.config/spinupwp-tui/stack-cache.json`, hydrated at startup, so detections
 survive restarts without re-running SSH.
+
+## Installed plugins & themes
+
+Press `p` on a site (Servers tab, sites pane) to list its installed plugins and
+themes over SSH — the `wp plugin list` / `wp theme list` detail the SpinupWP API
+never exposes (it only gives you *counts* of pending updates). You see every
+plugin and theme with its **status** (active / inactive / must-use / dropin),
+**current version**, and the **new version** when an update is available (`→ 1.2.3`
+in gold; `✓ current` otherwise), grouped into `PLUGINS` and `THEMES` sections each
+with an update badge.
+
+It's strictly **read-only**: it runs wp-cli as the site user using your local SSH
+keys (the same non-interactive auth the health view uses), and **detects the real
+WordPress directory itself** rather than trusting the `public_folder` setting — so
+it works on standard `/public/` installs and Bedrock (`web/wp`) alike, and even on
+sites SpinupWP misclassifies as non-WordPress (it finds WordPress core over SSH).
+Non-WordPress sites get a clear "no WordPress core found" message.
+
+`↑↓` / `jk` scroll, `r` re-reads over SSH, `Esc` / `q` / `p` closes.
 
 ## Upgrading PHP
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spinupwp-tui",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "A cool terminal UI for browsing and monitoring your SpinupWP servers and sites.",
   "type": "module",
   "bin": {

--- a/src/lib/wpInventory.ts
+++ b/src/lib/wpInventory.ts
@@ -1,0 +1,153 @@
+// A site's installed plugins & themes over SSH — the `wp plugin list` / `wp theme
+// list` detail the API never exposes (it only counts pending updates). Strictly
+// read-only: we shell out to the local `ssh` client as the site user (the same
+// non-interactive, key-based auth the health view uses) and run wp-cli in the
+// site's real WordPress directory.
+//
+// The WP dir is DETECTED, never assumed: `public_folder` is a setting, not a fact
+// (see CLAUDE.md "WordPress layout rules"), so we reuse the clone wizard's
+// wp-settings.php probe to locate core on both /public/ and root-webroot sites.
+
+import type { Server, Site } from "../api/types.ts"
+import { SSH_OPTS, sshPort } from "./dbBackup.ts"
+import { detectWpDirScript } from "./serverClone.ts"
+
+// One plugin or theme, mirroring `wp {plugin,theme} list` columns.
+export interface WpItem {
+  name: string
+  status: string // active | inactive | must-use | dropin | parent | active-network
+  version: string
+  update: string // available | none | unavailable
+  updateVersion: string | null // the version an update would install, when available
+}
+
+export interface WpInventory {
+  plugins: WpItem[]
+  themes: WpItem[]
+}
+
+export type WpInventoryResult =
+  | { ok: true; target: string; wpDir: string; inventory: WpInventory }
+  | { ok: false; target: string; error: string }
+
+// wp-cli's JSON fields (snake_case) → our WpItem.
+interface RawItem {
+  name?: string
+  status?: string
+  version?: string
+  update?: string | boolean // wp emits `false` for must-use/dropin items
+  update_version?: string
+}
+
+function normalize(raw: RawItem[]): WpItem[] {
+  return raw.map((r) => ({
+    name: r.name ?? "(unknown)",
+    status: r.status ?? "",
+    version: r.version ?? "",
+    update: typeof r.update === "string" ? r.update : "none",
+    updateVersion: r.update_version && r.update_version !== "" ? r.update_version : null,
+  }))
+}
+
+// Split the batched remote output into its ===LABEL sections.
+function splitSections(out: string): Record<string, string[]> {
+  const sections: Record<string, string[]> = {}
+  let current = ""
+  for (const rawLine of out.split("\n")) {
+    const line = rawLine.replace(/\r$/, "")
+    const m = line.match(/^===([A-Z]+)$/)
+    if (m) {
+      current = m[1]
+      sections[current] = []
+    } else if (current) {
+      sections[current].push(line)
+    }
+  }
+  return sections
+}
+
+// wp --format=json emits a single-line JSON array; tolerate blank/garbage by
+// returning [] rather than throwing (a fresh site can legitimately have 0 themes).
+function parseJsonArray(lines: string[] | undefined): RawItem[] {
+  const text = (lines ?? []).join("").trim()
+  if (!text) return []
+  try {
+    const parsed = JSON.parse(text)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+export async function fetchWpInventory(
+  server: Server,
+  site: Site,
+  sshUser: string | null,
+): Promise<WpInventoryResult> {
+  const ip = server.ip_address
+  const user = site.site_user ?? sshUser
+  if (!ip) return { ok: false, target: "(no IP)", error: "Server has no IP address." }
+  if (!user) return { ok: false, target: ip, error: "Site has no site user — can't SSH in to read wp-cli." }
+  const target = `${user}@${ip}`
+  // We deliberately do NOT gate on site.is_wordpress: the API flag is unreliable
+  // (it's false for many git/Bedrock sites and for Standard-WP sites SpinupWP
+  // misclassified — e.g. a /public/ install imported as "Generic"). The remote
+  // wp-settings.php probe below is authoritative for both /public/ and Bedrock
+  // (web/wp) layouts, and returns a clean "no core found" error otherwise.
+  const root = `/sites/${site.domain}/files`
+  const fields = "name,status,version,update,update_version"
+  // Detect the WP dir, bail cleanly if there's no core, then list both from it.
+  const remote = [
+    detectWpDirScript(root, site.public_folder ?? undefined),
+    `if [ -z "$W" ]; then echo ===NOTWP; echo ===END; exit 0; fi`,
+    `WP=$(command -v wp 2>/dev/null || echo /usr/local/bin/wp)`,
+    `echo ===WPDIR; printf '%s\\n' "$W"`,
+    // The trailing `echo` after each wp command is load-bearing: `wp --format=json`
+    // emits NO trailing newline, so without it the next ===MARKER glues onto the end
+    // of the JSON line — the marker never parses and JSON.parse chokes on it.
+    `echo ===PLUGINS; "$WP" --path="$W" plugin list --fields=${fields} --format=json 2>/dev/null || true; echo`,
+    `echo ===THEMES; "$WP" --path="$W" theme list --fields=${fields} --format=json 2>/dev/null || true; echo`,
+    `echo ===END`,
+  ].join("\n")
+
+  let proc: ReturnType<typeof Bun.spawn>
+  try {
+    proc = Bun.spawn(["ssh", ...SSH_OPTS, ...sshPort(server.ssh_port ?? null), target, remote], {
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    })
+  } catch (err) {
+    return { ok: false, target, error: `Failed to launch ssh: ${(err as Error).message}` }
+  }
+  const timer = setTimeout(() => {
+    try {
+      proc.kill()
+    } catch {
+      /* already gone */
+    }
+  }, 45_000)
+  const code = await proc.exited
+  clearTimeout(timer)
+  const stdout = await new Response(proc.stdout as ReadableStream<Uint8Array>).text()
+  const stderr = await new Response(proc.stderr as ReadableStream<Uint8Array>).text()
+
+  if (code !== 0 && !stdout.includes("===END")) {
+    const reason = stderr.trim().split("\n").slice(-2).join(" ") || `ssh exited with code ${code}`
+    return { ok: false, target, error: reason }
+  }
+
+  const s = splitSections(stdout)
+  if ("NOTWP" in s) {
+    return { ok: false, target, error: `No WordPress core found under ${root} — is this a WordPress site?` }
+  }
+  const wpDir = (s.WPDIR?.[0] || root).trim()
+  const plugins = normalize(parseJsonArray(s.PLUGINS))
+  const themes = normalize(parseJsonArray(s.THEMES))
+  return { ok: true, target, wpDir, inventory: { plugins, themes } }
+}
+
+// Count of items with an update available — for section-header badges.
+export function updateCount(items: WpItem[]): number {
+  return items.filter((i) => i.update === "available").length
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -32,6 +32,7 @@ import { LocalLinkOverlay } from "./views/LocalLink.tsx"
 import { Discover } from "./views/Discover.tsx"
 import { Forgotten } from "./views/Forgotten.tsx"
 import { DnsInventory } from "./views/DnsInventory.tsx"
+import { WpInventory } from "./views/WpInventory.tsx"
 import { ProviderConnect } from "./views/ProviderConnect.tsx"
 import { DnsRecords } from "./views/DnsRecords.tsx"
 import { KumaSite } from "./views/KumaSite.tsx"
@@ -58,6 +59,7 @@ export function App() {
     showExplain ||
     store.releaseNotesInfo !== null ||
     store.healthServer !== null ||
+    store.wpInventorySite !== null ||
     store.phpUpgradeSite !== null ||
     store.httpsToggleSite !== null ||
     store.purgeCacheSite !== null ||
@@ -116,6 +118,9 @@ export function App() {
 
     // The health overlay owns the keyboard while open (it handles Esc/q/r/h).
     if (store.healthServer) return
+
+    // The plugins/themes overlay owns the keyboard while open.
+    if (store.wpInventorySite) return
 
     // The PHP-upgrade overlay owns the keyboard while open.
     if (store.phpUpgradeSite) return
@@ -231,6 +236,7 @@ export function App() {
       {showExplain && <ExplainOverlay route={store.route} />}
       {store.releaseNotesInfo && <ReleaseNotes />}
       {store.healthServer && <Health />}
+      {store.wpInventorySite && <WpInventory />}
       {store.phpUpgradeSite && <PhpUpgrade />}
       {store.httpsToggleSite && <HttpsToggle />}
       {store.purgeCacheSite && <PurgeCache />}

--- a/src/ui/Details.tsx
+++ b/src/ui/Details.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react"
 import { theme, statusColor, diskColor } from "../lib/theme.ts"
 import { formatBytes, diskUsedPct, bar, formatDate, timeAgo, truncate } from "../lib/format.ts"
 import { Field, StatusBadge, ControlPanel, type ActionGroup } from "./components.tsx"
-import { classifyStack, stackColor } from "../lib/stack.ts"
+import { effectiveStack, stackColor } from "../lib/stack.ts"
 import { probeKindColor } from "../lib/probe.ts"
 import { resolveLocalLink } from "../lib/local.ts"
 import { normalizeDomain } from "../lib/dns.ts"
@@ -137,8 +137,12 @@ export function SiteDetail({ site, serverName }: { site: Site; serverName: strin
   const httpsProgress = httpsToggles.get(site.id)
   const purgeProgress = purgeCacheProgress.get(site.id)
   const updates = (site.wp_plugin_updates || 0) + (site.wp_theme_updates || 0) + (site.wp_core_update ? 1 : 0)
-  const stack = classifyStack(site)
   const probe = probes.get(site.id)
+  // Prefer the DETECTED stack over SpinupWP's is_wordpress/git shape, which
+  // misclassifies some sites (a /public/ WP install shows as "Generic", Bedrock
+  // git sites report is_wordpress:false). Falls back to the API when unprobed.
+  const stack = effectiveStack(site, probe?.result.kind)
+  const isWordPress = stack !== "Non-WP"
   const probing = probingIds.has(site.id)
   const upgrade = phpUpgrades.get(site.id)
   const link = localLinks.get(site.id)
@@ -173,7 +177,7 @@ export function SiteDetail({ site, serverName }: { site: Site; serverName: strin
         value={probing ? "identifying…" : probe ? probe.result.label + (isProbeStale(site) ? " (stale)" : "") : "not identified · d"}
         valueColor={probing ? theme.textDim : probe ? probeKindColor(probe.result.kind) : theme.textFaint}
       />
-      <Field label="Type" value={site.is_wordpress ? "WordPress" : "Generic"} valueColor={site.is_wordpress ? theme.brand : theme.textDim} />
+      <Field label="Type" value={isWordPress ? "WordPress" : "Generic"} valueColor={isWordPress ? theme.brand : theme.textDim} />
       <Field
         label="PHP"
         value={

--- a/src/ui/components.tsx
+++ b/src/ui/components.tsx
@@ -228,6 +228,61 @@ export function SiteMetaCell({
   )
 }
 
+// The main Sites-row status column: a FIXED-slot capability strip so the stack /
+// PHP columns after it line up across every row (unlike SiteMetaCell, whose
+// present-or-absent marks shove later columns around). Each slot reserves the
+// same width whether or not the capability is on — a lit letter when on, a faint
+// "·" when off — giving a scannable H/C/B matrix down the list:
+//   ◆   local working copy linked
+//   👤🔑 personal / machine SSH key on the site (2-emoji-wide slot, always)
+//   H   HTTPS enabled   C  page cache enabled   B  backups (files or db) enabled
+//   ↑N  N pending WordPress updates
+// Detail (which keys, backup schedule, etc.) lives in the Details pane / context
+// strip; this strip is glance-only.
+export function SiteStatusColumn({
+  linked,
+  personalKey = false,
+  machineKey = false,
+  https,
+  cache,
+  backup,
+  updates,
+  selected = false,
+}: {
+  linked: boolean
+  personalKey?: boolean
+  machineKey?: boolean
+  https: boolean
+  cache: boolean
+  backup: boolean
+  updates: number
+  selected?: boolean
+}) {
+  const onColor = selected ? theme.text : theme.good
+  const offColor = selected ? theme.textDim : theme.textFaint
+  // A fixed-width toggle slot: the letter when on, a faint dot when off.
+  const flag = (label: string, on: boolean) => (
+    <text content={`${on ? label : "·"} `} fg={on ? onColor : offColor} wrapMode="none" style={{ flexShrink: 0 }} />
+  )
+  // Key slot is always two emoji-cells wide (pad the empties) so H/C/B never shift.
+  const keyCell = (personalKey ? "👤" : "  ") + (machineKey ? "🔑" : "  ")
+  return (
+    <box style={{ flexDirection: "row", flexShrink: 0 }}>
+      <text content={`${linked ? "◆" : " "} `} fg={selected ? theme.text : theme.good} wrapMode="none" style={{ flexShrink: 0 }} />
+      <text content={`${keyCell} `} wrapMode="none" style={{ flexShrink: 0 }} />
+      {flag("H", https)}
+      {flag("C", cache)}
+      {flag("B", backup)}
+      <text
+        content={updates > 0 ? `↑${updates} `.padEnd(4) : "    "}
+        fg={selected ? theme.text : theme.warn}
+        wrapMode="none"
+        style={{ flexShrink: 0 }}
+      />
+    </box>
+  )
+}
+
 // A masked text field for secrets/tokens. OpenTUI's <input> keeps its own editor
 // buffer and has no masking/password mode, so a controlled "show dots" value
 // fights that buffer (the secret flashes, then the field clears). Instead this

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -473,6 +473,9 @@ interface StoreValue extends DataState {
   // The server whose live health view is open, or null. Set by the Browser.
   healthServer: Server | null
   setHealthServer: (s: Server | null) => void
+  // The site whose plugins/themes (wp-cli) view is open, or null. Set by site views.
+  wpInventorySite: Site | null
+  setWpInventorySite: (s: Site | null) => void
   // The site whose PHP-upgrade overlay is open, or null. Set by site views.
   phpUpgradeSite: Site | null
   setPhpUpgradeSite: (s: Site | null) => void
@@ -920,6 +923,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const [inputMode, setInputMode] = useState(false)
   const [overlayOpen, setOverlayOpen] = useState(false)
   const [healthServer, setHealthServer] = useState<Server | null>(null)
+  const [wpInventorySite, setWpInventorySite] = useState<Site | null>(null)
   const [phpUpgradeSite, setPhpUpgradeSite] = useState<Site | null>(null)
   const [phpUpgrades, setPhpUpgrades] = useState<Map<number, PhpUpgradeProgress>>(new Map())
   const [httpsToggleSite, setHttpsToggleSite] = useState<Site | null>(null)
@@ -4040,6 +4044,8 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     setOverlayOpen,
     healthServer,
     setHealthServer,
+    wpInventorySite,
+    setWpInventorySite,
     phpUpgradeSite,
     setPhpUpgradeSite,
     phpUpgrades,

--- a/src/ui/views/Browser.tsx
+++ b/src/ui/views/Browser.tsx
@@ -8,9 +8,9 @@
 import { useEffect, useMemo, useState } from "react"
 import { useKeyboard } from "@opentui/react"
 import { theme, statusColor, statusDot } from "../../lib/theme.ts"
-import { classifyStack, stackColor, stackTag } from "../../lib/stack.ts"
+import { effectiveStack, stackColor, stackTag } from "../../lib/stack.ts"
 import { truncate } from "../../lib/format.ts"
-import { Panel, PhpVersionCell, Spinner, SiteMetaCell } from "../components.tsx"
+import { Panel, PhpVersionCell, Spinner, SiteStatusColumn } from "../components.tsx"
 import { List, moveSelection } from "../List.tsx"
 import { ServerDetail, SiteDetail, SiteContextStrip, SITE_CONTEXT_STRIP_HEIGHT } from "../Details.tsx"
 import { StatusBar } from "../StatusBar.tsx"
@@ -23,7 +23,7 @@ type Focus = "servers" | "sites"
 
 export function Browser({ rows }: { rows: number }) {
   const store = useStore()
-  const { servers, sitesForServer, route, inputMode, overlayOpen, setHealthServer, runProbe, accountSlug, setPhpUpgradeSite, phpUpgrades, setHttpsToggleSite, setPurgeCacheSite, setGrantKeySite, setSudoConnectServer, isSudoConnected, grantedKeyKinds, setServerActionsServer, serverOps, setLocalLinkSite, openLocalTerminal, openLocalUrl, localLinks, sshSite, setDnsInventoryServer, setNewServerSource, setNewServerOpen, setVanityServer, vanityJob, beginClone, isServerOsEol, setKumaSite } = store
+  const { servers, sitesForServer, route, inputMode, overlayOpen, setHealthServer, setWpInventorySite, runProbe, probes, accountSlug, setPhpUpgradeSite, phpUpgrades, setHttpsToggleSite, setPurgeCacheSite, setGrantKeySite, setSudoConnectServer, isSudoConnected, grantedKeyKinds, setServerActionsServer, serverOps, setLocalLinkSite, openLocalTerminal, openLocalUrl, localLinks, sshSite, setDnsInventoryServer, setNewServerSource, setNewServerOpen, setVanityServer, vanityJob, beginClone, isServerOsEol, setKumaSite } = store
 
   const [serverIndex, setServerIndex] = useState(0)
   const [siteIndex, setSiteIndex] = useState(0)
@@ -152,6 +152,10 @@ export function Browser({ rows }: { rows: number }) {
         // DNS inventory scoped to the selected site (its domains + records).
         if (focus === "sites" && sites[siteIndex] && server) setDnsInventoryServer(server, sites[siteIndex].id)
         return
+      case "p":
+        // Plugins & themes (wp-cli over SSH) for the selected site.
+        if (focus === "sites" && sites[siteIndex]) setWpInventorySite(sites[siteIndex])
+        return
       case "N":
         // Server-wide DNS inventory — every site on the server.
         if (server) setDnsInventoryServer(server)
@@ -236,6 +240,7 @@ export function Browser({ rows }: { rows: number }) {
           { key: "u", label: "change PHP" },
           { key: "m", label: "monitoring" },
           { key: "K", label: "grant key" },
+          { key: "p", label: "plugins" },
           { key: "o", label: "open" },
           { key: "w", label: "SpinupWP" },
           { key: "s", label: "ssh" },
@@ -285,7 +290,15 @@ export function Browser({ rows }: { rows: number }) {
         </Panel>
 
         {/* Sites pane */}
-        <Panel title={server ? ` Sites · ${truncate(server.name, 20)} (${sites.length}) ` : " Sites "} active={focus === "sites"} flexGrow={1}>
+        <Panel
+          title={
+            server
+              ? ` Sites · ${truncate(server.name, 20)} (${sites.length})   👤🔑 keys · H·C·B https/cache/backup `
+              : " Sites "
+          }
+          active={focus === "sites"}
+          flexGrow={1}
+        >
           <List
             items={sites}
             selectedIndex={siteIndex}
@@ -295,7 +308,11 @@ export function Browser({ rows }: { rows: number }) {
             emptyText="No sites yet — press V to create a vanity site and connect this server"
             renderRow={(s, selected) => {
               const updates = (s.wp_plugin_updates || 0) + (s.wp_theme_updates || 0) + (s.wp_core_update ? 1 : 0)
-              const stack = classifyStack(s)
+              // Use the DETECTED stack (probe result) so the tag reflects `d identify`
+              // — SpinupWP's is_wordpress/git shape misclassifies some sites (e.g. a
+              // /public/ WP install shown as "app" until probed). Falls back to the
+              // API classification when unprobed. Matches the Stacks / Forgotten views.
+              const stack = effectiveStack(s, probes.get(s.id)?.result.kind)
               const keyKinds = grantedKeyKinds(s.id)
               // The server's own vanity/health page blends in perfectly when servers
               // are named like domains — mark it (⌂ + brand tint) so it can't hide.
@@ -309,8 +326,20 @@ export function Browser({ rows }: { rows: number }) {
                     wrapMode="none"
                     style={{ flexGrow: 1, flexShrink: 1 }}
                   />
-                  <SiteMetaCell linked={localLinks.has(s.id)} updates={updates} personalKey={keyKinds.personal > 0} machineKey={keyKinds.machine > 0} selected={selected} />
-                  <text content={stackTag(stack) + " "} fg={stackColor(stack, selected)} style={{ flexShrink: 0 }} />
+                  <SiteStatusColumn
+                    linked={localLinks.has(s.id)}
+                    personalKey={keyKinds.personal > 0}
+                    machineKey={keyKinds.machine > 0}
+                    https={!!s.https?.enabled}
+                    cache={!!s.page_cache?.enabled}
+                    backup={!!(s.backups?.files || s.backups?.database)}
+                    updates={updates}
+                    selected={selected}
+                  />
+                  {/* Fixed-width stack column (widest tag = "bedrock" = 7) so the
+                      icon columns to its left, and the PHP column to its right,
+                      stay vertically aligned across every row regardless of tag. */}
+                  <text content={stackTag(stack).padEnd(7) + " "} fg={stackColor(stack, selected)} wrapMode="none" style={{ flexShrink: 0 }} />
                   <PhpVersionCell version={s.php_version} upgrade={phpUpgrades.get(s.id)} selected={selected} />
                 </>
               )

--- a/src/ui/views/WpInventory.tsx
+++ b/src/ui/views/WpInventory.tsx
@@ -1,0 +1,218 @@
+// A site's installed plugins & themes (full-screen overlay).
+//
+// Opened from the Browser with `p`. Runs `wp plugin list` / `wp theme list` over
+// SSH (read-only) and renders them as one combined, scrollable list with PLUGINS
+// and THEMES section headers — the `wp plugin list` detail (current version +
+// update-available) the SpinupWP API never exposes. Esc/q/p closes it.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useKeyboard, useTerminalDimensions } from "@opentui/react"
+import { theme } from "../../lib/theme.ts"
+import { truncate } from "../../lib/format.ts"
+import { Spinner, Centered } from "../components.tsx"
+import { List, moveSelection } from "../List.tsx"
+import { StatusBar } from "../StatusBar.tsx"
+import { useStore } from "../store.tsx"
+import { fetchWpInventory, updateCount, type WpInventory as Inventory, type WpItem } from "../../lib/wpInventory.ts"
+
+// A flattened row: a section header, or one plugin/theme item.
+type Row =
+  | { kind: "header"; label: string; count: number; updates: number }
+  | { kind: "item"; item: WpItem }
+
+function buildRows(inv: Inventory): Row[] {
+  const rows: Row[] = []
+  rows.push({ kind: "header", label: "PLUGINS", count: inv.plugins.length, updates: updateCount(inv.plugins) })
+  for (const item of inv.plugins) rows.push({ kind: "item", item })
+  rows.push({ kind: "header", label: "THEMES", count: inv.themes.length, updates: updateCount(inv.themes) })
+  for (const item of inv.themes) rows.push({ kind: "item", item })
+  return rows
+}
+
+// Active items get a filled dot; inactive an open one; must-use/dropin a diamond.
+function statusGlyph(status: string): { glyph: string; color: string } {
+  if (status === "inactive") return { glyph: "○", color: theme.textFaint }
+  if (status === "must-use" || status === "dropin") return { glyph: "◆", color: theme.textDim }
+  return { glyph: "●", color: theme.good } // active / active-network / parent
+}
+
+function ItemRow({ item, selected }: { item: WpItem; selected: boolean }) {
+  const s = statusGlyph(item.status)
+  const hasUpdate = item.update === "available"
+  return (
+    <>
+      <text content=" " style={{ flexShrink: 0 }} />
+      <text content={`${s.glyph} `} fg={selected ? theme.text : s.color} wrapMode="none" style={{ flexShrink: 0 }} />
+      <text
+        content={truncate(item.name, 34)}
+        fg={selected ? theme.text : theme.text}
+        wrapMode="none"
+        style={{ flexGrow: 1, flexShrink: 1 }}
+      />
+      <text content={(item.status || "—").padEnd(10)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} />
+      <text content={(item.version || "—").padEnd(12)} fg={selected ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} />
+      {hasUpdate ? (
+        <text content={`→ ${item.updateVersion ?? "update"}`} fg={selected ? theme.text : theme.update} wrapMode="none" style={{ flexShrink: 0 }} />
+      ) : (
+        <text content="✓ current" fg={selected ? theme.text : theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
+      )}
+      <text content=" " style={{ flexShrink: 0 }} />
+    </>
+  )
+}
+
+function HeaderRow({ row }: { row: Extract<Row, { kind: "header" }> }) {
+  return (
+    <>
+      <text content={` ${row.label} `} fg={theme.brand} wrapMode="none" style={{ flexShrink: 0 }} />
+      <text content={`(${row.count})`} fg={theme.textDim} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
+      {row.updates > 0 ? (
+        <text content={`${row.updates} update${row.updates === 1 ? "" : "s"} `} fg={theme.update} wrapMode="none" style={{ flexShrink: 0 }} />
+      ) : (
+        <text content="up to date " fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
+      )}
+    </>
+  )
+}
+
+export function WpInventory() {
+  const { wpInventorySite, setWpInventorySite, serverById, sshUser } = useStore()
+  const { height } = useTerminalDimensions()
+  const site = wpInventorySite
+  const server = useMemo(() => serverById(site?.server_id), [serverById, site?.server_id])
+
+  const [inv, setInv] = useState<Inventory | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [target, setTarget] = useState("")
+  const [loading, setLoading] = useState(true)
+  const [selected, setSelected] = useState(0)
+  const busy = useRef(false)
+
+  const load = useCallback(async () => {
+    if (!site || !server || busy.current) return
+    busy.current = true
+    setLoading(true)
+    const res = await fetchWpInventory(server, site, sshUser)
+    busy.current = false
+    setTarget(res.target)
+    setLoading(false)
+    if (res.ok) {
+      setInv(res.inventory)
+      setError(null)
+    } else {
+      setError(res.error)
+      setInv(null)
+    }
+  }, [site, server, sshUser])
+
+  useEffect(() => {
+    setInv(null)
+    setError(null)
+    setSelected(0)
+    void load()
+  }, [load])
+
+  const rows = useMemo(() => (inv ? buildRows(inv) : []), [inv])
+
+  useKeyboard((key) => {
+    if (key.name === "escape" || key.name === "q" || key.name === "p") return setWpInventorySite(null)
+    if (key.name === "r") return void load()
+    if (rows.length === 0) return
+    if (key.name === "up" || key.name === "k") setSelected((i) => moveSelection(i, -1, rows.length))
+    else if (key.name === "down" || key.name === "j") setSelected((i) => moveSelection(i, 1, rows.length))
+    else if (key.name === "g") setSelected(0)
+    else if (key.name === "G") setSelected(rows.length - 1)
+  })
+
+  if (!site) return null
+
+  const totalUpdates = inv ? updateCount(inv.plugins) + updateCount(inv.themes) : 0
+  const listRows = Math.max(3, height - 4)
+
+  return (
+    <box
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        height: "100%",
+        flexDirection: "column",
+        backgroundColor: theme.bg,
+        zIndex: 200,
+      }}
+    >
+      {/* Title bar */}
+      <box
+        style={{
+          flexDirection: "row",
+          height: 1,
+          backgroundColor: theme.bgAlt,
+          paddingLeft: 1,
+          paddingRight: 1,
+          alignItems: "center",
+        }}
+      >
+        <text content="⧉ Plugins & Themes  " fg={theme.brand} style={{ flexShrink: 0 }} />
+        <text content={truncate(site.domain, 40)} fg={theme.text} wrapMode="none" style={{ flexShrink: 1 }} />
+        {inv && totalUpdates > 0 ? (
+          <text content={`  ↑${totalUpdates} update${totalUpdates === 1 ? "" : "s"}`} fg={theme.update} wrapMode="none" style={{ flexShrink: 0 }} />
+        ) : null}
+        <box style={{ flexGrow: 1 }} />
+        {loading && <Spinner interval={120} />}
+        <text content={target ? `  ${target}` : "  connecting…"} fg={theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
+      </box>
+
+      {loading && !inv && !error ? (
+        <Centered>
+          <box style={{ flexDirection: "row" }}>
+            <Spinner />
+            <text content={`  Reading plugins & themes over SSH…`} fg={theme.textDim} />
+          </box>
+        </Centered>
+      ) : error ? (
+        <Centered>
+          <box
+            title=" Couldn't read this site "
+            titleColor={theme.bad}
+            border
+            borderColor={theme.bad}
+            style={{ flexDirection: "column", width: 72, paddingLeft: 2, paddingRight: 2, paddingTop: 1, paddingBottom: 1 }}
+          >
+            <text content={`✕ ${error}`} fg={theme.bad} wrapMode="none" />
+            <box style={{ height: 1 }} />
+            <text content={`Tried:  ssh ${target}`} fg={theme.textDim} wrapMode="none" />
+            <text content="Reads via your local SSH keys as the site user (no password prompts)." fg={theme.textFaint} wrapMode="none" />
+            <text content={`Verify first:  ssh ${target} 'wp --path=/sites/${site.domain}/files plugin list'`} fg={theme.textFaint} wrapMode="none" />
+            <box style={{ height: 1 }} />
+            <text content="Press r to retry · Esc to close" fg={theme.textDim} />
+          </box>
+        </Centered>
+      ) : inv ? (
+        <box style={{ flexGrow: 1, flexDirection: "column", paddingLeft: 1, paddingRight: 1, paddingTop: 1 }}>
+          <List
+            items={rows}
+            selectedIndex={selected}
+            viewportRows={listRows}
+            focused
+            keyFor={(_r, i) => i}
+            emptyText="No plugins or themes found."
+            renderRow={(row, isSel) =>
+              row.kind === "header" ? <HeaderRow row={row} /> : <ItemRow item={row.item} selected={isSel} />
+            }
+          />
+        </box>
+      ) : null}
+
+      <StatusBar
+        hints={[
+          { key: "↑↓/jk", label: "scroll" },
+          { key: "r", label: "refresh" },
+          { key: "esc/q", label: "close" },
+        ]}
+        message={inv ? `${inv.plugins.length} plugins · ${inv.themes.length} themes` : undefined}
+        showGlobal={false}
+      />
+    </box>
+  )
+}


### PR DESCRIPTION
Two additions to the Servers view, plus a stack-detection fix — and the v0.18.0 release roll.

## Highlights
- **At-a-glance status column.** Every site row shows a fixed-width capability strip — `👤🔑` granted SSH keys, `H` HTTPS, `C` page cache, `B` backups (lit when on, faint `·` when off), plus `◆` linked and `↑N` pending updates — aligned into columns across the whole list. The site stack tag is now fixed-width so nothing jitters, and a compact key sits in the Sites panel title.
- **Installed plugins & themes (`p`).** Read-only `wp plugin list` / `wp theme list` over SSH: every plugin and theme with its status, current version, and available update (`→ 1.2.3`) — the detail the API only exposes as bare counts. Detects the real WordPress dir itself, so it works on `/public/` and Bedrock installs alike.

## Fixed
- **Stack & type follow the `d`-identify probe, not `is_wordpress`.** That flag is false for Bedrock/git sites and for Standard-WP `/public/` installs SpinupWP imported as "Generic", so a real WordPress site could show as `app` (and Details "Type" as Generic) even after `d` detected it. The row tag, Details "Stack"/"Type", and the plugins/themes view now use the detected stack / confirm WP core over SSH.

## Testing
- Verified live against the fleet: status column alignment across mixed stacks/keys; plugins/themes view on Standard-WP, `/public/`, and Bedrock sites; the misclassified-`app` site (`is_wordpress:false`) now lists plugins correctly.
- Caught (and fixed) a `wp --format=json`-has-no-trailing-newline bug that only live SSH testing surfaces — typecheck was green throughout.

README (Features / Keybindings / new section) and CHANGELOG updated; `package.json` bumped to 0.18.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)