### PR TITLE
fix: clone wizard now consults probe-corrected stack classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+### Fixed
+- **The clone wizard no longer silently skips the database for API-mislabeled
+  WordPress sites.** Its stack picker read `is_wordpress` straight from the
+  API, unlike every other view (Stacks, Browser), which corrects that flag
+  against a `d` probe result. A site the API wrongly reports as non-WordPress
+  (confirmed live against two real client sites) would default to a files-only pull — filesystem copied, database never
+  touched, so the "clone" wasn't a working WordPress site. The wizard now
+  consults the same probe-corrected classification: **probe the site (`d`)
+  before cloning** so the wizard picks it up as WordPress.
+
 ## [0.19.1] - 2026-07-08
 
 ### Fixed

--- a/src/lib/stack.ts
+++ b/src/lib/stack.ts
@@ -49,6 +49,20 @@ export function effectiveStack(site: Site, probeKind?: ProbeKind | null): Stack 
   }
 }
 
+// Which pull the clone wizard runs for a site — the SAME effectiveStack a
+// probe corrects elsewhere (Stacks tab, Browser), so an API-mislabeled site
+// (is_wordpress=false but really WordPress — e.g. lp.anchoredconstructiontn.com,
+// northcoastmodern.com, verified live 2026-07-08) gets a real database pull
+// once probed, instead of silently defaulting to a files-only copy. git.repo
+// still takes precedence for Bedrock detection (the pull needs the repo URL,
+// which a probe alone can't supply) — a probe saying "bedrock" without a
+// connected repo can't actually be pulled as Bedrock, so it falls back to
+// files-only rather than a wrong wp-stack pull.
+export function cloneStackFor(site: Site, probeKind?: ProbeKind | null): "wp" | "bedrock" | "files" {
+  if (site.git?.repo) return "bedrock"
+  return effectiveStack(site, probeKind) === "Standard WP" ? "wp" : "files"
+}
+
 // `onSelection` brightens the colors that read poorly on the focused
 // (bright-green) selection background (green-on-green Bedrock, the faint grey).
 export function stackColor(stack: Stack, onSelection = false): string {

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -17,7 +17,7 @@ import { APP_VERSION } from "../version.ts"
 import { cachedUpdateInfo, refreshUpdateInfo, type UpdateInfo } from "../lib/appUpdate.ts"
 import { fetchReleaseNotes, type ReleaseNotesInfo } from "../lib/releaseNotes.ts"
 import { resolveLocalLink, expandPath, normalizeLink, type LocalLink } from "../lib/local.ts"
-import type { Stack } from "../lib/stack.ts"
+import { cloneStackFor, type Stack } from "../lib/stack.ts"
 import { openTerminalAt, openUrl, openSshSession } from "../lib/open.ts"
 import { gitDrift, type Drift } from "../lib/gitStatus.ts"
 import { probeSite } from "../lib/probe.ts"
@@ -343,12 +343,6 @@ export function cloneNeedsGitAccess(j: CloneJob): boolean {
 }
 export function isCloneInFlight(j: CloneJob | null | undefined): boolean {
   return j != null && j.step !== "done" && j.step !== "error"
-}
-// Detect a site's stack the way the clone branches: a git repo → Bedrock
-// (is_wordpress is unreliable for git sites — see the API findings doc);
-// is_wordpress → Standard WP; anything else → files-only (no DB, no wp-cli).
-export function cloneStackFor(site: Site): "wp" | "bedrock" | "files" {
-  return site.git?.repo ? "bedrock" : site.is_wordpress ? "wp" : "files"
 }
 // Alphanumeric token for generated dest DB passwords (never printed/persisted).
 function randomToken(n: number): string {
@@ -3335,8 +3329,11 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       }
       const srcSites = sitesForServer(server.id)
       const sites: CloneSiteState[] = srcSites.map((s) => {
-        const stack = cloneStackFor(s)
-        const isWordPress = s.is_wordpress
+        // Probe-corrected: an API-mislabeled site (is_wordpress=false but really
+        // WordPress) gets a real database pull once probed (`d`), instead of
+        // silently defaulting to a files-only copy — see cloneStackFor's comment.
+        const stack = cloneStackFor(s, probes.get(s.id)?.result.kind)
+        const isWordPress = stack !== "files"
         return {
           sourceSiteId: s.id,
           domain: s.domain,
@@ -3371,7 +3368,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       setCloneServer(server)
       setCloneJob(draft)
     },
-    [cloneJob, sitesForServer, servers],
+    [cloneJob, sitesForServer, servers, probes],
   )
 
   // Background an in-flight clone: hide the wizard but KEEP the job running (the


### PR DESCRIPTION
## The bug (live incident, 2026-07-08)

Today's `web4.wenmarkdigital.com → earth.wenmarkdigital.com` clone silently pulled **two real WordPress sites with no database**: both landed as `stack: "files"` in the job log.

Root cause: `cloneStackFor()` (previously in `store.tsx`) read `site.is_wordpress` straight from the API. Every *other* stack-aware view (Stacks tab, Browser) corrects that flag against a `d` probe result via `effectiveStack()` — SpinupWP's API is known to mislabel some real WordPress sites as `is_wordpress: false`, and these two are confirmed live examples. The clone wizard never got that correction, so a mislabeled site silently defaulted to a files-only pull: filesystem copied, database never touched. The result isn't a working WordPress site — visiting it hits a database-connection error.

## The fix

- `cloneStackFor` moved to `lib/stack.ts`, now takes an optional `probeKind` and defers to `effectiveStack()` for the WordPress/non-WordPress call — the exact same correction path the Stacks tab and Browser already use.
- `git.repo` still takes precedence for Bedrock detection (the pull needs the actual repo URL, which a probe alone can't supply) — a probe saying "bedrock" without a connected repo falls back to files-only rather than a wrong wp-stack pull.
- `store.tsx`'s `beginClone` now passes the live probe cache; the derived `isWordPress` field on `CloneSiteState` (previously unused, now correctness-consistent) reflects the corrected stack too.

## Verification

- `bun run typecheck` green.
- Live-verified against the real incident: neither site had a cached probe yet, so I ran the actual read-only SSH probe (`probeSite`) against both — both identify as `"wordpress"`. Feeding that result into the fixed `cloneStackFor()` now returns `"wp"` instead of `"files"` for both.

## Not covered by this PR

The two files-only clones from the incident have already been re-cloned and cut over to DNS — resolved operationally, independent of this code fix landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CG4F86wNKsGNwKztkM74Ua
