### PR TITLE
fix: clone wizard falsely failed sites on slow add-domain events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+### Fixed
+- **Clone wizard no longer falsely fails a site when SpinupWP is slow to run its
+  add-domain event.** SpinupWP serializes events per server, so under a concurrent
+  clone an additional-domain add can sit queued for minutes behind site-creates.
+  The wizard's poll gave up after a flat 3 minutes and reported "failed on
+  SpinupWP" — aborting the site before any files were copied — even when the event
+  went on to succeed seconds later (2026-07-07 post-mortem, event 40454437). The
+  poll now waits out queueing with a generous 30-minute backstop, takes one final
+  look at the event before giving up, and when it does time out it says so
+  honestly ("gave up waiting … retry the site to re-check") instead of blaming
+  SpinupWP — a per-site retry safely resumes, since already-added domains are
+  skipped.
+
 ## [0.18.0] - 2026-07-07
 
 ### Added

--- a/src/lib/cloneDomains.ts
+++ b/src/lib/cloneDomains.ts
@@ -11,23 +11,41 @@ import type { AdditionalDomain } from "../api/types.ts"
 const EVENT_DONE = new Set(["deployed", "completed", "provisioned", "finished", "success"])
 const EVENT_FAIL = new Set(["failed", "errored", "error"])
 
+type PollOutcome = { outcome: "done" } | { outcome: "failed" } | { outcome: "timeout"; lastStatus?: string }
+
 // 5s cadence; a transient failure to READ the event is not the event failing —
 // tolerate a few consecutive API errors (the client already absorbs 429 bursts).
-async function pollEvent(client: SpinupWPClientLike, eventId: number, timeoutMs = 180_000): Promise<boolean> {
+// The timeout is a generous BACKSTOP, not an expectation: SpinupWP serializes
+// events per server, so under a concurrent clone an add-domain event can sit
+// queued for minutes behind site-creates. (The 2026-07-07 sparkmamas run sat
+// queued 173s and a flat 180s deadline declared it failed 12s before it
+// deployed — every timeout must be reported as a timeout, never as a failure.)
+export async function pollEvent(client: SpinupWPClientLike, eventId: number, timeoutMs = 1_800_000, pollMs = 5000): Promise<PollOutcome> {
   const deadline = Date.now() + timeoutMs
   let apiErrs = 0
+  let lastStatus: string | undefined
   while (Date.now() < deadline) {
-    await new Promise((r) => setTimeout(r, 5000))
+    await new Promise((r) => setTimeout(r, pollMs))
     try {
       const e = await client.getEvent(eventId)
       apiErrs = 0
-      if (EVENT_FAIL.has(e.status)) return false
-      if (EVENT_DONE.has(e.status) || e.finished_at) return true
+      lastStatus = e.status
+      if (EVENT_FAIL.has(e.status)) return { outcome: "failed" }
+      if (EVENT_DONE.has(e.status) || e.finished_at) return { outcome: "done" }
     } catch {
-      if (++apiErrs >= 3) return false
+      if (++apiErrs >= 3) return { outcome: "timeout", lastStatus }
     }
   }
-  return false
+  // One last look before giving up — the event may have finished on the wire.
+  try {
+    const e = await client.getEvent(eventId)
+    if (EVENT_FAIL.has(e.status)) return { outcome: "failed" }
+    if (EVENT_DONE.has(e.status) || e.finished_at) return { outcome: "done" }
+    lastStatus = e.status
+  } catch {
+    /* keep the polled status */
+  }
+  return { outcome: "timeout", lastStatus }
 }
 
 export interface DomainSyncResult {
@@ -62,10 +80,16 @@ export async function syncAdditionalDomains(
         domain: d.domain,
         redirect: d.redirect ? { enabled: d.redirect.enabled, type: d.redirect.type, destination: d.redirect.destination } : undefined,
       })
-      const ok = await pollEvent(client, ev.event_id)
-      if (ok) {
+      const res = await pollEvent(client, ev.event_id)
+      if (res.outcome === "done") {
         result.added.push(d.domain)
-        log?.({ event: "domain-add", destSiteId, domain: d.domain, eventId: ev.event_id, ok })
+        log?.({ event: "domain-add", destSiteId, domain: d.domain, eventId: ev.event_id, ok: true })
+      } else if (res.outcome === "timeout") {
+        // NOT a SpinupWP failure — we stopped waiting. Retrying the site is safe
+        // (already-present domains are skipped), so point the user there.
+        const error = `gave up waiting for add-domain event ${ev.event_id}${res.lastStatus ? ` (still "${res.lastStatus}")` : ""} — it may yet finish on SpinupWP; retry the site to re-check`
+        result.failed.push({ domain: d.domain, error })
+        log?.({ event: "domain-add", destSiteId, domain: d.domain, eventId: ev.event_id, ok: false, outcome: "timeout", lastStatus: res.lastStatus })
       } else {
         // Pull the event's own output so the roster/log say WHY, not just "failed".
         let out = ""
@@ -76,7 +100,7 @@ export async function syncAdditionalDomains(
         }
         const error = `add-domain event ${ev.event_id} failed${out ? `: …${out.slice(-200)}` : " on SpinupWP"}`
         result.failed.push({ domain: d.domain, error })
-        log?.({ event: "domain-add", destSiteId, domain: d.domain, eventId: ev.event_id, ok, output: out })
+        log?.({ event: "domain-add", destSiteId, domain: d.domain, eventId: ev.event_id, ok: false, output: out })
       }
     } catch (err) {
       const error = (err as Error).message


### PR DESCRIPTION
## The bug (2026-07-07 post-mortem of a real transfer)

During a server-to-server transfer, the wizard created the dest site, requested the additional-domain add, and polled the event. SpinupWP serializes events per server, so with 3 concurrent site-creates the add-domain event sat **queued for 173s** — and `pollEvent`'s flat **180s deadline** expired while it was still working. The wizard reported *"add-domain event 40454437 failed on SpinupWP"* and aborted the site at the `create` step, so **no files were ever copied**. The event actually **deployed 12 seconds later**.

## The fix

- `pollEvent` now returns a typed outcome (`done` / `failed` / `timeout` + last-seen status) with a generous **30-minute backstop** instead of 3 minutes — queueing behind other events is normal under a concurrent clone, not a hang. (The site-*create* poll already had no deadline; this brings the domain poll in line.)
- One **final `getEvent` check** before giving up, so an event that finishes on the wire isn't dropped.
- A timeout is reported honestly — *"gave up waiting for add-domain event N (still \"queued\") — it may yet finish on SpinupWP; retry the site to re-check"* — never as a SpinupWP failure. Retry is safe: `syncAdditionalDomains` skips domains already on the dest.
- The JSONL clone log records `outcome` + `lastStatus` for timeouts.

## Verification

- `bun run typecheck` green.
- Scratch harness replayed all paths against a fake client: the real-world shape (35 queued polls → deployed) now resolves **done** (old code: false failure); genuine `failed` status still fails; a stuck event times out with its last status; `syncAdditionalDomains` end-to-end adds after a queue wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CG4F86wNKsGNwKztkM74Ua
