### PR TITLE
fix: clone wizard no longer routes git-deployed static sites through Bedrock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ versions; such changes are called out here.
 ## [Unreleased]
 
 ### Fixed
+- **The clone wizard no longer routes git-deployed non-WordPress sites through
+  a Bedrock pull.** `cloneStackFor` trusted `git.repo` alone as "this is
+  Bedrock" — true often enough (`is_wordpress` is unreliable for git sites),
+  but a git-deployed **static** site (confirmed live: a client's static site,
+  repo literally named `*-static-site`) would be routed through
+  `composer install`/wp-cli anyway, which it can't survive. A conclusive
+  non-WordPress probe (`whmcs`/`laravel`/`static`) now overrides `git.repo`;
+  a probe saying `bedrock`/`wordpress`, or no probe at all, still trusts it
+  (same "probe the site (`d`) before cloning" caveat as the sibling fix
+  above).
 - **The clone wizard no longer silently skips the database for API-mislabeled
   WordPress sites.** Its stack picker read `is_wordpress` straight from the
   API, unlike every other view (Stacks, Browser), which corrects that flag

--- a/src/lib/stack.ts
+++ b/src/lib/stack.ts
@@ -51,15 +51,24 @@ export function effectiveStack(site: Site, probeKind?: ProbeKind | null): Stack 
 
 // Which pull the clone wizard runs for a site — the SAME effectiveStack a
 // probe corrects elsewhere (Stacks tab, Browser), so an API-mislabeled site
-// (is_wordpress=false but really WordPress — e.g. lp.anchoredconstructiontn.com,
-// northcoastmodern.com, verified live 2026-07-08) gets a real database pull
-// once probed, instead of silently defaulting to a files-only copy. git.repo
-// still takes precedence for Bedrock detection (the pull needs the repo URL,
-// which a probe alone can't supply) — a probe saying "bedrock" without a
-// connected repo can't actually be pulled as Bedrock, so it falls back to
-// files-only rather than a wrong wp-stack pull.
+// (is_wordpress=false but really WordPress — confirmed live against real
+// client sites, 2026-07-08) gets a real database pull once probed, instead
+// of silently defaulting to a files-only copy. git.repo still takes
+// precedence for Bedrock detection (the pull needs the repo URL, which a
+// probe alone can't supply) — is_wordpress is unreliable for git sites, so
+// absent a probe (or a WP-family one) git.repo remains the best available
+// signal. But git.repo alone only proves "deployed via git," not "is
+// Bedrock" — a git-deployed STATIC site (confirmed live, 2026-07-09: a
+// client's git-deployed static site, repo literally named
+// "*-static-site") would otherwise be routed through a Bedrock pull
+// (composer install, wp-cli) it can't survive. A CONCLUSIVE non-WordPress
+// probe (whmcs/laravel/static) overrides git.repo; a probe saying
+// "bedrock"/"wordpress", or no probe at all, still trusts git.repo.
 export function cloneStackFor(site: Site, probeKind?: ProbeKind | null): "wp" | "bedrock" | "files" {
-  if (site.git?.repo) return "bedrock"
+  if (site.git?.repo) {
+    if (probeKind === "whmcs" || probeKind === "laravel" || probeKind === "static") return "files"
+    return "bedrock"
+  }
   return effectiveStack(site, probeKind) === "Standard WP" ? "wp" : "files"
 }
 


### PR DESCRIPTION
## The bug (live incident, 2026-07-09)

The clone wizard's Plan step tagged a client's git-deployed **static** site as `bedrock` — meaning it would be routed through `runBedrockPull` (composer install, wp-cli calls) at clone time, which a non-WordPress static site can't survive.

Root cause: `cloneStackFor`'s Bedrock branch trusted `site.git.repo` alone — `if (site.git?.repo) return "bedrock"`. That's a deliberate design choice (`is_wordpress` is unreliable for git sites, so `git.repo` was kept as the strongest available signal absent a probe), but `git.repo` only proves "deployed via git," not "is Bedrock." Confirmed live: the site's repo is literally named `*-static-site`, and a real SSH probe identifies it as `"static"`.

## The fix

A conclusive non-WordPress probe (`whmcs`/`laravel`/`static`) now overrides `git.repo` and routes to `"files"` instead. A probe saying `bedrock`/`wordpress`, or **no probe at all**, still trusts `git.repo` — unchanged fallback behavior, so this doesn't regress real Bedrock sites or sites that haven't been probed yet. Same "probe the site (`d`) before cloning" operational caveat as the sibling fix (#29/#30) — the wizard's Plan step needs a cached probe to consult.

## Verification

- `bun run typecheck` green.
- Verified against the real captured site data (the source server was retired mid-session, so I used the exact `git.repo`/`is_wordpress` values already confirmed live before that): unprobed still resolves `"bedrock"` (unchanged), the real probe result `"static"` now resolves `"files"` (was `"bedrock"`), and probing as actual `bedrock`/`wordpress` still correctly resolves `"bedrock"` — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CG4F86wNKsGNwKztkM74Ua