### PR TITLE
fix: pin wp-cli to the site's configured PHP version, not the server default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,32 @@ versions; such changes are called out here.
   WordPress sites.** Its stack picker read `is_wordpress` straight from the
   API, unlike every other view (Stacks, Browser), which corrects that flag
   against a `d` probe result. A site the API wrongly reports as non-WordPress
-  (confirmed live against two real client sites) would default to a files-only pull — filesystem copied, database never
-  touched, so the "clone" wasn't a working WordPress site. The wizard now
-  consults the same probe-corrected classification: **probe the site (`d`)
-  before cloning** so the wizard picks it up as WordPress.
+  (confirmed live against two real client sites) would default to a
+  files-only pull — filesystem copied, database never touched, so the
+  "clone" wasn't a working WordPress site. The wizard now consults the same
+  probe-corrected classification: **probe the site (`d`) before cloning** so
+  the wizard picks it up as WordPress.
+- **wp-cli reads now use the site's own configured PHP version, not the
+  server's system default.** wp-cli's installed binary shebangs
+  `#!/usr/bin/env php`, which resolves through `PATH` to whichever PHP a
+  server's `update-alternatives` currently calls default — independent of
+  any individual site's configured version, and it can be missing extensions
+  that version's CLI never got configured with. Confirmed live: a site
+  configured for PHP 8.1 silently ran its wp-cli reads under the server's
+  default 8.4, whose CLI was missing `mysqli` — every WordPress-content read
+  (posts, pages, users, active plugins, site/home URL) failed silently,
+  while file-only or native-MySQL-client commands (`core version`, `db
+  export`/`import`/`check`) were unaffected. This broke the clone wizard's
+  **Verify** step (`v`) and the **installed plugins & themes** view (`p`) for
+  any site whose configured PHP differs from the server's system default —
+  both now pin wp-cli to the site's own PHP-CLI binary, falling back to the
+  system default only if that specific version isn't installed.
+- **Verify now tells the difference between "the clone actually differs" and
+  "wp-cli couldn't read one side's database."** If `core version` succeeds
+  (a file read, no DB) but every database-backed fact comes back empty, that's
+  the missing-extension failure above, not a real content difference — Verify
+  now reports it plainly instead of a wall of misleading ✕ rows implying data
+  loss.
 
 ## [0.19.1] - 2026-07-08
 

--- a/src/lib/serverClone.ts
+++ b/src/lib/serverClone.ts
@@ -11,6 +11,7 @@
 // that shape the Bedrock branch).
 
 import type { Server } from "../api/types.ts"
+import { wpCliResolveScript } from "./wpCli.ts"
 
 const SSH_OPTS = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=accept-new"]
 
@@ -700,6 +701,7 @@ export interface VerifySpec {
   publicFolder?: string // configured public folder — fallback when the pull's rels are unknown
   sourceWebrootRel?: string // DETECTED source layout from the pull ("" = files root)
   destWebrootRel?: string // the CLONE's WP dir from the pull (post-normalization)
+  phpVersion?: string | null // the site's configured PHP version — see wpCli.ts
 }
 
 // One round-trip per side: collect labeled wp-cli facts as `key=value` lines.
@@ -707,10 +709,14 @@ export interface VerifySpec {
 // stalled outbound call once ate the whole budget and cut the facts off mid-script) —
 // and the flags are identical on both sides, so every count stays comparable. The
 // trailing `eof` sentinel is how verifyClone tells "read got cut off" from "differs".
-async function wpFacts(ctx: SudoCtx, root: string, user: string): Promise<Record<string, string>> {
+// wp-cli is pinned to the site's OWN configured PHP-CLI (wpCliResolveScript) rather
+// than bare `wp` — see wpCli.ts for why (a server's system-default PHP can silently
+// differ from, and be missing extensions present in, the site's actual version).
+async function wpFacts(ctx: SudoCtx, root: string, user: string, phpVersion?: string | null): Promise<Record<string, string>> {
   const script = [
     `cd ${shq(root)} 2>/dev/null || exit 0`,
-    `u() { sudo -u ${shq(user)} -H wp --skip-plugins --skip-themes "$@" 2>/dev/null; }`,
+    wpCliResolveScript(phpVersion),
+    `u() { sudo -u ${shq(user)} -H "$PHP" "$WP" --skip-plugins --skip-themes "$@" 2>/dev/null; }`,
     `echo "core=$(u core version)"`,
     `echo "posts=$(u post list --post_type=any --format=count)"`,
     `echo "pages=$(u post list --post_type=page --format=count)"`,
@@ -753,8 +759,8 @@ export async function verifyClone(source: SudoCtx, dest: SudoCtx, spec: VerifySp
   const srcDir = dirFor(spec.sourceWebrootRel)
   const destDir = dirFor(spec.destWebrootRel)
   const [sf, cf, http] = await Promise.all([
-    wpFacts(source, srcDir, spec.sourceSiteUser),
-    wpFacts(dest, destDir, spec.destSiteUser),
+    wpFacts(source, srcDir, spec.sourceSiteUser, spec.phpVersion),
+    wpFacts(dest, destDir, spec.destSiteUser, spec.phpVersion),
     curlStatus(spec.domain, spec.destIp),
   ])
   // A missing tail sentinel means the facts script was cut off partway (timeout, a
@@ -763,6 +769,22 @@ export async function verifyClone(source: SudoCtx, dest: SudoCtx, spec: VerifySp
   if (sf.eof !== "1" || cf.eof !== "1") {
     const side = sf.eof !== "1" ? "source" : "clone"
     throw new Error(`couldn't read the ${side}'s WordPress facts (the wp-cli read was cut off) — press v to re-run`)
+  }
+  // `core` succeeding (a file read, no DB) while EVERY database-backed fact comes
+  // back empty is a distinct signature from a real content difference (which shows
+  // differing NON-empty values, not blanks) — it means wp-cli's PHP-CLI couldn't
+  // reach the database on that side, commonly a missing `mysqli` extension for
+  // whatever PHP version it resolved to (see wpCli.ts). Surface that plainly
+  // instead of a wall of misleading ✕ rows implying the clone lost data.
+  const dbFields = ["posts", "pages", "users", "plugins", "siteurl", "home"] as const
+  const looksBroken = (f: Record<string, string>) => !!f.core && dbFields.every((k) => !f[k])
+  const srcBroken = looksBroken(sf)
+  const cloneBroken = looksBroken(cf)
+  if (srcBroken || cloneBroken) {
+    const side = srcBroken && cloneBroken ? "both the source and the clone" : srcBroken ? "the source" : "the clone"
+    throw new Error(
+      `wp-cli can't reach ${side}'s database over PHP (commonly a missing "mysqli" extension for whatever PHP-CLI it resolved to) — this looks like a server/PHP-CLI environment issue, not an actual data difference.`,
+    )
   }
   const checks: VerifyCheck[] = []
   checks.push({ key: "http", label: "Clone serves (HTTP)", source: "—", clone: http, ok: /^[23]\d\d$/.test(http) })

--- a/src/lib/wpCli.ts
+++ b/src/lib/wpCli.ts
@@ -1,0 +1,30 @@
+// Resolve wp-cli through the SITE's own configured PHP-CLI, not the bare `wp`
+// command. wp-cli's installed binary shebangs `#!/usr/bin/env php`, which
+// resolves through PATH to the SERVER's system-DEFAULT PHP — which drifts
+// toward whatever version was installed most recently, independent of any
+// individual site's configured version, and can be missing extensions that
+// version's CLI SAPI never got configured with.
+//
+// Verified live 2026-07-09 on web4.wenmarkdigital.com: the system default had
+// drifted to 8.4, whose CLI lacked `mysqli` (its FPM pool likely never needed
+// it — no site there runs 8.4), while lp.anchoredconstructiontn.com's actual
+// configured version (8.1) has a fully working php8.1-cli. Bare `wp` silently
+// ran under 8.4 and failed on anything touching $wpdb (post/user/plugin list,
+// option get) — while `wp core version`, and `wp db export/import/check/size`
+// (they shell out to native mysql client tools, not through mysqli) were
+// unaffected. Confirmed the fix directly: `/usr/bin/php8.1 /usr/local/bin/wp
+// post list ...` returned correct data where bare `wp` errored.
+//
+// Only applies to REMOTE (SSH) wp-cli calls against SpinupWP-managed servers,
+// which have this specific multi-PHP-version-drift shape. Local dev-machine
+// wp-cli (e.g. dbSync.ts's prod→local pull) is a different environment with
+// its own PHP entirely and is not affected — don't apply this there.
+
+// Emits POSIX shell that resolves $WP (the wp-cli binary) and $PHP (the
+// version-pinned interpreter, falling back to the bare `php` on PATH if the
+// versioned binary isn't installed — never worse than today's behavior).
+// Callers invoke `"$PHP" "$WP" ...` in place of bare `wp ...`.
+export function wpCliResolveScript(phpVersion?: string | null): string {
+  const phpBin = phpVersion ? `php${phpVersion}` : "php"
+  return [`WP=$(command -v wp 2>/dev/null || echo /usr/local/bin/wp)`, `PHP=$(command -v ${phpBin} 2>/dev/null || command -v php)`].join("\n")
+}

--- a/src/lib/wpInventory.ts
+++ b/src/lib/wpInventory.ts
@@ -11,6 +11,7 @@
 import type { Server, Site } from "../api/types.ts"
 import { SSH_OPTS, sshPort } from "./dbBackup.ts"
 import { detectWpDirScript } from "./serverClone.ts"
+import { wpCliResolveScript } from "./wpCli.ts"
 
 // One plugin or theme, mirroring `wp {plugin,theme} list` columns.
 export interface WpItem {
@@ -100,13 +101,16 @@ export async function fetchWpInventory(
   const remote = [
     detectWpDirScript(root, site.public_folder ?? undefined),
     `if [ -z "$W" ]; then echo ===NOTWP; echo ===END; exit 0; fi`,
-    `WP=$(command -v wp 2>/dev/null || echo /usr/local/bin/wp)`,
+    // Pinned to the site's OWN configured PHP-CLI — bare `wp` resolves through
+    // its shebang to the server's system-default PHP, which can differ from
+    // (and lack extensions present in) the site's actual version. See wpCli.ts.
+    wpCliResolveScript(site.php_version),
     `echo ===WPDIR; printf '%s\\n' "$W"`,
     // The trailing `echo` after each wp command is load-bearing: `wp --format=json`
     // emits NO trailing newline, so without it the next ===MARKER glues onto the end
     // of the JSON line — the marker never parses and JSON.parse chokes on it.
-    `echo ===PLUGINS; "$WP" --path="$W" plugin list --fields=${fields} --format=json 2>/dev/null || true; echo`,
-    `echo ===THEMES; "$WP" --path="$W" theme list --fields=${fields} --format=json 2>/dev/null || true; echo`,
+    `echo ===PLUGINS; "$PHP" "$WP" --path="$W" plugin list --fields=${fields} --format=json 2>/dev/null || true; echo`,
+    `echo ===THEMES; "$PHP" "$WP" --path="$W" theme list --fields=${fields} --format=json 2>/dev/null || true; echo`,
     `echo ===END`,
   ].join("\n")
 

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -3767,7 +3767,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         try {
           const res = site.stack === "files"
             ? await verifyFilesClone(source, dest, { domain: site.domain, destIp })
-            : await verifyClone(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, destIp, publicFolder: site.stack === "wp" ? site.publicFolder : undefined, sourceWebrootRel: site.stack === "wp" ? site.sourceWebrootRel : undefined, destWebrootRel: site.stack === "wp" ? site.destWebrootRel : undefined })
+            : await verifyClone(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, destIp, publicFolder: site.stack === "wp" ? site.publicFolder : undefined, sourceWebrootRel: site.stack === "wp" ? site.sourceWebrootRel : undefined, destWebrootRel: site.stack === "wp" ? site.destWebrootRel : undefined, phpVersion: site.phpVersion })
           setCloneSite(siteId, (s) => ({ ...s, verifying: false, verify: res }))
         } catch (err) {
           setCloneSite(siteId, (s) => ({ ...s, verifying: false, verifyError: (err as Error).message }))


### PR DESCRIPTION
## The bug (live incident, 2026-07-09)

The clone wizard's **Verify** step (`v`) showed a wall of false mismatches for a client site after cloning — source showing "–" for Posts, Pages, Users, Active plugins, Site URL, Home URL, while the clone showed real numbers.

Root cause: wp-cli's installed binary (`/usr/local/bin/wp`) starts `#!/usr/bin/env php`, which resolves through `PATH` to the **server's system-default PHP** — not the site's own configured version. The site is configured for PHP 8.1, but the server's system default had drifted to 8.4 (likely because no site there actually runs 8.4 in production, so its CLI SAPI was never configured to match FPM's extension set — it's specifically missing `mysqli`).

Confirmed live: bare `wp post list` → `Error: ...missing the MySQL extension...`. Invoking the site's own PHP-CLI binary directly instead → correct data (matching the clone). `wp core version` (a file read) and `wp db export`/`import`/`check` (native `mysql` client tools, not PHP's mysqli) were unaffected — which is why the actual clone data was always fine; only wp-cli's *content reads* were broken.

## The fix

- New `src/lib/wpCli.ts`: `wpCliResolveScript(phpVersion)` resolves `$WP` and a version-pinned `$PHP` (`php{version}`), falling back to the bare `php` on `PATH` if that version isn't installed — never worse than today.
- Wired into `serverClone.ts`'s `wpFacts()`/`verifyClone()` (Verify, `v`) and `wpInventory.ts`'s `fetchWpInventory()` (plugins/themes, `p`) — the two places that read WordPress content over SSH against a managed server. `dbSync.ts`'s wp-cli calls run on the **user's own local machine** (`bash -lc`, not SSH) — a completely different environment, correctly left untouched.
- `verifyClone` also gets a defensive check: if `core version` succeeds but every database-backed fact comes back empty on one side, that's this exact failure signature (not a real content difference) — now reported as a clear, specific error instead of a wall of misleading ✕ rows.

## Verification

- `bun run typecheck` green.
- Live-verified against the real incident site: ran the exact resolved script (`php8.1` + `wp-cli`) over SSH — returns correct data (83 posts, 8 pages, 3 users, 14 active plugins, matching the clone) where bare `wp` failed. Same confirmed for the plugin/theme JSON-list path used by `p`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CG4F86wNKsGNwKztkM74Ua
