### PR TITLE
feat: show site count in the clone wizard's existing-server picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+### Added
+- **The clone wizard's existing-server picker now shows each server's current
+  site count.** Picking a destination previously showed only provider/region/
+  IP — no sense of how busy a candidate already is. Each row now leads with
+  `N site(s)`.
+
 ### Fixed
 - **The clone wizard no longer routes git-deployed non-WordPress sites through
   a Bedrock pull.** `cloneStackFor` trusted `git.repo` alone as "this is

--- a/README.md
+++ b/README.md
@@ -592,7 +592,8 @@ over SSH). The steps:
    `space` toggles). SpinupTUI sizes each one live (disk + database) into a payload total
    so you know what you're moving; a concurrency cap protects the busy source.
 2. **Destination** — provision a fresh server pre-matched to the source (reusing the
-   `c` flow), or `d` to pick an existing server as the target.
+   `c` flow), or `d` to pick an existing server as the target — each listed with its
+   current site count, so you can see at a glance how busy a candidate already is.
 3. **Connect** — connect sudo on **both** servers. The clone is a server-to-server
    **pull**: the destination pulls each site directly from the source over SSH (no
    bytes routed through your laptop), authenticating with a key granted onto the source

--- a/src/ui/views/CloneWizard.tsx
+++ b/src/ui/views/CloneWizard.tsx
@@ -48,6 +48,7 @@ export function CloneWizard() {
     cloneServer: server,
     cloneJob: job,
     servers,
+    sitesForServer,
     accountSlug,
     toggleCloneSite,
     toggleCloneSiteUploads,
@@ -473,7 +474,8 @@ export function CloneWizard() {
           <box style={{ height: 1 }} />
           {eligibleDests.map((s, i) => {
             const sel = i === destIdx
-            const meta = `${s.provider_name || "—"} · ${s.region || "—"}${s.ip_address ? "  " + s.ip_address : ""}`
+            const n = sitesForServer(s.id).length
+            const meta = `${n} site${n === 1 ? "" : "s"} · ${s.provider_name || "—"} · ${s.region || "—"}${s.ip_address ? "  " + s.ip_address : ""}`
             return (
               <box key={s.id} style={{ flexDirection: "row", height: 1, backgroundColor: sel ? theme.bgAlt : undefined }}>
                 <text content={sel ? "❯ " : "  "} fg={theme.brand} style={{ flexShrink: 0 }} />


### PR DESCRIPTION
## What

Picking a destination server for a clone previously showed only provider/region/IP — no sense of how busy each candidate already is. Each row now leads with `N site(s)`, using the same `sitesForServer` store helper the Plan step already relies on (no new data fetching).

## Verification

- `bun run typecheck` green.
- Computed the exact real meta string against several live servers to confirm correctness and singular/plural handling:
  ```
  earth.wenmarkdigital.com     7 sites · DigitalOcean · NYC3  143.198.24.117
  venus.wenmarkdigital.com     10 sites · DigitalOcean · NYC1  206.189.224.134
  monitor.wenmarkdigital.com   1 site · Hetzner · HEL1  204.168.177.200
  ```
- README's "Cloning a server" section updated to mention it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CG4F86wNKsGNwKztkM74Ua