### PR TITLE
fix: honest header badge when a vanity build waits on your SSH key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+### Fixed
+- **The header no longer shows a perpetual "Connecting {server}…" spinner when a
+  vanity-site build is just waiting for you.** The connect flow's SSH-key step is
+  manual by design (add your key, confirm in the overlay), but the resumable job
+  surfaced it with the same animated spinner as active work — so a build parked
+  at that step looked stuck-connecting on every launch, with no hint of what it
+  wanted. That state now gets its own badge: `○ {server} needs your SSH key —
+  press V`. The active "Connecting…" badge also gained the "press V" pointer the
+  clone badge always had.
+
 ## [0.18.0] - 2026-07-07
 
 ### Added

--- a/src/ui/Header.tsx
+++ b/src/ui/Header.tsx
@@ -31,7 +31,11 @@ export function Header() {
   const kumaDown = [...kumaStatus.values()].filter((s) => s.up === false).length
   const updateReady = updateInfo?.updateAvailable ?? false
   const building = isNewServerInFlight(newServerJob)
-  const connecting = isVanityInFlight(vanityJob)
+  // The sshkey step is the one that waits on the USER (add your key, confirm in
+  // the overlay) — a spinner there reads as "working" when nothing is running,
+  // so it gets a distinct waiting badge that says what it wants and where.
+  const vanityWaiting = vanityJob?.step === "sshkey"
+  const connecting = isVanityInFlight(vanityJob) && !vanityWaiting
   const vanityStuck = vanityJob != null && vanityJob.step === "error"
   // Show a clone badge only when it's running AND backgrounded (wizard closed) — the
   // open wizard covers the screen, so no badge is needed there.
@@ -83,8 +87,11 @@ export function Header() {
         {connecting && (
           <box style={{ flexDirection: "row", flexShrink: 0, alignItems: "center" }}>
             <Spinner interval={120} color={theme.warn} />
-            <text content={`  Connecting ${truncate(vanityJob!.hostname, 22)}  `} fg={theme.warn} wrapMode="none" />
+            <text content={`  Connecting ${truncate(vanityJob!.hostname, 22)} — press V  `} fg={theme.warn} wrapMode="none" />
           </box>
+        )}
+        {vanityWaiting && (
+          <text content={`  ○ ${truncate(vanityJob!.hostname, 20)} needs your SSH key — press V  `} fg={theme.warn} style={{ flexShrink: 0 }} wrapMode="none" />
         )}
         {vanityStuck && <text content={`  ⚠ ${truncate(vanityJob!.hostname, 20)} — press V  `} fg={theme.bad} style={{ flexShrink: 0 }} wrapMode="none" />}
         {/* A backgrounded clone keeps running in the store — surface it so it's


### PR DESCRIPTION
## The report

"I commonly see a 'Connecting earth.wenmarkdigital…' message. What is this about? Bug?"

## Diagnosis

Not a stuck job — a resumable vanity-connect build (`V`) for earth.wenmarkdigital.com has been parked at the **sshkey step since July 6**. That step waits for the user by design (add your SSH key, confirm in the overlay) — and the key in question already works, so pressing `V` on earth will verify and finish the build. The bug is presentation: the header showed the same animated spinner + "Connecting…" as genuinely active steps, implying work was happening, with no hint of what the job wanted or how to reach it.

## Fix

- `step === "sshkey"` gets its own badge: `○ {server} needs your SSH key — press V` — no spinner, names the ask and the key.
- The true "Connecting…" badge (DNS/site/HTTPS steps actually running) now also says "— press V", matching the clone badge's reachability pointer.

## Verification

Typecheck green; PTY-rendered the header at 200 cols against the real parked job — badge reads `○ earth.wenmarkdigita… needs your SSH key — press V`.

Note: this PR, #26, and #27 each add entries under CHANGELOG `[Unreleased]` — whichever merges last may need a trivial conflict resolution there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CG4F86wNKsGNwKztkM74Ua