### PR TITLE
CLI access commands + monitoring UI overhaul (v0.21.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,69 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-07-09
+
+### Added
+- **`spinuptui ssh <domain>`** — non-interactive CLI subcommand for external
+  tooling (e.g. an incident-diagnostics agent that's handed only a domain).
+  Resolves the domain to its site/server, builds the SSH target, and runs a
+  live connectivity probe, returning JSON with a classified failure reason
+  (site not found, ambiguous domain match, server has no IP, key not
+  granted, token rejected, etc.) when it can't connect.
+- **`spinuptui incidents <domain>` / `--all`** — surfaces Uptime Kuma's
+  down/up incident history as JSON, scoped to sites SpinupTUI manages
+  monitoring for. `--all` sweeps every such site over a single Kuma
+  connection; `--hours` sets the lookback window (default 24). Pairs with
+  `spinuptui ssh` for an external agent's discover → access → report loop.
+- **Server-wide PHP-fatal sentinel monitor.** Fixes a real monitoring blind
+  spot: SpinupWP's page cache keeps serving `/` even while PHP is fataling on
+  anything the cache doesn't already have, so the existing health/fingerprint
+  monitors can sleep through a real outage (confirmed against a 2026-07-07
+  incident that went undetected for 54 of its 68 minutes). A root-level cron
+  (one per server, added via the monitoring overlay's repair flow once sudo
+  is connected — same place the Redis sentinel is set up) tails every site's
+  error/debug logs each minute for new `PHP Fatal error` lines and reports
+  up/down to a single new Kuma push monitor, with the actually-affected
+  site domain(s) carried in the down message. Surfaces automatically in
+  `spinuptui incidents --all`.
+- **Cache-bypass monitor, opt-in per site.**
+  Closes the other half of the page-cache blind spot: a wedged PHP-FPM pool
+  that never logs a fatal is invisible to both the plain health monitor and
+  the new fatal sentinel above, since nginx serves the cache without ever
+  touching PHP-FPM. This registers an ordinary Kuma HTTP monitor with a
+  `Cookie: wordpress_no_cache=1` header — the same page-cache bypass
+  `siteDoctor.ts` already uses — so it actually exercises PHP on every check
+  (verified live: `fastcgi-cache-bypass-reason: COOKIE`). Deliberately opt-in
+  (not automatic) and defaults to a 1h check window (30m/1h/2h/4h/6h
+  choices), since forcing a real render costs the site something, unlike the
+  cache-served health/fingerprint checks — meant for sites with an actual
+  history of this failure mode, not the whole fleet.
+
+### Changed
+- **Site/server monitoring overlay rebuilt as a full-screen two-pane browser**
+  (`m` in the sites pane), replacing the small centered popover. A narrow
+  left list of the site's monitor kinds (with a live status dot) sits next
+  to a wide detail pane showing whichever one is selected — its one-line
+  definition, a longer explanation of the actual mechanism, live status, and
+  how to act on it. Grew out of real confusion testing the popover version:
+  six monitor kinds across two site contexts didn't fit legibly in a 68-col
+  box, and a separate glossary overlay left the explanation disconnected
+  from live status. Also **collapses the per-kind action keys into one `a`**
+  that acts on whichever monitor is currently highlighted (front page
+  selected → calibration picker; cache bypass selected → its picker;
+  anything else → register/repair) — fewer keys to remember now that the
+  detail pane shows which monitor you're acting on. The overlay also gained:
+  a passive "Alerts: …" header line (fetched once per open, not polled) so
+  notification wiring is visible without pressing `n`; `o` to deep-link
+  straight to the selected monitor's own page in Uptime Kuma; and `x` to
+  remove the front-page or cache-bypass monitor (confirm-gated) — scoped to
+  just those two kinds, since the other four re-derive themselves
+  automatically on the next repair and would silently reappear.
+- **The header's fleet-wide "N monitors down" badge now names the domain(s)**
+  (falling back to a bare count once there are too many to list) and points
+  at the Search tab to find them, instead of an unactionable number with no
+  way to tell which site it means.
+
 ## [0.20.1] - 2026-07-08
 
 ### Changed
@@ -996,7 +1059,8 @@ Initial tagged release.
 ### Notes
 - Read-only release: works with a SpinupWP **Read Only** API token.
 
-[Unreleased]: https://github.com/mwender/spinupwp-tui/compare/v0.20.1...HEAD
+[Unreleased]: https://github.com/mwender/spinupwp-tui/compare/v0.21.0...HEAD
+[0.21.0]: https://github.com/mwender/spinupwp-tui/compare/v0.20.1...v0.21.0
 [0.20.1]: https://github.com/mwender/spinupwp-tui/compare/v0.20.0...v0.20.1
 [0.20.0]: https://github.com/mwender/spinupwp-tui/compare/v0.19.1...v0.20.0
 [0.19.1]: https://github.com/mwender/spinupwp-tui/compare/v0.19.0...v0.19.1

--- a/README.md
+++ b/README.md
@@ -65,12 +65,19 @@
   [how it works](docs/clone-wizard-explained.md)
 - **Privileged writes over SSH** (`S` / `K`) — grant or revoke SSH keys directly,
   since the API can't. → [docs/privileged-ssh-writes.md](docs/privileged-ssh-writes.md)
-- **Uptime Kuma monitoring** (`m`) — wire a site into your own
-  [Uptime Kuma](https://github.com/louislam/uptime-kuma) for uptime, load, and
-  health checks. → [docs/uptime-kuma.md](docs/uptime-kuma.md)
-- **Site monitoring: fingerprints, a doctor, and a Redis sentinel** (`M`) — a
-  front-page identity check, a cache/outage doctor, and alert wiring.
-  → [docs/site-monitoring.md](docs/site-monitoring.md)
+- **Site & server monitoring** (`m`) — a two-pane browser of a site's Uptime
+  Kuma monitors (health, front-page fingerprint, an opt-in cache-bypass
+  check, and, for vanity/server sites, load/Redis/PHP-fatal sentinels), each
+  with a live status dot, an in-context explanation, and one action key to
+  register/recalibrate/remove it — plus a cache/outage doctor and alert
+  wiring. → [docs/site-monitoring.md](docs/site-monitoring.md) ·
+  [docs/uptime-kuma.md](docs/uptime-kuma.md)
+- **Non-interactive CLI subcommands for external tooling** — `spinuptui ssh <domain>`
+  resolves a domain to a live SSH target with a live connectivity probe;
+  `spinuptui incidents <domain>` / `--all` surfaces Uptime Kuma's down/up
+  history as JSON. Built so another agent/script can go from just a domain to
+  "what's wrong and how do I get in" with no manual lookup.
+  → [CLI subcommands](#cli-subcommands)
 - **Completion toasts** — a non-focus-stealing toast when a background write
   (PHP upgrade, reboot, DNS resolve, …) finishes.
 - **Release notes** — an in-app "what's new" after every update, sourced
@@ -156,6 +163,15 @@ to the version in the header (and in the `?` About panel).
 spinuptui            Launch the dashboard
 spinuptui login      Set or update your saved API token
 spinuptui where      Show the config path and which source the token came from
+spinuptui ssh <domain>  Print SSH access info for a site as JSON (resolves the
+                     site's server, builds its SSH target, and runs a live
+                     connectivity probe — for external tooling, e.g. an
+                     incident-diagnostics agent handed only a domain)
+spinuptui incidents <domain> | --all [--hours N]  Print Uptime Kuma down/up
+                     incidents as JSON, scoped to sites SpinupTUI manages
+                     monitoring for (config.json's kumaMonitors) — --all
+                     sweeps every such site in one Kuma connection, --hours
+                     sets the lookback window (default 24)
 spinuptui --version  Print the version
 spinuptui --help     Show help
 ```
@@ -232,8 +248,7 @@ These can be set in `config.json` or via an environment variable:
 | `u` | Upgrade a site's PHP version (Servers / Stacks / Search; needs a Read/Write token) |
 | `H` | Enable / disable HTTPS on a site (Servers / Stacks / Search; needs a Read/Write token) |
 | `P` | Purge a site's page cache + object cache (Servers / Stacks / Search; needs a Read/Write token) |
-| `m` | Site monitoring via Uptime Kuma (Servers tab, sites pane — same overlay as `M`) |
-| `M` | Site monitoring overlay — add monitors, `f` front-page check, `d` site doctor, `n` alert wiring, vanity refresh/rotation (Servers / Stacks / Search) |
+| `m` / `M` | Site/server monitoring — a two-pane browser of this site's Uptime Kuma monitors (`M` is an alias, since lowercase `m` is taken in Search/Stacks). Inside: `↑`/`↓` selects a monitor, `a` registers/recalibrates/repairs it (Front page and Cache bypass open a check-window picker), `x` removes Front page or Cache bypass, `o` opens the selected monitor in Kuma, `d` runs the site doctor, `n` shows/edits alert wiring, and vanity sites add `R`/`r` for page refresh/secret rotation (Servers / Stacks / Search) |
 | `a` | Server actions: reboot / restart a service (Servers / Search; needs a Read/Write token) |
 | `c` | Create a new server (Servers tab; needs a Read/Write token) |
 | `V` | Add a vanity site at the server's own hostname — DNS + site + HTTPS + SSH-key handoff (Servers tab; offered when no hostname site exists; needs a Read/Write token) |
@@ -286,9 +301,12 @@ Needs a Read/Write token. Full details: [docs/server-actions.md](docs/server-act
 
 ## Site monitoring
 
-`M` on a site opens the monitoring overlay — uptime/Redis monitors, a
-template-identity front-page check, a cache/outage doctor, and Kuma alert
-wiring, all against your own Uptime Kuma instance. Full details:
+`m` on a site opens a full-screen two-pane monitor browser — health,
+front-page fingerprint, an opt-in cache-bypass check, and (vanity/server
+sites) load/Redis/PHP-fatal sentinels, each with live status, an in-context
+explanation, and a single action key to register/recalibrate/remove it —
+plus a cache/outage doctor and Kuma alert wiring, all against your own
+Uptime Kuma instance. Full details:
 [docs/site-monitoring.md](docs/site-monitoring.md) ·
 [docs/uptime-kuma.md](docs/uptime-kuma.md).
 

--- a/docs/site-monitoring.md
+++ b/docs/site-monitoring.md
@@ -1,50 +1,121 @@
-# Site monitoring
+# Site & server monitoring
 
-Everything hangs off one overlay: press `M` on a site in any view (the Servers
-tab also keeps its original `m`). It talks to your own
-[Uptime Kuma](https://github.com/louislam/uptime-kuma) — Kuma watches 24/7 and
-sends the alerts; SpinupTUI creates the monitors *correctly* and diagnoses on
-demand.
+Everything hangs off one overlay: press `m` on a site in any view (`M` is an
+alias — the binding Search/Stacks use for something else, so the capital
+works everywhere). It's a full-screen two-pane browser: a list of this
+site's monitor kinds on the left (each with a live status dot), and a detail
+pane on the right for whichever one is highlighted — a one-line definition,
+how it actually works, live status, and the one action that applies to it.
+It talks to your own [Uptime Kuma](https://github.com/louislam/uptime-kuma)
+— Kuma watches 24/7 and sends the alerts; SpinupTUI creates the monitors
+*correctly* and gives you an in-context glossary + diagnosis on demand.
 
-- **`a` — uptime monitors.** Regular sites get a homepage monitor (up/down +
-  cert-expiry). Vanity sites get the full server treatment: healthz + load
-  push + a **Redis sentinel** — the heartbeat cron runs `redis-cli ping` every
-  minute and reports up/down to a `{server} redis` monitor (registered only
-  after probing that Redis actually answers on that box). Why it matters: with
-  SpinupWP's default object-cache drop-in, a dead Redis is **fatal (HTTP 500)
-  for every request that misses the page cache** — cached pages keep serving
-  200, so only the sentinel notices, within a minute.
-- **`f` — the front-page check.** SpinupTUI reads your *healthy* front page,
-  derives a template-identity fingerprint from WordPress's own `body_class()`
-  output (`class="home`, `page-id-N`, …, falling back to the canonical link),
-  validates it against a throwaway search render to prove it discriminates,
-  and registers a Kuma keyword monitor at your chosen window (5m default —
-  the check is served straight from the page cache, so it costs the site
-  nothing). A red check means "answering 200 but serving the WRONG page" —
-  the stale/corrupt-page-cache incident — and shows as `WRONG PAGE SERVED` in
-  Details. Re-running `f` recalibrates the same monitor in place (history
-  survives a redesign).
-- **`d` — the site doctor.** Read-only, zero setup, works without Kuma. It
-  fetches the page twice — once normally, once with the cache-bypass cookie —
-  and lets the server's `fastcgi-cache: HIT/BYPASS` headers prove which layer
-  answered each request, then compares template identity between the two. It
-  also knocks on the wp-admin door (the login page — never cached; Bedrock's
-  relocated `/wp/` login handled). Verdicts: healthy · stale-cache (with a
-  copyable runbook; the Elementor one-command flush is suggested only when
-  Elementor is detected in the served markup) · **partial-outage** (cached
-  pages 200, fresh renders or wp-admin 5xx — Redis or a PHP fatal; visitors
-  look fine, admins are broken) · recalibrate (`f` jumps straight there) ·
-  down · inconclusive.
-- **`n` — alert wiring.** SpinupTUI detects the notification providers configured
-  in your Kuma (by name — Telegram, email, whatever you've set up) and shows
-  whether each is attached to this site's monitors (`✓` all / `◐` some / `○`
-  none); `⏎` toggles a provider across all of the site's checks at once.
-  Creating the provider (bot tokens etc.) is the one step that stays in Kuma.
+## The monitor kinds
+
+A regular site sees three:
+
+- **Health check** — is this specific website up right now? A plain HTTP
+  check on the site's own homepage, plus certificate-expiry alerting.
+  Served straight from the page cache when one exists — cheap, but for
+  that exact reason it can't see a PHP fatal hiding behind a still-warm
+  cache.
+- **Front page** — is the cache serving the right page? At setup, reads
+  the live homepage and derives a template-identity fingerprint from
+  whatever's actually there (a body-class token, or failing that the
+  canonical link tag), then asserts it stays present at your chosen check
+  window (5m/15m/30m/1h). Reads from the page cache too, so it catches the
+  cache serving a stale/wrong template even though the page still answers
+  200 — a failure the plain health check can't see. Shows as
+  `WRONG PAGE SERVED` when it trips.
+- **Cache bypass** — can PHP actually render this page *right now*? Same
+  homepage URL, but with a `Cookie: wordpress_no_cache=1` header that
+  forces the page cache to be skipped, so unlike the two checks above,
+  this one genuinely exercises PHP on every check. That's also why it
+  costs the site something (a full render each time) and is **opt-in**
+  rather than automatic — a 30m/1h/2h/4h/6h window, defaulting to 1h —
+  meant for sites with an actual history of PHP fatals hiding behind the
+  cache, not the whole fleet.
+
+A vanity/server site sees four:
+
+- **Health check** — is the *server* itself under strain? Hits the vanity
+  page's `/?healthz` endpoint (a small script reporting load/disk) and
+  returns 503 when strained. This is about the server, not any one site —
+  a customer site can be completely broken while this stays green, and the
+  server can be strained while every site still limps out a 200.
+- **Load heartbeat** — is the server itself still alive? A once-a-minute
+  cron pushes its 1-minute load average to Kuma. Dead-man's-switch: the
+  cron never reports down itself, it just goes silent if the
+  server/cron/network egress dies, and Kuma's own missed-heartbeat timeout
+  raises the alarm.
+- **Redis sentinel** — is Redis actually answering? The same cron also
+  runs `redis-cli ping` every minute and actively reports up/down —
+  unlike the load heartbeat, this alerts immediately when Redis dies while
+  the server itself is fine, since SpinupWP's default object-cache drop-in
+  makes a dead Redis fatal on every page-cache miss.
+- **PHP-fatal sentinel** — did any site on this server just start
+  fataling? A root-level cron (needs sudo connected — press `S`) scans
+  every site's error/debug logs each minute for new `PHP Fatal error`
+  lines. Catches a fatal hiding behind a still-warm page cache that none
+  of the checks above would ever notice. One monitor per server, not per
+  site, to avoid a monitor pile-up across a large fleet — the specific
+  affected domain is named in the down alert's own message.
+
+## Using the overlay
+
+`↑`/`↓` (or `j`/`k`) moves the highlight in the left list. `a` acts on
+whichever monitor is currently selected:
+
+- **Front page** selected → opens its check-window picker; re-running
+  recalibrates the same monitor in place (history survives a redesign).
+- **Cache bypass** selected → opens its check-window picker (registers on
+  first use, since it's opt-in).
+- **Anything else** (Health check / Load heartbeat / Redis sentinel /
+  PHP-fatal) → registers or repairs. Safe to re-run any time — it re-syncs
+  with Kuma, e.g. if a monitor was deleted directly in Kuma, or sudo just
+  got connected (unlocking the PHP-fatal sentinel).
+
+`x` removes the selected monitor — **only offered for Front page and Cache
+bypass** (confirm-gated; deletes the Kuma monitor, history included).
+The other four kinds don't offer it: they're all re-derived automatically
+on the next `a`, so a delete would just silently reappear. If you need one
+of those gone for good (e.g. a test site with no real DNS record, so its
+health check can never succeed), **pause it directly in Kuma** instead —
+a paused monitor is still "live" to SpinupTUI's adopt-or-create check, so
+repairing the site again won't un-pause it or create a duplicate.
+
+`o` opens the selected monitor's own page directly in Uptime Kuma (a deep
+link to `<your-kuma-url>/dashboard/<id>`) — handy when Kuma's own list has
+several similarly-named monitors and it's not obvious which is which.
+
+`d` — the site doctor (regular sites, read-only, zero setup, works without
+Kuma). It fetches the page twice — once normally, once with the
+cache-bypass cookie — and lets the server's `fastcgi-cache: HIT/BYPASS`
+headers prove which layer answered each request, then compares template
+identity between the two. It also knocks on the wp-admin door (the login
+page — never cached; Bedrock's relocated `/wp/` login handled). Verdicts:
+healthy · stale-cache (with a copyable runbook) · **partial-outage**
+(cached pages 200, fresh renders or wp-admin 5xx — Redis or a PHP fatal;
+visitors look fine, admins are broken) · recalibrate · down · inconclusive.
+
+`n` — alert wiring. SpinupTUI detects the notification providers
+configured in your Kuma (by name — Telegram, email, whatever you've set
+up) and shows whether each is attached to this site's monitors (`✓` all /
+`◐` some / `○` none); `⏎` toggles a provider across all of the site's
+checks at once. A passive **`Alerts: …`** line in the overlay's header
+shows the same summary the moment you open it (fetched once per open, not
+continuously polled), so you don't need to press `n` just to check.
+Creating the provider (bot tokens etc.) is the one step that stays in
+Kuma.
+
+Vanity sites additionally get `R` (re-publish the page, then register
+monitors + cron) and `r` (rotate the monitoring secrets — see
+[docs/uptime-kuma.md](uptime-kuma.md)).
 
 The design principle across all of it: **the page cache makes sites look
-healthy while things break behind it** — every check watches either *through*
-the cache on purpose (is the right thing being served?) or deliberately
-*around* it (is the machinery behind it alive?).
+healthy while things break behind it** — every check watches either
+*through* the cache on purpose (is the right thing being served?) or
+deliberately *around* it (is the machinery behind it alive?).
 
-See also [docs/uptime-kuma.md](uptime-kuma.md) for connecting and configuring
-Kuma itself.
+See also [docs/uptime-kuma.md](uptime-kuma.md) for connecting Kuma and
+the vanity-site health-endpoint recipes it's built on.

--- a/docs/uptime-kuma.md
+++ b/docs/uptime-kuma.md
@@ -76,16 +76,23 @@ anywhere.
 
 Connect your Kuma instance once and Spinup registers monitors itself:
 
-- **`m` on any site** (sites pane) opens the monitoring overlay. First use walks
-  through connecting (URL + login, verified by actually logging in; stored in
-  `config.json`, chmod 600 — or set `SPINUP_KUMA_URL`, `SPINUP_KUMA_USERNAME`,
-  `SPINUP_KUMA_PASSWORD`). Then `a` registers monitors: vanity sites get the
-  healthz monitor + a **load push monitor fed by a once-a-minute cron** in the
-  site user's crontab. Kuma graphs the pushed value: 1-min load ×100 as an
-  integer (164 = load 1.64 — some Kuma builds drop float pings; Spinup's own
-  views scale it back). A silent cron — server down, cron dead, egress broken —
-  flips the monitor: dead-man's-switch semantics. Regular
-  sites get a homepage monitor; Spinup never touches a client site's files.
+- **`m` on any site** (sites pane) opens the monitoring overlay — a two-pane
+  browser of that site's monitor kinds; see
+  [docs/site-monitoring.md](site-monitoring.md) for the full list and how to
+  act on each one. First use walks through connecting (URL + login, verified
+  by actually logging in; stored in `config.json`, chmod 600 — or set
+  `SPINUP_KUMA_URL`, `SPINUP_KUMA_USERNAME`, `SPINUP_KUMA_PASSWORD`). Then `a`
+  registers monitors: vanity sites get the healthz monitor + a **load push
+  monitor fed by a once-a-minute cron** in the site user's crontab, plus a
+  **Redis sentinel** (if Redis actually answers on that box) and, once sudo
+  is connected, a **PHP-fatal sentinel** (a root cron tailing every site's
+  error/debug logs for new fatals — one per server, not per site). Kuma
+  graphs the load push value: 1-min load ×100 as an integer (164 = load 1.64
+  — some Kuma builds drop float pings; Spinup's own views scale it back). A
+  silent load cron — server down, cron dead, egress broken — flips that
+  monitor: dead-man's-switch semantics. Regular sites get a homepage monitor
+  plus two further opt-in checks (front-page fingerprint, cache-bypass);
+  Spinup never touches a client site's files.
 - **Vanity pages published before this feature** need one `R` (refresh) from the
   `m` overlay to gain the health endpoints, then everything above applies. `R`
   doesn't require a Kuma connection — unconnected it just re-publishes the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spinuptui",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "SpinupTUI — a terminal dashboard for browsing, monitoring, and managing your SpinupWP servers and sites.",
   "type": "module",
   "bin": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -116,6 +116,9 @@ export interface KumaMonitorRef {
   pushToken?: string
   redisId?: number // "{server} redis" push monitor fed by the cron's redis-cli ping (vanity/server domains)
   redisToken?: string
+  fatalId?: number // "{server} php-fatal" server-wide sentinel fed by the root cron's error/debug.log tail (vanity/server domains)
+  fatalToken?: string
+  bypassId?: number // "{domain} cache-bypass" opt-in http monitor with a page-cache-bypass Cookie header (per-site, no token — Kuma polls it directly)
   fingerprintId?: number // keyword monitor asserting the front page serves its own template
   // What fingerprint calibration derived (lib/siteFingerprint.ts) — shown in the
   // overlay and kept so a recalibration can explain what it's replacing.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,9 +12,13 @@ import { StoreProvider } from "./ui/store.tsx"
 import { App } from "./ui/App.tsx"
 import { Onboarding } from "./ui/Onboarding.tsx"
 import { isDevMode } from "./dev/devMode.ts"
+import { SpinupWPClient } from "./api/client.ts"
+import { resolveSshAccess } from "./lib/cliSsh.ts"
+import { resolveIncidents } from "./lib/cliIncidents.ts"
 
 const args = process.argv.slice(2)
-const command = args.find((a) => !a.startsWith("-"))
+const positionals = args.filter((a) => !a.startsWith("-"))
+const command = positionals[0]
 
 if (args.includes("-h") || args.includes("--help") || command === "help") {
   const cfg = loadConfig()
@@ -24,6 +28,9 @@ Usage:
   spinuptui            Launch the dashboard
   spinuptui login      Set or update your saved API token
   spinuptui where      Print the config file path and token source
+  spinuptui ssh <domain>  Print SSH access info for a site (JSON)
+  spinuptui incidents <domain> | --all [--hours N]  Print Uptime Kuma
+                       down/up incidents for a site or the whole fleet (JSON)
   spinuptui --version  Print the version
   spinuptui --help     Show this help
 
@@ -46,6 +53,42 @@ if (command === "where") {
   console.log(`config: ${configPath()}`)
   console.log(`token source: ${cfg.tokenSource}`)
   process.exit(0)
+}
+
+if (command === "ssh") {
+  const domain = positionals[1]
+  if (!domain) {
+    console.error(JSON.stringify({ ok: false, reason: "usage", message: "Usage: spinuptui ssh <domain>" }))
+    process.exit(1)
+  }
+  const cfg = loadConfig()
+  const client = new SpinupWPClient(cfg)
+  const result = await resolveSshAccess(domain, client, cfg)
+  console.log(JSON.stringify(result))
+  process.exit(result.ok ? 0 : 1)
+}
+
+if (command === "incidents") {
+  const rest = args.slice(1)
+  const hoursIdx = rest.indexOf("--hours")
+  const hours = hoursIdx !== -1 ? Number(rest[hoursIdx + 1]) : 24
+  const allFlag = rest.includes("--all")
+  const domainArg = rest.find((a, i) => !a.startsWith("-") && !(hoursIdx !== -1 && i === hoursIdx + 1))
+
+  if ((!domainArg && !allFlag) || (domainArg && allFlag) || !Number.isFinite(hours) || hours <= 0) {
+    console.error(
+      JSON.stringify({
+        ok: false,
+        reason: "usage",
+        message: "Usage: spinuptui incidents <domain> | spinuptui incidents --all [--hours N]",
+      }),
+    )
+    process.exit(1)
+  }
+  const cfg = loadConfig()
+  const result = await resolveIncidents(cfg, { domain: domainArg, hours })
+  console.log(JSON.stringify(result))
+  process.exit(result.ok ? 0 : 1)
 }
 
 // `spinuptui login` forces the onboarding wizard even when a token already exists,

--- a/src/lib/cliIncidents.ts
+++ b/src/lib/cliIncidents.ts
@@ -1,0 +1,126 @@
+// `spinuptui incidents <domain>` / `spinuptui incidents --all` — surfaces
+// Uptime Kuma's down/up incident history for the fleet SpinupTUI itself
+// manages monitoring for, for external tooling (e.g. an incident-diagnostics
+// agent polling on its own schedule). Scoped to config.kumaMonitors, not
+// Kuma's full live monitor list — a monitor added by hand in Kuma with no
+// corresponding SpinupWP site would have nowhere actionable for a caller to
+// go, so it's deliberately excluded.
+
+import type { AppConfig, KumaMonitorRef } from "../config.ts"
+import { withKuma, KumaError, type KumaBeat } from "./uptimeKuma.ts"
+
+export type IncidentKind = "health" | "push" | "redis" | "fingerprint" | "fatal" | "bypass"
+export type IncidentStatus = "down" | "up" | "pending" | "maintenance"
+
+export interface IncidentEvent {
+  domain: string
+  kind: IncidentKind
+  status: IncidentStatus
+  time: string
+  message: string
+}
+
+export type IncidentsResult =
+  | { ok: true; windowHours: number; events: IncidentEvent[] }
+  | { ok: false; reason: "kuma_not_configured" | "no_monitors_registered" | "kuma_error"; message: string }
+
+const STATUS_LABEL: Record<number, IncidentStatus> = { 0: "down", 1: "up", 2: "pending", 3: "maintenance" }
+
+const KIND_FIELDS: Array<[keyof KumaMonitorRef, IncidentKind]> = [
+  ["healthId", "health"],
+  ["pushId", "push"],
+  ["redisId", "redis"],
+  ["fingerprintId", "fingerprint"],
+  ["fatalId", "fatal"],
+  ["bypassId", "bypass"],
+]
+
+interface Target {
+  domain: string
+  kind: IncidentKind
+  id: number
+}
+
+export async function resolveIncidents(
+  cfg: AppConfig,
+  opts: { domain?: string; hours: number },
+): Promise<IncidentsResult> {
+  if (!cfg.uptimeKuma) {
+    return {
+      ok: false,
+      reason: "kuma_not_configured",
+      message: "No Uptime Kuma connection configured in SpinupTUI.",
+    }
+  }
+
+  const domains = opts.domain ? [opts.domain] : Object.keys(cfg.kumaMonitors)
+  const targets: Target[] = []
+  for (const domain of domains) {
+    const ref = cfg.kumaMonitors[domain]
+    if (!ref) continue
+    for (const [field, kind] of KIND_FIELDS) {
+      const id = ref[field]
+      if (typeof id === "number") targets.push({ domain, kind, id })
+    }
+  }
+
+  if (targets.length === 0) {
+    return {
+      ok: false,
+      reason: "no_monitors_registered",
+      message: opts.domain
+        ? `No Kuma monitors registered for "${opts.domain}" in SpinupTUI.`
+        : "No Kuma monitors registered for any site in SpinupTUI.",
+    }
+  }
+
+  try {
+    const { result } = await withKuma(cfg.uptimeKuma, async (kuma) => {
+      const perTarget = await Promise.all(
+        targets.map(async (t) => {
+          try {
+            return { t, beats: await kuma.getMonitorBeats(t.id, opts.hours) }
+          } catch {
+            return { t, beats: [] as KumaBeat[] }
+          }
+        }),
+      )
+      const events: IncidentEvent[] = []
+      for (const { t, beats } of perTarget) {
+        for (const b of beats) {
+          if (!b.important) continue
+          const status = STATUS_LABEL[b.status] ?? "pending"
+          const message = b.msg || ""
+          // The fatal sentinel is registered under the server's vanity domain,
+          // not the site that's actually broken — a down beat pushed BY OUR
+          // OWN cron carries the real, comma-separated affected domain(s) as
+          // msg instead. But Kuma can ALSO generate its own synthetic down
+          // beats on this same push monitor (e.g. "No heartbeat in the time
+          // window" if the cron itself stops beating) — those are an
+          // infrastructure signal about the server, not a parseable domain
+          // list, and must NOT be mistaken for one (confirmed live: this
+          // exact message has no commas and isn't a hostname). Only messages
+          // that parse cleanly as a comma-separated list of hostname-shaped
+          // tokens get split into per-domain events; anything else — Kuma's
+          // own wording included — stays tagged to the vanity domain like
+          // every other kind.
+          const domainList = message.split(",").map((d) => d.trim())
+          const looksLikeDomainList = domainList.every((d) => /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?)+$/.test(d))
+          if (t.kind === "fatal" && status === "down" && looksLikeDomainList) {
+            for (const domain of domainList) {
+              events.push({ domain, kind: t.kind, status, time: b.time, message })
+            }
+            continue
+          }
+          events.push({ domain: t.domain, kind: t.kind, status, time: b.time, message })
+        }
+      }
+      events.sort((a, b) => a.time.localeCompare(b.time))
+      return events
+    })
+    return { ok: true, windowHours: opts.hours, events: result }
+  } catch (err) {
+    const message = err instanceof KumaError ? err.message : `Unexpected error: ${(err as Error).message}`
+    return { ok: false, reason: "kuma_error", message }
+  }
+}

--- a/src/lib/cliSsh.ts
+++ b/src/lib/cliSsh.ts
@@ -1,0 +1,161 @@
+// `spinuptui ssh <domain>` — non-interactive SSH access lookup for external
+// tooling (e.g. an incident-diagnostics agent that's handed only a domain).
+// Resolves domain -> site -> server -> SSH target, then runs a live
+// connectivity probe (BatchMode, same as probeSite) so the result is a
+// trustworthy go/no-go rather than a guess.
+
+import type { AppConfig } from "../config.ts"
+import type { SpinupWPClientLike } from "../api/client.ts"
+import { ApiError } from "../api/client.ts"
+import { resolveSiteSshTarget, SSH_OPTS } from "./probe.ts"
+
+export type SshAccessReason =
+  | "no_token"
+  | "token_rejected"
+  | "site_not_found"
+  | "multiple_matches"
+  | "server_has_no_ip"
+  | "permission_denied"
+  | "connection_failed"
+  | "ssh_error"
+  | "api_error"
+
+export interface SshAccessCandidate {
+  siteId: number
+  serverId: number
+  server: string
+}
+
+export type SshAccessResult =
+  | { ok: true; domain: string; primaryDomain: string; sshTarget: string; port: number | null; server: string }
+  | {
+      ok: false
+      domain: string
+      reason: SshAccessReason
+      message: string
+      remedy?: string
+      candidates?: SshAccessCandidate[]
+    }
+
+const GRANT_KEY_REMEDY =
+  "Run `spinuptui`, select this site in the Browser view, and press K to grant this device's key (sudo must be connected on the server first — press S)."
+
+export async function resolveSshAccess(
+  domain: string,
+  client: SpinupWPClientLike,
+  cfg: AppConfig,
+): Promise<SshAccessResult> {
+  if (!cfg.token) {
+    return { ok: false, domain, reason: "no_token", message: "No API token configured. Run `spinuptui login`." }
+  }
+
+  let site
+  let server
+  try {
+    const sites = await client.listSites()
+    const matches = sites.filter(
+      (s) => s.domain === domain || s.additional_domains?.some((a) => a.domain === domain),
+    )
+    if (matches.length === 0) {
+      return {
+        ok: false,
+        domain,
+        reason: "site_not_found",
+        message: `No site matching "${domain}" found in this SpinupWP account.`,
+      }
+    }
+    if (matches.length > 1) {
+      const candidates: SshAccessCandidate[] = await Promise.all(
+        matches.map(async (s) => {
+          const srv = await client.getServer(s.server_id)
+          return { siteId: s.id, serverId: s.server_id, server: srv.name }
+        }),
+      )
+      return {
+        ok: false,
+        domain,
+        reason: "multiple_matches",
+        message: `"${domain}" matches ${matches.length} sites in this account — cannot pick one automatically.`,
+        candidates,
+      }
+    }
+    site = matches[0]
+    server = await client.getServer(site.server_id)
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 401) {
+      return {
+        ok: false,
+        domain,
+        reason: "token_rejected",
+        message: "Saved API token was rejected (401) — it may be expired or revoked.",
+        remedy: "Run `spinuptui login` to save a fresh token.",
+      }
+    }
+    const message = err instanceof ApiError ? err.message : `Unexpected error: ${(err as Error).message}`
+    return { ok: false, domain, reason: "api_error", message }
+  }
+
+  if (!server.ip_address) {
+    return {
+      ok: false,
+      domain,
+      reason: "server_has_no_ip",
+      message: `Server "${server.name}" has no IP address on file.`,
+    }
+  }
+
+  const target = resolveSiteSshTarget(site, server, cfg.sshUser)
+  const port = server.ssh_port && server.ssh_port !== 22 ? server.ssh_port : null
+  const portOpt = port ? ["-p", String(port)] : []
+
+  let proc: ReturnType<typeof Bun.spawn>
+  try {
+    proc = Bun.spawn(["ssh", ...SSH_OPTS, ...portOpt, target, "true"], {
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    })
+  } catch (err) {
+    return { ok: false, domain, reason: "ssh_error", message: `Failed to launch ssh: ${(err as Error).message}` }
+  }
+
+  const timeout = setTimeout(() => {
+    try {
+      proc.kill()
+    } catch {
+      /* already gone */
+    }
+  }, 15000)
+
+  const exitCode = await proc.exited
+  clearTimeout(timeout)
+  const stderr = await new Response(proc.stderr as ReadableStream<Uint8Array>).text()
+
+  if (exitCode === 0) {
+    return { ok: true, domain, primaryDomain: site.domain, sshTarget: target, port, server: server.name }
+  }
+
+  if (/permission denied/i.test(stderr)) {
+    return {
+      ok: false,
+      domain,
+      reason: "permission_denied",
+      message: stderr.trim().split("\n").slice(-2).join(" ") || "Permission denied.",
+      remedy: GRANT_KEY_REMEDY,
+    }
+  }
+  if (/(connection timed out|operation timed out|connection refused|could not resolve)/i.test(stderr)) {
+    return {
+      ok: false,
+      domain,
+      reason: "connection_failed",
+      message: stderr.trim().split("\n").slice(-2).join(" ") || `ssh exited with code ${exitCode}`,
+    }
+  }
+  return {
+    ok: false,
+    domain,
+    reason: "ssh_error",
+    message: stderr.trim().split("\n").slice(-2).join(" ") || `ssh exited with code ${exitCode}`,
+  }
+}

--- a/src/lib/probe.ts
+++ b/src/lib/probe.ts
@@ -60,7 +60,7 @@ export function resolveSiteSshTarget(site: Site, server: Server | undefined, ssh
   return `${user}@${ip}`
 }
 
-const SSH_OPTS = [
+export const SSH_OPTS = [
   "-o", "BatchMode=yes",
   "-o", "ConnectTimeout=7",
   "-o", "StrictHostKeyChecking=accept-new",

--- a/src/lib/ssh.ts
+++ b/src/lib/ssh.ts
@@ -444,6 +444,52 @@ async function runSudoSiteOp(
   return { ok: true, target: `${siteUser}@${ip}` }
 }
 
+export type SudoServerResult = { ok: true } | { ok: false; error: string }
+
+// Same probe → maybe-password → `sudo -S -p '' bash -s` idiom as runSudoSiteOp,
+// but scoped to the SERVER as root — no Site/site_user involved. Used for ops
+// that need to read/write across every site's directory (e.g. the fatal-log
+// monitor's cron, which globs /sites/* — a regular site user can't even list
+// that directory, confirmed live).
+export async function runSudoServerOp(
+  server: Server,
+  opts: { sudoUser: string; sudoPassword: string },
+  build: () => string,
+  marker: string,
+): Promise<SudoServerResult> {
+  const ip = server.ip_address
+  if (!ip) return { ok: false, error: "Server has no IP address." }
+  const target = `${opts.sudoUser}@${ip}`
+  const port = server.ssh_port ?? null
+
+  const probe = await runSshStdin(target, port, "sudo -n true 2>&1", null, 15000)
+  let needPassword = false
+  if (probe.code === 0) {
+    needPassword = false
+  } else if (probe.code === 255 || probe.code === -1) {
+    return { ok: false, error: lastErrorLine(probe.stdout + "\n" + probe.stderr, "Couldn't connect over SSH — is your key on the server for this user?") }
+  } else {
+    const out = (probe.stdout + " " + probe.stderr).toLowerCase()
+    if (/not in the sudoers|not allowed to run|may not run|unknown user|is not allowed/.test(out)) {
+      return { ok: false, error: `${opts.sudoUser} can't run sudo on this server.` }
+    }
+    needPassword = true
+    if (!opts.sudoPassword) return { ok: false, error: "A sudo password is required for this server." }
+  }
+
+  const script = build()
+  const payload = needPassword ? `${opts.sudoPassword}\n${script}\n` : `${script}\n`
+  const res = await runSshStdin(target, port, "sudo -S -p '' bash -s", payload, 30000)
+  if (res.code !== 0 || !res.stdout.includes(marker)) {
+    const out = (res.stderr + " " + res.stdout).toLowerCase()
+    if (/incorrect password|sorry, try again|authentication failure/.test(out)) {
+      return { ok: false, error: "Sudo password was rejected." }
+    }
+    return { ok: false, error: lastErrorLine(res.stderr || res.stdout, `The remote command failed (ssh exit ${res.code}).`) }
+  }
+  return { ok: true }
+}
+
 // Append the given public keys to a site user's authorized_keys, via the server's
 // sudo user. Idempotent (re-running never duplicates a line). The caller resolves
 // which keys to deploy (machine key via ensureSpinupKey, personal via listPersonalKeys).

--- a/src/lib/uptimeKuma.ts
+++ b/src/lib/uptimeKuma.ts
@@ -41,6 +41,7 @@ export interface KumaBeat {
   time: string
   msg?: string
   ping?: number | null
+  important?: boolean // true on a status-transition row (Kuma's own "important events" flag)
 }
 
 // A notification provider as configured in Kuma (Settings → Notifications) —
@@ -403,6 +404,27 @@ export function redisPushMonitorPayload(name: string, pushToken: string): Record
   }
 }
 
+// The server-wide PHP-fatal sentinel: one per server (like the Redis sentinel),
+// fed by a root-level cron that greps every site's error.log/debug.log for new
+// "PHP Fatal error" lines — catches PHP dying behind a still-warm page cache,
+// which the plain up/down and fingerprint monitors sleep straight through.
+// Unlike every other monitor kind, a down beat's `msg` carries a comma-separated
+// list of the actual site domain(s) that fataled (this monitor's own domain is
+// just the server's vanity anchor, not the site that's actually broken).
+export function fatalPushMonitorPayload(name: string, pushToken: string): Record<string, unknown> {
+  return {
+    type: "push",
+    name,
+    pushToken,
+    description: "Server-wide PHP fatal sentinel: a root cron greps every site's error/debug log each minute for new PHP fatals and reports up/down. `msg` on a down beat lists the affected domain(s).",
+    interval: 60,
+    retryInterval: 60,
+    maxretries: 2,
+    upsideDown: false,
+    accepted_statuscodes: ["200-299"],
+  }
+}
+
 // The front-page fingerprint monitor (site monitoring Phase 1): a `keyword`
 // monitor asserting the front page still carries the template-identity string
 // calibration derived (lib/siteFingerprint.ts). Catches "the page cache is
@@ -453,6 +475,53 @@ export async function registerFingerprintMonitor(
   return kuma.addMonitor(fingerprintMonitorPayload(name, url, opts.keyword, opts.interval))
 }
 
+// The cache-bypass monitor (site monitoring blind-spot fix, part 2): a plain
+// http monitor on the front page, but with a Cookie header that forces
+// SpinupWP's nginx to bypass the page cache — the same bypass siteDoctor.ts
+// already uses and has verified live. Unlike the health/fingerprint monitors,
+// this actually exercises PHP on every check, so it's deliberately opt-in
+// (not automatic) and meant for a much looser interval than either of those.
+export function bypassMonitorPayload(name: string, url: string, interval: number): Record<string, unknown> {
+  return {
+    type: "http",
+    name,
+    url,
+    method: "GET",
+    interval,
+    retryInterval: 60,
+    resendInterval: 0,
+    maxretries: 2,
+    timeout: 48,
+    accepted_statuscodes: ["200-299"],
+    expiryNotification: false, // the plain health monitor already owns cert expiry
+    ignoreTls: false,
+    upsideDown: false,
+    maxredirects: 10,
+    headers: JSON.stringify({ Cookie: "wordpress_no_cache=1" }),
+  }
+}
+
+// Adopt-or-EDIT-or-create, same philosophy as registerFingerprintMonitor:
+// recalibrating the interval updates the existing row in place so history and
+// notification wiring survive.
+export async function registerBypassMonitor(
+  kuma: KumaClient,
+  domain: string,
+  opts: { proto: "http" | "https"; interval: number; knownId?: number | null },
+): Promise<number> {
+  const name = `${domain} cache-bypass`
+  const url = `${opts.proto}://${domain}/`
+  const monitors = await kuma.getMonitors()
+  const byId = new Map(monitors.map((m) => [m.id, m]))
+  const existingId = (opts.knownId != null && byId.has(opts.knownId) ? opts.knownId : undefined) ?? monitors.find((m) => m.name === name)?.id
+  if (existingId != null) {
+    const full = await kuma.getMonitor(existingId)
+    await kuma.editMonitor({ ...full, type: "http", url, interval: opts.interval, headers: JSON.stringify({ Cookie: "wordpress_no_cache=1" }) })
+    return existingId
+  }
+  return kuma.addMonitor(bypassMonitorPayload(name, url, opts.interval))
+}
+
 // Adopt-or-create the monitors for one domain — THE single implementation shared
 // by the vanity wizard's monitor step and the `m` overlay's add/repair, so the
 // two paths cannot drift. Rules:
@@ -464,8 +533,24 @@ export async function registerFingerprintMonitor(
 export async function registerMonitors(
   kuma: KumaClient,
   domain: string,
-  opts: { proto: "http" | "https"; healthzPath: string; wantPush: boolean; wantRedis?: boolean; known?: KumaMonitorRef | null; pushToken?: string | null },
-): Promise<{ healthId: number; pushId?: number; pushToken?: string; redisId?: number; redisToken?: string }> {
+  opts: {
+    proto: "http" | "https"
+    healthzPath: string
+    wantPush: boolean
+    wantRedis?: boolean
+    wantFatal?: boolean
+    known?: KumaMonitorRef | null
+    pushToken?: string | null
+  },
+): Promise<{
+  healthId: number
+  pushId?: number
+  pushToken?: string
+  redisId?: number
+  redisToken?: string
+  fatalId?: number
+  fatalToken?: string
+}> {
   const monitors = await kuma.getMonitors()
   const byId = new Map(monitors.map((m) => [m.id, m]))
   const byName = new Map(monitors.map((m) => [m.name, m]))
@@ -482,7 +567,12 @@ export async function registerMonitors(
   const existingRedis = opts.wantRedis && live(known.redisId) == null ? byName.get(`${domain} redis`) : undefined
   if (existingRedis?.pushToken) redisToken = existingRedis.pushToken
 
-  const [healthId, pushId, redisId] = await Promise.all([
+  // Same independent-token story as Redis — its own push URL, its own cron line.
+  let fatalToken = known.fatalToken ?? genPushToken()
+  const existingFatal = opts.wantFatal && live(known.fatalId) == null ? byName.get(`${domain} php-fatal`) : undefined
+  if (existingFatal?.pushToken) fatalToken = existingFatal.pushToken
+
+  const [healthId, pushId, redisId, fatalId] = await Promise.all([
     (async () => live(known.healthId) ?? byName.get(domain)?.id ?? (await kuma.addMonitor(healthMonitorPayload(domain, `${opts.proto}://${domain}${opts.healthzPath}`))))(),
     (async () => {
       if (!opts.wantPush) return undefined
@@ -492,6 +582,10 @@ export async function registerMonitors(
       if (!opts.wantRedis) return undefined
       return live(known.redisId) ?? existingRedis?.id ?? (await kuma.addMonitor(redisPushMonitorPayload(`${domain} redis`, redisToken)))
     })(),
+    (async () => {
+      if (!opts.wantFatal) return undefined
+      return live(known.fatalId) ?? existingFatal?.id ?? (await kuma.addMonitor(fatalPushMonitorPayload(`${domain} php-fatal`, fatalToken)))
+    })(),
   ])
   return {
     healthId,
@@ -499,6 +593,8 @@ export async function registerMonitors(
     pushToken: opts.wantPush ? pushToken : undefined,
     redisId,
     redisToken: opts.wantRedis ? redisToken : undefined,
+    fatalId,
+    fatalToken: opts.wantFatal ? fatalToken : undefined,
   }
 }
 

--- a/src/lib/vanitySite.ts
+++ b/src/lib/vanitySite.ts
@@ -6,8 +6,10 @@
 // docs/vanity-site/index.php is the design reference; keep the two in sync.
 
 import { resolve4 } from "node:dns/promises"
+import type { Server } from "../api/types.ts"
 import { SSH_OPTS, sshPort, runProcess, meaningfulError, remoteDocRoot } from "./dbBackup.ts"
 import { pushUrl, LOAD_PUSH_SCALE } from "./uptimeKuma.ts"
+import { runSudoServerOp } from "./ssh.ts"
 
 // The vanity convention: the site living at the server's own hostname. Every
 // feature that special-cases vanity sites (full monitoring, page re-seed) keys
@@ -294,4 +296,76 @@ export async function seedVanityPushCron(t: PushCronTarget): Promise<{ ok: boole
   const r = await runProcess(["ssh", ...SSH_OPTS, ...sshPort(t.port), `${t.user}@${t.host}`, remote], 60_000)
   if (r.code !== 0) return { ok: false, error: meaningfulError(r.stderr, "Couldn't install the heartbeat cron over SSH.") }
   return { ok: true }
+}
+
+const FATAL_CRON_MARKER = "spinup-kuma-fatal"
+const FATAL_SCRIPT_PATH = "/root/spinup-fatal-check.sh"
+const FATAL_INSTALLED_MARKER = "===FATALCRON_INSTALLED"
+
+// Server-wide PHP-fatal sentinel (site monitoring blind-spot fix): SpinupWP's
+// page cache keeps serving `/` even while PHP is fataling on anything the
+// cache doesn't already have — the plain up/down and fingerprint monitors
+// never touch broken PHP as long as the cache stays warm (verified against a
+// real 2026-07-07 incident that sat undetected for 54 of its 68 minutes).
+//
+// Runs as ROOT (via sudo) because it globs every site on the box: a site's
+// own user can't even list `/sites` (confirmed live), let alone read a
+// sibling site's logs once logrotate recreates them `640 root adm`. One
+// monitor covers the whole server rather than one per site, to avoid Kuma
+// "monitor bloat" — a down beat's `msg` carries the actual affected
+// domain(s), since THIS monitor's own name is just the server's vanity
+// anchor, not the site that's actually broken.
+//
+// A PHP fatal can land in either logs/error.log (nginx) or logs/debug.log
+// (WordPress's own log, populated when WP_DEBUG_LOG is on) depending on that
+// site's config — verified live: the real incident above is in debug.log,
+// not error.log. Both are checked for every site.
+const FATAL_CHECK_SCRIPT = `#!/bin/bash
+STATE_DIR=/root/.spinup-fatal-state
+mkdir -p "$STATE_DIR"
+FOUND=""
+for site_dir in /sites/*/; do
+  domain=$(basename "$site_dir")
+  for logname in error.log debug.log; do
+    logfile="\${site_dir}logs/\${logname}"
+    [ -f "$logfile" ] || continue
+    state_file="$STATE_DIR/\${domain}__\${logname}.offset"
+    prev=$(cat "$state_file" 2>/dev/null || echo 0)
+    cur=$(stat -c %s "$logfile" 2>/dev/null || echo 0)
+    [ "$cur" -lt "$prev" ] && prev=0
+    if [ "$cur" -gt "$prev" ] && tail -c +"$((prev + 1))" "$logfile" | grep -q "PHP Fatal error"; then
+      FOUND="\${FOUND:+$FOUND,}$domain"
+    fi
+    echo "$cur" > "$state_file"
+  done
+done
+if [ -n "$FOUND" ]; then
+  curl -fsS --max-time 20 "__PUSH_URL__?status=down&msg=$FOUND" >/dev/null 2>&1
+else
+  curl -fsS --max-time 20 "__PUSH_URL__?status=up&msg=fatal-check-ok" >/dev/null 2>&1
+fi
+`
+
+// Adopt-or-refresh: writes the check script (push URL baked in) and installs
+// the one-line-per-minute crontab entry that invokes it, in ROOT's crontab.
+// Idempotent, same strip-marked-line-then-append idiom as seedVanityPushCron.
+export async function seedFatalMonitorCron(
+  server: Server,
+  opts: { sudoUser: string; sudoPassword: string; kumaUrl: string; pushToken: string },
+): Promise<{ ok: boolean; error?: string }> {
+  const push = pushUrl(opts.kumaUrl, opts.pushToken)
+  const script = FATAL_CHECK_SCRIPT.replace(/__PUSH_URL__/g, push)
+  const scriptB64 = Buffer.from(script, "utf8").toString("base64")
+  return runSudoServerOp(
+    server,
+    { sudoUser: opts.sudoUser, sudoPassword: opts.sudoPassword },
+    () =>
+      [
+        `printf '%s' '${scriptB64}' | base64 -d > ${FATAL_SCRIPT_PATH}`,
+        `chmod +x ${FATAL_SCRIPT_PATH}`,
+        `( crontab -l 2>/dev/null | grep -v -e '${FATAL_CRON_MARKER}' ; echo '* * * * * ${FATAL_SCRIPT_PATH} >/dev/null 2>&1 # ${FATAL_CRON_MARKER}' ) | crontab -`,
+        `echo ${FATAL_INSTALLED_MARKER}`,
+      ].join("\n"),
+    FATAL_INSTALLED_MARKER,
+  )
 }

--- a/src/ui/Header.tsx
+++ b/src/ui/Header.tsx
@@ -28,7 +28,13 @@ const SUBTITLES: Record<Route, string> = {
 
 export function Header() {
   const { route, servers, sites, loading, lastUpdated, updateInfo, newServerJob, vanityJob, cloneJob, cloneServer, kumaStatus } = useStore()
-  const kumaDown = [...kumaStatus.values()].filter((s) => s.up === false).length
+  // Name the domain(s) when there are few enough to fit the header row; fall
+  // back to a bare count once there are too many to list safely. Deliberately
+  // still just the plain up/down signal (kumaStatus.up) — not expanding what
+  // counts as "down" here, only how it's displayed.
+  const downDomains = [...kumaStatus.entries()].filter(([, s]) => s.up === false).map(([domain]) => domain)
+  const kumaDown = downDomains.length
+  const kumaDownLabel = kumaDown === 0 ? "" : kumaDown <= 2 ? `${downDomains.map((d) => truncate(d, 24)).join(", ")} down` : `${kumaDown} monitors down`
   const updateReady = updateInfo?.updateAvailable ?? false
   const building = isNewServerInFlight(newServerJob)
   // The sshkey step is the one that waits on the USER (add your key, confirm in
@@ -103,7 +109,9 @@ export function Header() {
           </box>
         )}
         {/* Uptime Kuma: only bad news earns header space — silence when all up. */}
-        {kumaDown > 0 && <text content={`  ▼ ${kumaDown} monitor${kumaDown === 1 ? "" : "s"} down  `} fg={theme.bad} style={{ flexShrink: 0 }} wrapMode="none" />}
+        {kumaDown > 0 && (
+          <text content={`  ▼ ${kumaDownLabel} — 4 to find ${kumaDown === 1 ? "it" : "them"}  `} fg={theme.bad} style={{ flexShrink: 0 }} wrapMode="none" />
+        )}
         {loading && <Spinner interval={100} />}
         <text content={`  ${servers.length} servers · ${sites.length} sites  `} fg={theme.textDim} style={{ flexShrink: 0 }} />
         <text content={lastUpdated ? `updated ${timeAgo(lastUpdated.toISOString())}` : "loading…"} fg={theme.textFaint} style={{ flexShrink: 0 }} />

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -40,8 +40,8 @@ import {
 } from "../lib/providers.ts"
 import { ProvidersCache, type VerifiedConn } from "../lib/providersCache.ts"
 import { recordProviderFor, type DnsRecord, type RecordResult } from "../lib/dnsRecords.ts"
-import { deriveSiteUser, seedVanityIndex, seedVanityPushCron, probeServerRedis, aRecordResolves, isVanityPair } from "../lib/vanitySite.ts"
-import { withKuma, KumaClient, registerMonitors, registerFingerprintMonitor, setMonitorNotifications, genPushToken, rotatePushToken, retargetHealthKeyMonitors, LOAD_PUSH_SCALE } from "../lib/uptimeKuma.ts"
+import { deriveSiteUser, seedVanityIndex, seedVanityPushCron, seedFatalMonitorCron, probeServerRedis, aRecordResolves, isVanityPair } from "../lib/vanitySite.ts"
+import { withKuma, KumaClient, registerMonitors, registerFingerprintMonitor, registerBypassMonitor, setMonitorNotifications, genPushToken, rotatePushToken, retargetHealthKeyMonitors, LOAD_PUSH_SCALE } from "../lib/uptimeKuma.ts"
 import { deriveFingerprint } from "../lib/siteFingerprint.ts"
 import type { StoredProviders } from "../config.ts"
 import { fetchRebootInfo, grantSiteSshKey, revokeSiteSshKey, verifySudo, ensureSpinupKey, listPersonalKeys, keyBody, type RebootInfo } from "../lib/ssh.ts"
@@ -219,6 +219,14 @@ export interface KumaDomainStatus {
   // The server's Redis sentinel (vanity domains only): false = the cron reports
   // Redis unreachable while the server itself is beating fine.
   redisUp: boolean | null
+  // The server-wide PHP-fatal sentinel (vanity domains only): false = a new
+  // fatal was detected on some site on this server (see the down beat's own
+  // message for which one — this field is just "is anything on fire").
+  fatalUp: boolean | null
+  // The cache-bypass monitor (regular sites, opt-in): false = PHP couldn't
+  // render a fresh request even with the page cache skipped — distinct from
+  // `up`, which a warm cache can keep green even when this is failing.
+  bypassUp: boolean | null
 }
 
 // Clone a server to a new server (backlog item 5). Five server-level steps wrapping
@@ -538,6 +546,7 @@ interface StoreValue extends DataState {
   clearVanity: () => void
   vanityHealthKeyFor: (domain: string) => string | null // key baked into the seeded page's ?format=json mode
   kumaConfigured: boolean // an Uptime Kuma connection exists (config or env)
+  kumaUrl: string | null // base URL for deep-linking to a monitor's own Kuma page
   kumaSite: Site | null // site whose Kuma overlay (m) is open
   setKumaSite: (s: Site | null) => void
   kumaOps: Map<number, KumaOp> // in-flight/settled monitor setups, by site id
@@ -547,6 +556,8 @@ interface StoreValue extends DataState {
   startVanityReseed: (site: Site) => void // refresh an existing vanity page (no Kuma needed)
   startKumaRotate: (site: Site) => void // rotate the push token + health key (vanity; old URLs die immediately)
   startFingerprintSetup: (site: Site, intervalSec: number) => void // calibrate + register the front-page fingerprint monitor
+  startBypassMonitorSetup: (site: Site, intervalSec: number) => void // register (or recalibrate) the opt-in cache-bypass monitor
+  removeSiteMonitor: (site: Site, kind: "fingerprint" | "bypass") => void // delete an opt-in per-site monitor (front page / cache bypass only)
   fetchKumaAlerts: (site: Site) => Promise<{ ok: true; providers: KumaAlertProvider[]; monitorIds: number[] } | { ok: false; error: string }> // live read of provider/attachment state
   toggleKumaAlert: (site: Site, providerId: number, on: boolean, monitorIds: number[]) => Promise<{ ok: true } | { ok: false; error: string }>
   clearKumaOp: (siteId: number) => void // forget a settled op so the overlay opens fresh
@@ -2947,7 +2958,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           // very maintenance windows we create around reboots).
           const beatUp = (s: number) => s !== 0
           for (const [domain, ref] of Object.entries(cfgRef.current.kumaMonitors)) {
-            const status: KumaDomainStatus = { up: null, uptime24: null, responseBeats: [], loadBeats: [], lastLoad: null, fingerprintUp: null, redisUp: null }
+            const status: KumaDomainStatus = { up: null, uptime24: null, responseBeats: [], loadBeats: [], lastLoad: null, fingerprintUp: null, redisUp: null, fatalUp: null, bypassUp: null }
             if (ref.healthId && byId.has(ref.healthId)) {
               const beats = kuma.beatsFor(ref.healthId)
               const last = beats[beats.length - 1]
@@ -2973,6 +2984,16 @@ export function StoreProvider({ children }: { children: ReactNode }) {
               const beats = kuma.beatsFor(ref.redisId)
               const last = beats[beats.length - 1]
               status.redisUp = last ? beatUp(last.status) : null
+            }
+            if (ref.fatalId && byId.has(ref.fatalId)) {
+              const beats = kuma.beatsFor(ref.fatalId)
+              const last = beats[beats.length - 1]
+              status.fatalUp = last ? beatUp(last.status) : null
+            }
+            if (ref.bypassId && byId.has(ref.bypassId)) {
+              const beats = kuma.beatsFor(ref.bypassId)
+              const last = beats[beats.length - 1]
+              status.bypassUp = last ? beatUp(last.status) : null
             }
             map.set(domain, status)
           }
@@ -3106,13 +3127,22 @@ export function StoreProvider({ children }: { children: ReactNode }) {
             wantRedis = probe.ok
             if (!probe.ok) redisNote = probe.error ?? "Redis sentinel skipped."
           }
+          // The PHP-fatal sentinel is also server-wide (it globs every site's
+          // logs), but unlike Redis it needs ROOT — a regular site user can't
+          // even list /sites (confirmed live). Only offer it when sudo is
+          // already connected for this server; otherwise skip quietly rather
+          // than blocking the rest of setup, and say what unlocks it.
+          const sudoReady = isVanity && !!server && isSudoConnected(server.id)
+          const wantFatal = sudoReady
+          let fatalNote: string | null = null
+          if (isVanity && server && !sudoReady) fatalNote = "PHP-fatal sentinel skipped — connect sudo (S) first, then re-run to add it."
           setOp({ status: "running", detail: "Registering monitors in Uptime Kuma…" })
           const known = cfgRef.current.kumaMonitors[domain] ?? {}
           // Monitor over the protocol the site actually serves — an https monitor
           // on an http-only site would be permanently down.
           const proto = site.https?.enabled ? "https" : "http"
           const { result, jwt } = await withKuma(conn, (kuma) =>
-            registerMonitors(kuma, domain, { proto, healthzPath: isVanity ? "/?healthz" : "/", wantPush: isVanity, wantRedis, known }),
+            registerMonitors(kuma, domain, { proto, healthzPath: isVanity ? "/?healthz" : "/", wantPush: isVanity, wantRedis, wantFatal, known }),
           )
           persistKumaAuth(conn, jwt)
           persistKumaMonitors(domain, {
@@ -3122,16 +3152,28 @@ export function StoreProvider({ children }: { children: ReactNode }) {
             pushToken: result.pushToken ?? known.pushToken,
             redisId: result.redisId ?? known.redisId,
             redisToken: result.redisToken ?? known.redisToken,
+            fatalId: result.fatalId ?? known.fatalId,
+            fatalToken: result.fatalToken ?? known.fatalToken,
           })
           if (isVanity && result.pushId && result.pushToken && server) {
             setOp({ status: "running", detail: "Installing the heartbeat cron…" })
             const cron = await seedVanityPushCron({ ...ssh, kumaUrl: conn.url, pushToken: result.pushToken, redisToken: result.redisId != null ? (result.redisToken ?? known.redisToken ?? null) : null })
             if (!cron.ok) throw new Error(cron.error || "Couldn't install the heartbeat cron.")
           }
+          if (sudoReady && server && result.fatalId && result.fatalToken) {
+            setOp({ status: "running", detail: "Installing the PHP-fatal check (sudo)…" })
+            const sudoUser = sudoUsers.get(server.id) ?? ""
+            const sudoPassword = sudoPwRef.current.get(server.id) ?? ""
+            const fatalCron = await seedFatalMonitorCron(server, { sudoUser, sudoPassword, kumaUrl: conn.url, pushToken: result.fatalToken })
+            if (!fatalCron.ok) {
+              if (/password was rejected|password is required|can't run sudo|couldn't connect/i.test(fatalCron.error ?? "")) disconnectSudo(server.id)
+              fatalNote = `PHP-fatal sentinel skipped — ${fatalCron.error ?? "couldn't install the cron."}`
+            }
+          }
           setOp({
             status: "done",
             detail: isVanity
-              ? `Monitors live: healthz checks + load graph${result.redisId != null ? " + Redis sentinel" : ""} (cron beating every minute).${redisNote ? ` ${redisNote}` : ""}`
+              ? `Monitors live: healthz checks + load graph${result.redisId != null ? " + Redis sentinel" : ""}${result.fatalId != null && !fatalNote ? " + PHP-fatal sentinel" : ""} (cron beating every minute).${redisNote ? ` ${redisNote}` : ""}${fatalNote ? ` ${fatalNote}` : ""}`
               : "Monitor live: homepage checks + certificate-expiry alerts.",
           })
         } catch (err) {
@@ -3140,7 +3182,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       }
       void run()
     },
-    [servers, reseedVanityPage, persistKumaAuth, persistKumaMonitors],
+    [servers, reseedVanityPage, persistKumaAuth, persistKumaMonitors, isSudoConnected, sudoUsers, disconnectSudo],
   )
 
   // Calibrate + register the front-page fingerprint monitor (site monitoring
@@ -3177,6 +3219,76 @@ export function StoreProvider({ children }: { children: ReactNode }) {
             status: "done",
             detail: `Front-page check live — asserts ${derived.fingerprint.detail} every ${win}${derived.validated ? "" : ` (${derived.note ?? "unvalidated"})`}.`,
           })
+        } catch (err) {
+          setOp({ status: "error", detail: "", error: (err as Error).message })
+        }
+      }
+      void run()
+    },
+    [persistKumaAuth, persistKumaMonitors],
+  )
+
+  // Register (or recalibrate) the per-site cache-bypass monitor (site
+  // monitoring blind-spot fix, part 2): opt-in, deliberately a much looser
+  // interval than health/fingerprint since it forces a real PHP render on
+  // every check, unlike those two which are served straight from cache.
+  const startBypassMonitorSetup = useCallback(
+    (site: Site, intervalSec: number) => {
+      const conn = cfgRef.current.uptimeKuma
+      if (!conn || isDevMode()) return
+      const setOp = (op: KumaOp) => setKumaOps((prev) => new Map(prev).set(site.id, op))
+      const run = async () => {
+        try {
+          const domain = site.domain
+          const proto = site.https?.enabled ? "https" : "http"
+          const known = cfgRef.current.kumaMonitors[domain] ?? {}
+          setOp({ status: "running", detail: "Registering the cache-bypass monitor…" })
+          const { result: bypassId, jwt } = await withKuma(conn, (kuma) =>
+            registerBypassMonitor(kuma, domain, { proto, interval: intervalSec, knownId: known.bypassId }),
+          )
+          persistKumaAuth(conn, jwt)
+          persistKumaMonitors(domain, { ...known, bypassId })
+          const win = intervalSec % 3600 === 0 ? `${intervalSec / 3600}h` : `${Math.round(intervalSec / 60)}m`
+          setOp({ status: "done", detail: `Cache-bypass check live — forces a fresh render every ${win}, bypassing the page cache.` })
+        } catch (err) {
+          setOp({ status: "error", detail: "", error: (err as Error).message })
+        }
+      }
+      void run()
+    },
+    [persistKumaAuth, persistKumaMonitors],
+  )
+
+  // Remove an opt-in per-site monitor (front-page fingerprint or cache-bypass)
+  // — deliberately NOT offered for health/push/redis/fatal, which are all
+  // re-derived automatically on the next `a`/`R` press (no persisted opt-out
+  // exists for them yet), so "removing" one there would just silently
+  // reappear. These two are genuinely opt-in: pressing `a` after removal
+  // just reopens the picker, nothing re-creates them on its own.
+  const removeSiteMonitor = useCallback(
+    (site: Site, kind: "fingerprint" | "bypass") => {
+      const conn = cfgRef.current.uptimeKuma
+      if (!conn || isDevMode()) return
+      const setOp = (op: KumaOp) => setKumaOps((prev) => new Map(prev).set(site.id, op))
+      const run = async () => {
+        try {
+          const domain = site.domain
+          const known = cfgRef.current.kumaMonitors[domain] ?? {}
+          const id = kind === "fingerprint" ? known.fingerprintId : known.bypassId
+          const label = kind === "fingerprint" ? "Front-page" : "Cache-bypass"
+          if (id == null) return setOp({ status: "done", detail: "Already removed." })
+          setOp({ status: "running", detail: `Removing the ${label.toLowerCase()} monitor…` })
+          const { jwt } = await withKuma(conn, (kuma) => kuma.deleteMonitor(id))
+          persistKumaAuth(conn, jwt)
+          const next = { ...known }
+          if (kind === "fingerprint") {
+            delete next.fingerprintId
+            delete next.fingerprint
+          } else {
+            delete next.bypassId
+          }
+          persistKumaMonitors(domain, next)
+          setOp({ status: "done", detail: `${label} monitor removed.` })
         } catch (err) {
           setOp({ status: "error", detail: "", error: (err as Error).message })
         }
@@ -4083,6 +4195,9 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     clearVanity,
     vanityHealthKeyFor,
     kumaConfigured: !isDevMode() && cfgRef.current.uptimeKuma != null,
+    // Base URL for deep-linking straight to a monitor's own Kuma page
+    // (`${kumaUrl}/dashboard/${id}`) — null in Dev Mode / when unconfigured.
+    kumaUrl: !isDevMode() ? (cfgRef.current.uptimeKuma?.url ?? null) : null,
     kumaSite,
     setKumaSite,
     kumaOps,
@@ -4092,6 +4207,8 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     startVanityReseed,
     startKumaRotate,
     startFingerprintSetup,
+    startBypassMonitorSetup,
+    removeSiteMonitor,
     fetchKumaAlerts,
     toggleKumaAlert,
     clearKumaOp,

--- a/src/ui/views/KumaSite.tsx
+++ b/src/ui/views/KumaSite.tsx
@@ -1,19 +1,23 @@
 // Site monitoring overlay — opened with `m` in the sites pane.
 //
-// The monitor screen is the default; the Kuma connect form is opt-in (`c`, or
-// pressing `a` while unconnected), so the vanity-page refresh works with no
-// Uptime Kuma at all:
-//   - `R` on a vanity site (domain = server name) re-publishes the embedded page
-//     — the upgrade path for pages seeded by older Spinup versions. Without a
-//     Kuma connection that's ALL it does; with one it also registers the healthz
-//     + load push monitors and installs the heartbeat cron.
-//   - `a` registers monitors for this site (vanity: healthz + load push + cron;
-//     regular site: homepage monitor only — client site files are never touched).
-//   - `f` (regular sites) calibrates the front-page check: reads the live front
-//     page, derives a template fingerprint (body class / canonical — survives
-//     copy edits), and registers a Kuma keyword monitor asserting it at a chosen
-//     window. Catches "the cache is serving the wrong page" (HTTP stays 200).
-//     Re-running recalibrates in place (monitor history survives a redesign).
+// Full-screen two-pane browser (mirrors ProviderConnect.tsx): a left list of
+// this site's monitor kinds (source: MONITOR_GLOSSARY, filtered by vanity vs
+// regular) with a status dot, and a right detail pane showing whichever one
+// is highlighted — its one-liner, longer mechanism description, live status,
+// and how to act on it. The Kuma connect form is opt-in (`c`, or pressing
+// `a` while unconnected), so the vanity-page refresh works with no Uptime
+// Kuma at all:
+//   - `↑↓`/`jk` move the highlight in the left list.
+//   - `a` acts on WHICHEVER monitor is currently selected — one key, not one
+//     per kind. Front page selected → opens the calibration window picker;
+//     Cache bypass selected → opens its window picker; anything else →
+//     register/repair (vanity: healthz + load push + cron + Redis/PHP-fatal
+//     sentinels if sudo is connected; regular site: homepage monitor only —
+//     client site files are never touched).
+//   - `R` on a vanity site (domain = server name) re-publishes the embedded
+//     page — the upgrade path for pages seeded by older Spinup versions.
+//     Without a Kuma connection that's ALL it does; with one it also
+//     registers monitors and installs the heartbeat cron.
 //   - `n` (alerts) lists Kuma's notification providers by name (Telegram, email,
 //     …) and toggles them per site across all of the site's Spinup monitors —
 //     detection is real (providers ride the post-login event burst), only the
@@ -21,17 +25,20 @@
 //   - `r` (vanity, confirm-gated) rotates the monitoring secrets: new push token
 //     edited into the existing monitor (history kept), cron rewritten, new health
 //     key re-seeded — so secrets shown on a screencast can be killed right after.
+//   - `d` (regular sites) runs the doctor — a pure-HTTP cache-vs-fresh-render
+//     diagnosis, deliberately not gated on a Kuma connection.
 //   - The connect form verifies by actually logging in before anything persists;
 //     the minted JWT is stored so later sessions (and 2FA accounts) log in by
 //     token. Env-sourced connections (SPINUP_KUMA_*) never see the form.
 
 import { useEffect, useState } from "react"
 import { useKeyboard } from "@opentui/react"
-import { theme } from "../../lib/theme.ts"
+import { theme, statusDot, statusColor } from "../../lib/theme.ts"
 import { Panel, Centered, Field, SecretInput, Spinner } from "../components.tsx"
 import { StatusBar } from "../StatusBar.tsx"
 import { useStore, type KumaAlertProvider } from "../store.tsx"
 import { isVanityPair } from "../../lib/vanitySite.ts"
+import { openUrl } from "../../lib/open.ts"
 import { runSiteDoctor, type DoctorReport } from "../../lib/siteDoctor.ts"
 import { classifyStack } from "../../lib/stack.ts"
 
@@ -50,6 +57,88 @@ const FP_WINDOWS = [
   { label: "1h", sec: 3600 },
 ] as const
 
+// Check windows for the cache-bypass monitor. Unlike the fingerprint check
+// (served from cache, costs nothing), this forces a real PHP render every
+// time — the window is really "how much added load is acceptable", so it
+// skews much longer. Defaults to 1h.
+const BYPASS_WINDOWS = [
+  { label: "30m", sec: 1800 },
+  { label: "1h", sec: 3600 },
+  { label: "2h", sec: 7200 },
+  { label: "4h", sec: 14400 },
+  { label: "6h", sec: 21600 },
+] as const
+const BYPASS_DEFAULT_IDX = 1 // "1h"
+
+// The `i` glossary overlay's content — one entry per monitor kind this view
+// can register, accurate to the actual mechanism (not an approximation of
+// it). `contexts` gates which site kind sees each entry.
+interface GlossaryEntry {
+  key: string
+  label: string
+  tagline: string
+  detail: string
+  contexts: Array<"vanity" | "regular">
+}
+const MONITOR_GLOSSARY: GlossaryEntry[] = [
+  {
+    key: "health-site",
+    label: "Site health check",
+    tagline: "Is this specific website up right now?",
+    detail:
+      "A plain HTTP check on this site's own homepage, plus certificate-expiry alerting. Served straight from the page cache when one exists — cheap, but for that exact reason it can't see a PHP fatal hiding behind a still-warm cache. This is about whether THIS site answers — independent of whether the server it lives on is under strain.",
+    contexts: ["regular"],
+  },
+  {
+    key: "health-server",
+    label: "Server health check",
+    tagline: "Is the server itself under strain?",
+    detail:
+      "Hits the vanity page's /?healthz endpoint — a small script that reports the server's own resource state (load, disk) and returns 503 when it's strained. This is about the server's health, not any one site's: a customer site can be completely broken while this stays green, and the server can be strained while every site still limps out a 200.",
+    contexts: ["vanity"],
+  },
+  {
+    key: "push",
+    label: "Load heartbeat",
+    tagline: "Is the server itself still alive?",
+    detail:
+      "A once-a-minute cron on the server pushes its 1-minute load average to Kuma. It's a dead-man's-switch: the cron never reports \"down\" itself — it just goes silent if the server, the cron, or its network egress dies, and Kuma's own missed-heartbeat timeout is what raises the alarm.",
+    contexts: ["vanity"],
+  },
+  {
+    key: "redis",
+    label: "Redis sentinel",
+    tagline: "Is Redis actually answering?",
+    detail:
+      "The same heartbeat cron also runs redis-cli ping every minute and actively reports up/down. Unlike the load heartbeat, this alerts immediately when Redis stops answering while the server itself is fine — important because SpinupWP's default object-cache drop-in makes a dead Redis fatal on every page-cache miss.",
+    contexts: ["vanity"],
+  },
+  {
+    key: "fatal",
+    label: "PHP-fatal sentinel",
+    tagline: "Did any site on this server just start fataling?",
+    detail:
+      "A root-level cron scans every site's error/debug logs each minute for new \"PHP Fatal error\" lines. Catches the exact blind spot where a fatal happens behind a still-warm page cache and the plain per-site checks never notice. One monitor per server (not per site) to avoid pileup — the specific affected domain is named in the down alert's own message.",
+    contexts: ["vanity"],
+  },
+  {
+    key: "fingerprint",
+    label: "Front page",
+    tagline: "Is the cache serving the right page?",
+    detail:
+      "At setup time, reads the live homepage and derives a template-identity fingerprint from whatever's actually there — a body-class token if one exists, otherwise the canonical link tag. From then on it asserts that same fingerprint stays present. Reads straight from the page cache, so it catches the cache serving a stale or wrong template even though the page still answers 200 — a failure a plain up/down check can't see.",
+    contexts: ["regular"],
+  },
+  {
+    key: "bypass",
+    label: "Cache bypass",
+    tagline: "Can PHP actually render this page right now?",
+    detail:
+      "The same homepage URL, but with a Cookie: wordpress_no_cache=1 header that forces the page cache to be skipped — so unlike the checks above, this one genuinely exercises PHP on every check. That's also why it costs the site something (a full render each time) and is opt-in rather than automatic, meant for sites with an actual history of PHP fatals hiding behind the cache.",
+    contexts: ["regular"],
+  },
+]
+
 // The `n` (alerts) step's state machine: load → list providers → toggle.
 type AlertsState =
   | null
@@ -57,8 +146,13 @@ type AlertsState =
   | { kind: "error"; error: string }
   | { kind: "ready"; providers: KumaAlertProvider[]; monitorIds: number[]; idx: number; busy: boolean; flash: string | null }
 
+// A passive, header-line summary of alert wiring — fetched once when the
+// overlay opens (not polled), kept in sync with `n`'s own toggles. Separate
+// from AlertsState since it must survive after `n`'s interactive view closes.
+type AlertSummary = null | { kind: "loading" } | { kind: "error"; error: string } | { kind: "ready"; providers: KumaAlertProvider[] }
+
 export function KumaSite() {
-  const { kumaSite: site, setKumaSite, kumaConfigured, connectKuma, kumaMonitorFor, kumaOps, startKumaSetup, startVanityReseed, startKumaRotate, startFingerprintSetup, fetchKumaAlerts, toggleKumaAlert, clearKumaOp, kumaStatus, servers, setInputMode } = useStore()
+  const { kumaSite: site, setKumaSite, kumaConfigured, kumaUrl, connectKuma, kumaMonitorFor, kumaOps, startKumaSetup, startVanityReseed, startKumaRotate, startFingerprintSetup, startBypassMonitorSetup, removeSiteMonitor, fetchKumaAlerts, toggleKumaAlert, clearKumaOp, kumaStatus, servers, setInputMode } = useStore()
 
   const [draft, setDraft] = useState({ url: "", username: "", password: "" })
   const [fieldIdx, setFieldIdx] = useState(0)
@@ -69,12 +163,26 @@ export function KumaSite() {
   // `r` arms a confirm (rotation kills the live push URL / health key the moment
   // it fires — never do that on a stray keypress); y/⏎ fires, Esc disarms.
   const [confirmRotate, setConfirmRotate] = useState(false)
+  // `x` arms a confirm before deleting an opt-in monitor (front page / cache
+  // bypass) — remembers WHICH kind, unlike confirmRotate (only one target).
+  const [confirmRemove, setConfirmRemove] = useState<"fingerprint" | "bypass" | null>(null)
   // `f` opens the front-page check-window picker; ⏎ calibrates & registers.
   const [fpPick, setFpPick] = useState(false)
   const [fpIdx, setFpIdx] = useState(0)
+  // `b` opens the cache-bypass check-window picker; ⏎ registers/recalibrates.
+  // Own state (not shared with fpPick) — different window array and default.
+  const [bypassPick, setBypassPick] = useState(false)
+  const [bypassIdx, setBypassIdx] = useState(BYPASS_DEFAULT_IDX)
   // `n` opens the alerts step — a live read of Kuma's notification providers and
   // which are attached to this site's monitors; ⏎ toggles the selected one.
   const [alerts, setAlerts] = useState<AlertsState>(null)
+  // Passive header-line summary of alert wiring — fetched once per site open
+  // (see the effect below), not polled; kept in sync with `n`'s own toggles.
+  const [alertSummary, setAlertSummary] = useState<AlertSummary>(null)
+  // Which monitor kind is highlighted in the left-hand list (full-screen
+  // browser). Clamped against `entries.length` at read time, not here — the
+  // list's length depends on isVanity, computed after this point.
+  const [selectedIdx, setSelectedIdx] = useState(0)
   // `d` runs the doctor — read-only HTTP diagnosis (works without Kuma).
   const [doctor, setDoctor] = useState<null | { kind: "loading" } | { kind: "ready"; report: DoctorReport }>(null)
   // 2FA: revealed only after Kuma answers `tokenRequired` to a correct password.
@@ -92,12 +200,166 @@ export function KumaSite() {
   // without this the only fix would be hand-editing config.json).
   const connecting = showConnect
 
+  // The left-hand list's rows for this site's context, and the currently
+  // highlighted one — clamped so a stale index (e.g. from a previous site
+  // with more rows) never indexes past the end.
+  const entries = MONITOR_GLOSSARY.filter((e) => e.contexts.includes(isVanity ? "vanity" : "regular"))
+  const safeIdx = Math.min(selectedIdx, Math.max(entries.length - 1, 0))
+  const selected = entries[safeIdx]
+
+  const win = (sec: number) => (sec % 3600 === 0 ? `${sec / 3600}h` : `${Math.round(sec / 60)}m`)
+  const healthUp = site ? (kumaStatus.get(site.domain)?.up ?? null) : null
+  const fpUp = site ? (kumaStatus.get(site.domain)?.fingerprintUp ?? null) : null
+  const redisUp = site ? (kumaStatus.get(site.domain)?.redisUp ?? null) : null
+  const fatalUp = site ? (kumaStatus.get(site.domain)?.fatalUp ?? null) : null
+  const bypassUp = site ? (kumaStatus.get(site.domain)?.bypassUp ?? null) : null
+  const fp = registered?.fingerprint
+  const fpValue = fp
+    ? `${fp.detail} · every ${win(fp.interval)}${fpUp === false ? " · WRONG PAGE SERVED" : fpUp === true ? " · ok" : ""}`
+    : registered?.fingerprintId
+      ? "registered (details unknown) · a recalibrates"
+      : "not calibrated · a"
+  const fpColor = fpUp === false ? theme.bad : fp ? (fpUp === true ? theme.good : theme.text) : theme.textFaint
+  const redisValue = !registered?.redisId
+    ? "not registered · a adds it"
+    : redisUp === false
+      ? "down"
+      : redisUp === true
+        ? "up"
+        : "registered (status unknown)"
+  const redisColor = redisUp === false ? theme.bad : registered?.redisId ? (redisUp === true ? theme.good : theme.text) : theme.textFaint
+  const fatalValue = !registered?.fatalId
+    ? "not registered · a adds it"
+    : fatalUp === false
+      ? "down"
+      : fatalUp === true
+        ? "up"
+        : "registered (status unknown)"
+  const fatalColor = fatalUp === false ? theme.bad : registered?.fatalId ? (fatalUp === true ? theme.good : theme.text) : theme.textFaint
+  const bypassValue = !registered?.bypassId
+    ? "not registered"
+    : bypassUp === false
+      ? "down · a recalibrates"
+      : bypassUp === true
+        ? "up · a recalibrates"
+        : "registered (status unknown) · a recalibrates"
+  const bypassColor = bypassUp === false ? theme.bad : registered?.bypassId ? (bypassUp === true ? theme.good : theme.text) : theme.textFaint
+
+  // Per-entry status, normalized into the { registered, upState } shape
+  // statusDot/statusColor's connection-style vocabulary maps onto (neither
+  // accepts "up"/"down" directly — see theme.ts).
+  function statusFor(key: string): { registered: boolean; upState: boolean | null; value: string; color: string } {
+    switch (key) {
+      case "health-site":
+      case "health-server":
+        return {
+          registered: !!registered?.healthId,
+          upState: healthUp,
+          value: !registered?.healthId
+            ? registered?.fingerprintId
+              ? "front-page check only"
+              : "not registered"
+            : healthUp === false
+              ? "down"
+              : healthUp === true
+                ? "up"
+                : "registered (status unknown)",
+          color: healthUp === false ? theme.bad : registered?.healthId ? (healthUp === true ? theme.good : theme.text) : theme.textFaint,
+        }
+      case "push":
+        // The load-heartbeat cron feeds the SAME shared `up` field as the
+        // health check (store.tsx's poll loop only sets it from push when
+        // health hasn't already) — there's no independent push-only signal.
+        return {
+          registered: !!registered?.pushId,
+          upState: healthUp,
+          value: !registered?.pushId ? "not registered" : healthUp === false ? "down" : healthUp === true ? "up" : "registered (status unknown)",
+          color: healthUp === false ? theme.bad : registered?.pushId ? (healthUp === true ? theme.good : theme.text) : theme.textFaint,
+        }
+      case "redis":
+        return { registered: !!registered?.redisId, upState: redisUp, value: redisValue, color: redisColor }
+      case "fatal":
+        return { registered: !!registered?.fatalId, upState: fatalUp, value: fatalValue, color: fatalColor }
+      case "fingerprint":
+        return { registered: !!registered?.fingerprintId, upState: fpUp, value: fpValue, color: fpColor }
+      case "bypass":
+        return { registered: !!registered?.bypassId, upState: bypassUp, value: bypassValue, color: bypassColor }
+      default:
+        return { registered: false, upState: null, value: "unknown", color: theme.textFaint }
+    }
+  }
+  // statusDot/statusColor's own vocabulary (theme.ts:26-47) is connection/
+  // deploy-style strings, not up/down — normalize here rather than there.
+  function dotStatus(s: { registered: boolean; upState: boolean | null }): string | null {
+    if (!s.registered) return null
+    if (s.upState === true) return "active"
+    if (s.upState === false) return "failed"
+    return "pending"
+  }
+  // The specific Kuma monitor id behind an entry, for the `o` deep-link — null
+  // when not yet registered (nothing to link to).
+  function monitorIdFor(key: string): number | null {
+    switch (key) {
+      case "health-site":
+      case "health-server":
+        return registered?.healthId ?? null
+      case "push":
+        return registered?.pushId ?? null
+      case "redis":
+        return registered?.redisId ?? null
+      case "fatal":
+        return registered?.fatalId ?? null
+      case "fingerprint":
+        return registered?.fingerprintId ?? null
+      case "bypass":
+        return registered?.bypassId ?? null
+      default:
+        return null
+    }
+  }
+
+  // Compresses alertSummary into one header line. Only flags the ABNORMAL
+  // case explicitly (partial wiring) — full wiring is the expected state and
+  // doesn't need its own callout.
+  function formatAlertSummary(): { text: string; color: string } {
+    if (!kumaConfigured) return { text: "Alerts: connect Kuma first · c", color: theme.textFaint }
+    if (!alertSummary || alertSummary.kind === "loading") return { text: "Alerts: checking…", color: theme.textFaint }
+    if (alertSummary.kind === "error") return { text: "Alerts: unavailable · n to retry", color: theme.textFaint }
+    if (alertSummary.providers.length === 0) return { text: "Alerts: none configured in Kuma · n to add one", color: theme.textFaint }
+    const attached = alertSummary.providers.filter((p) => p.attachedAny)
+    if (attached.length === 0) return { text: "Alerts: not wired to any provider · n to choose", color: theme.warn }
+    const names = attached.map((p) => p.name).join(", ")
+    const anyPartial = attached.some((p) => p.attachedAny && !p.attachedAll)
+    return { text: `Alerts: ${names}${anyPartial ? " (some monitors only)" : ""} · n to manage`, color: theme.good }
+  }
+
   // While the connect form is up, its inputs own the keyboard (suppresses the
   // global single-key shortcuts); cleared on connect/close.
   useEffect(() => {
     setInputMode(connecting)
     return () => setInputMode(false)
   }, [connecting, setInputMode])
+
+  // Silently fetch alert-wiring status once per site open (not polled — this
+  // needs a getMonitor round-trip per monitor, unlike the passive poll loop's
+  // beat reads, so it isn't "free" the way up/down status is). Re-fires on a
+  // genuinely different site (site?.domain toggles through undefined when the
+  // overlay closes, so reopening the same site re-fetches too).
+  useEffect(() => {
+    if (!site || !kumaConfigured) {
+      setAlertSummary(null)
+      return
+    }
+    let cancelled = false
+    setAlertSummary({ kind: "loading" })
+    void fetchKumaAlerts(site).then((r) => {
+      if (cancelled) return
+      setAlertSummary(r.ok ? { kind: "ready", providers: r.providers } : { kind: "error", error: r.error })
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [site?.domain, kumaConfigured, fetchKumaAlerts])
 
   const runDoctor = () => {
     if (!site) return
@@ -180,6 +442,15 @@ export function KumaSite() {
       if (name === "escape" || name === "n" || name === "q") return setConfirmRotate(false)
       return
     }
+    if (confirmRemove) {
+      if ((name === "y" || name === "return") && site) {
+        const kind = confirmRemove
+        setConfirmRemove(null)
+        return removeSiteMonitor(site, kind)
+      }
+      if (name === "escape" || name === "n" || name === "q") return setConfirmRemove(null)
+      return
+    }
     if (doctor) {
       if (name === "escape" || name === "q") return setDoctor(null)
       if (doctor.kind !== "ready") return
@@ -212,6 +483,12 @@ export function KumaSite() {
             const n = prev.monitorIds.length
             return { ...prev, providers, busy: false, flash: `✓ ${p.name} ${on ? "now alerts" : "no longer alerts"} for ${n} monitor${n === 1 ? "" : "s"}` }
           })
+          // Keep the header's passive summary in sync without a re-fetch.
+          if (r.ok) {
+            setAlertSummary((prev) =>
+              prev?.kind === "ready" ? { kind: "ready", providers: prev.providers.map((q) => (q.id === p.id ? { ...q, attachedAll: on, attachedAny: on } : q)) } : prev,
+            )
+          }
         })
         return
       }
@@ -228,15 +505,27 @@ export function KumaSite() {
       if (name === "escape" || name === "q") return setFpPick(false)
       return
     }
-    if (name === "c") return setShowConnect(true)
-    if (name === "f" && !isVanity && site && op?.status !== "running") {
-      if (!kumaConfigured) return setShowConnect(true) // the check lives in Kuma
-      // Preselect the stored window on recalibration so ⏎⏎ keeps it.
-      const storedSec = registered?.fingerprint?.interval
-      const idx = FP_WINDOWS.findIndex((w) => w.sec === storedSec)
-      setFpIdx(idx >= 0 ? idx : 0)
-      return setFpPick(true)
+    if (bypassPick) {
+      if (name === "left" || name === "up" || name === "h" || name === "k") return setBypassIdx((i) => Math.max(i - 1, 0))
+      if (name === "right" || name === "down" || name === "l" || name === "j" || name === "tab") return setBypassIdx((i) => Math.min(i + 1, BYPASS_WINDOWS.length - 1))
+      if (/^[1-5]$/.test(name)) return setBypassIdx(Number(name) - 1)
+      if (name === "return" && site) {
+        setBypassPick(false)
+        return startBypassMonitorSetup(site, BYPASS_WINDOWS[bypassIdx]!.sec)
+      }
+      if (name === "escape" || name === "q") return setBypassPick(false)
+      return
     }
+    if (name === "c") return setShowConnect(true)
+    if (name === "o" && site && op?.status !== "running") {
+      const id = selected ? monitorIdFor(selected.key) : null
+      if (kumaUrl && id != null) openUrl(`${kumaUrl}/dashboard/${id}`)
+      return
+    }
+    // Move the left list's highlight — only reachable here since every modal
+    // state above already returned.
+    if ((name === "up" || name === "k") && site && op?.status !== "running") return setSelectedIdx((i) => Math.max(i - 1, 0))
+    if ((name === "down" || name === "j") && site && op?.status !== "running") return setSelectedIdx((i) => Math.min(i + 1, entries.length - 1))
     if (name === "d" && !isVanity && site && op?.status !== "running") {
       // Pure HTTP — deliberately NOT gated on a Kuma connection.
       return runDoctor()
@@ -250,8 +539,29 @@ export function KumaSite() {
       return
     }
     if (name === "r" && isVanity && site && op?.status !== "running") return setConfirmRotate(true)
+    if (
+      name === "x" &&
+      site &&
+      op?.status !== "running" &&
+      (selected?.key === "fingerprint" || selected?.key === "bypass") &&
+      monitorIdFor(selected.key) != null
+    ) {
+      return setConfirmRemove(selected.key)
+    }
+    // The single "act on whichever monitor is selected" key — replaces the old
+    // per-kind f/b keys now that the right pane shows one monitor at a time.
     if (name === "a" && site && op?.status !== "running") {
       if (!kumaConfigured) return setShowConnect(true) // monitors need a connection
+      if (selected?.key === "fingerprint") {
+        const storedSec = registered?.fingerprint?.interval
+        const idx = FP_WINDOWS.findIndex((w) => w.sec === storedSec)
+        setFpIdx(idx >= 0 ? idx : 0)
+        return setFpPick(true)
+      }
+      if (selected?.key === "bypass") {
+        setBypassIdx(BYPASS_DEFAULT_IDX)
+        return setBypassPick(true)
+      }
       return startKumaSetup(site)
     }
     if (name === "R" && isVanity && site && op?.status !== "running") {
@@ -270,7 +580,27 @@ export function KumaSite() {
         <text content={site.domain} fg={theme.text} wrapMode="none" style={{ flexShrink: 1 }} />
       </box>
 
-      <Centered>{connecting ? renderConnect() : renderMonitor()}</Centered>
+      {connecting ? (
+        <Centered>{renderConnect()}</Centered>
+      ) : confirmRotate ? (
+        <Centered>{renderRotateConfirm()}</Centered>
+      ) : confirmRemove ? (
+        <Centered>{renderRemoveConfirm()}</Centered>
+      ) : doctor ? (
+        <Centered>
+          <Panel title=" Doctor — cache diagnosis " active>
+            <box style={{ flexDirection: "column", width: 68, paddingTop: 1, paddingBottom: 1 }}>{renderDoctor()}</box>
+          </Panel>
+        </Centered>
+      ) : alerts ? (
+        <Centered>
+          <Panel title=" Alerts " active>
+            <box style={{ flexDirection: "column", width: 68, paddingTop: 1, paddingBottom: 1 }}>{renderAlerts()}</box>
+          </Panel>
+        </Centered>
+      ) : (
+        renderMonitorBrowser()
+      )}
 
       <StatusBar hints={hints()} showGlobal={false} />
     </box>
@@ -326,77 +656,41 @@ export function KumaSite() {
     )
   }
 
-  function renderMonitor() {
-    const fp = registered?.fingerprint
-    const fpUp = site ? (kumaStatus.get(site.domain)?.fingerprintUp ?? null) : null
-    const win = (sec: number) => (sec % 3600 === 0 ? `${sec / 3600}h` : `${Math.round(sec / 60)}m`)
-    const fpValue = fp
-      ? `${fp.detail} · every ${win(fp.interval)}${fpUp === false ? " · WRONG PAGE SERVED" : fpUp === true ? " · ok" : ""}`
-      : registered?.fingerprintId
-        ? "registered (details unknown) · f recalibrates"
-        : "not calibrated · f"
-    const fpColor = fpUp === false ? theme.bad : fp ? (fpUp === true ? theme.good : theme.text) : theme.textFaint
+  // Full-screen browser: a narrow left list of this site's monitor kinds
+  // (status dot + label) and a wide right detail pane for whichever one is
+  // selected — mirrors ProviderConnect.tsx's two-Panel-in-a-row layout.
+  function renderMonitorBrowser() {
+    const alertLine = formatAlertSummary()
     return (
-      <Panel title=" Site monitoring " active>
-        <box style={{ flexDirection: "column", width: 68, paddingTop: 1, paddingBottom: 1 }}>
-          {connectedVersion && (
-            <>
-              <text content={`● Uptime Kuma connected (${connectedVersion}).`} fg={theme.good} wrapMode="none" />
-              <box style={{ height: 1 }} />
-            </>
-          )}
-          <Field label="Site" value={site!.domain} />
-          <Field label="Kind" value={isVanity ? "vanity page (full server monitoring)" : "site homepage (up/down + cert expiry)"} />
-          <Field label="Kuma" value={kumaConfigured ? "connected · c to reconnect" : "not connected · c"} valueColor={kumaConfigured ? theme.good : theme.textFaint} />
-          <Field
-            label="Monitors"
-            value={
-              registered?.healthId
-                ? `registered${registered.pushId ? " (healthz + load push)" : ""}`
-                : registered?.fingerprintId
-                  ? "front-page check only · a adds the up/down monitor"
-                  : "not registered yet"
-            }
-          />
-          {!isVanity && <Field label="Front page" value={fpValue} valueColor={fpColor} />}
-          <box style={{ height: 1 }} />
-          {doctor ? (
-            renderDoctor()
-          ) : alerts ? (
-            renderAlerts()
-          ) : fpPick ? (
-            <>
-              <text content="Front-page check — alerts when the wrong page is served." fg={theme.text} wrapMode="none" />
-              <text content="Reads the live page now (while it's healthy), derives a template" fg={theme.textDim} wrapMode="none" />
-              <text content="fingerprint (body class / canonical — survives copy edits), and" fg={theme.textDim} wrapMode="none" />
-              <text content="registers a Kuma keyword monitor asserting it." fg={theme.textDim} wrapMode="none" />
-              <box style={{ height: 1 }} />
-              <box style={{ flexDirection: "row" }}>
-                <text content="Check window:" fg={theme.textDim} style={{ flexShrink: 0 }} />
-                {FP_WINDOWS.map((w, i) => (
-                  <text key={w.label} content={i === fpIdx ? `  ▸${w.label}` : `   ${w.label}`} fg={i === fpIdx ? theme.brand : theme.textFaint} style={{ flexShrink: 0 }} />
-                ))}
-              </box>
-              <box style={{ height: 1 }} />
-              <text content="←/→ or 1-4 window · ⏎ calibrate & register · esc cancel" fg={theme.textFaint} wrapMode="none" />
-            </>
-          ) : confirmRotate ? (
-            <>
-              <text content="Rotate this site's monitoring secrets?" fg={theme.warn} wrapMode="none" />
-              <text content="A new push URL and health key are minted; the old ones stop" fg={theme.textDim} wrapMode="none" />
-              <text content="working immediately. Kuma monitor history is kept." fg={theme.textDim} wrapMode="none" />
-              <box style={{ height: 1 }} />
-              <text content="y / ⏎ rotate · esc cancel" fg={theme.textFaint} wrapMode="none" />
-            </>
-          ) : op?.status === "running" ? (
-            <box style={{ flexDirection: "row" }}>
-              <Spinner />
-              <text content={`  ${op.detail}`} fg={theme.textDim} wrapMode="none" />
+      <box style={{ flexDirection: "column", flexGrow: 1, paddingLeft: 1, paddingRight: 1, paddingTop: 1 }}>
+        {connectedVersion && (
+          <>
+            <text content={`● Uptime Kuma connected (${connectedVersion}).`} fg={theme.good} wrapMode="none" />
+            <box style={{ height: 1 }} />
+          </>
+        )}
+        <text content={isVanity ? "vanity page (full server monitoring)" : "site homepage (up/down + cert expiry)"} fg={theme.textDim} wrapMode="none" />
+        <text content={kumaConfigured ? "Uptime Kuma: connected · c to reconnect" : "Uptime Kuma: not connected · c"} fg={kumaConfigured ? theme.good : theme.textFaint} wrapMode="none" />
+        <text content={alertLine.text} fg={alertLine.color} wrapMode="none" />
+        <box style={{ height: 1 }} />
+        <box style={{ flexGrow: 1, flexDirection: "row", gap: 1 }}>
+          <Panel title=" Monitors " active width={30}>
+            <box style={{ flexDirection: "column", paddingTop: 1, paddingBottom: 1 }}>
+              {entries.map((e, i) => {
+                const s = statusFor(e.key)
+                const sel = i === safeIdx
+                return (
+                  <box key={e.key} style={{ flexDirection: "row", backgroundColor: sel ? theme.selectedBg : undefined }}>
+                    <text content={sel ? "› " : "  "} fg={theme.brand} style={{ flexShrink: 0 }} />
+                    <text content={`${statusDot(dotStatus(s))} `} fg={statusColor(dotStatus(s))} style={{ flexShrink: 0 }} />
+                    <text content={e.label} fg={sel ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 1 }} />
+                  </box>
+                )
+              })}
             </box>
-          ) : isVanity ? (
-            <>
-              {/* A settled result shows ABOVE the actions, never instead of them —
-                  the overlay must always offer its next moves. */}
+          </Panel>
+          <Panel title={selected ? ` ${selected.label} ` : " Monitor "} flexGrow={1} active>
+            <box style={{ flexDirection: "column", width: 90, paddingTop: 1, paddingBottom: 1, paddingLeft: 1 }}>
               {op?.status === "error" && (
                 <>
                   <text content={`✕ ${op.error}`} fg={theme.bad} />
@@ -409,43 +703,111 @@ export function KumaSite() {
                   <box style={{ height: 1 }} />
                 </>
               )}
-              <text
-                content={kumaConfigured ? "R — re-publish the page, register monitors & install the cron" : "R — re-publish the page (current version, health endpoints)"}
-                fg={theme.textDim}
-                wrapMode="none"
-              />
-              <text
-                content={kumaConfigured ? "a — register monitors & cron without touching the page" : "a — register Kuma monitors (connects Uptime Kuma first)"}
-                fg={theme.textDim}
-                wrapMode="none"
-              />
-              <text content="r — rotate secrets: new push URL + health key (old ones die)" fg={theme.textDim} wrapMode="none" />
-              <text content="n — alerts: choose where this server's checks notify" fg={theme.textDim} wrapMode="none" />
-            </>
-          ) : (
-            <>
-              {op?.status === "error" && (
+              {op?.status === "running" ? (
+                <box style={{ flexDirection: "row" }}>
+                  <Spinner />
+                  <text content={`  ${op.detail}`} fg={theme.textDim} wrapMode="none" />
+                </box>
+              ) : fpPick && selected?.key === "fingerprint" ? (
                 <>
-                  <text content={`✕ ${op.error}`} fg={theme.bad} />
+                  <text content="Reads the live page now (while it's healthy), derives a template" fg={theme.textDim} wrapMode="none" />
+                  <text content="fingerprint (body class / canonical — survives copy edits), and" fg={theme.textDim} wrapMode="none" />
+                  <text content="registers a Kuma keyword monitor asserting it." fg={theme.textDim} wrapMode="none" />
                   <box style={{ height: 1 }} />
+                  <box style={{ flexDirection: "row" }}>
+                    <text content="Check window:" fg={theme.textDim} style={{ flexShrink: 0 }} />
+                    {FP_WINDOWS.map((w, i) => (
+                      <text key={w.label} content={i === fpIdx ? `  ▸${w.label}` : `   ${w.label}`} fg={i === fpIdx ? theme.brand : theme.textFaint} style={{ flexShrink: 0 }} />
+                    ))}
+                  </box>
+                  <box style={{ height: 1 }} />
+                  <text content="←/→ or 1-4 window · ⏎ calibrate & register · esc cancel" fg={theme.textFaint} wrapMode="none" />
                 </>
-              )}
-              {op?.status === "done" && (
+              ) : bypassPick && selected?.key === "bypass" ? (
                 <>
-                  <text content={`✓ ${op.detail}`} fg={theme.good} />
+                  <text content="Forces a real PHP render, catching a fatal hidden behind a still-" fg={theme.textDim} wrapMode="none" />
+                  <text content="warm page cache. Costs the site a real render on every check, so" fg={theme.textDim} wrapMode="none" />
+                  <text content="pick a loose window; use only on sites with a history of this." fg={theme.textDim} wrapMode="none" />
                   <box style={{ height: 1 }} />
+                  <box style={{ flexDirection: "row" }}>
+                    <text content="Check window:" fg={theme.textDim} style={{ flexShrink: 0 }} />
+                    {BYPASS_WINDOWS.map((w, i) => (
+                      <text key={w.label} content={i === bypassIdx ? `  ▸${w.label}` : `   ${w.label}`} fg={i === bypassIdx ? theme.brand : theme.textFaint} style={{ flexShrink: 0 }} />
+                    ))}
+                  </box>
+                  <box style={{ height: 1 }} />
+                  <text content="←/→ or 1-5 window · ⏎ register · esc cancel" fg={theme.textFaint} wrapMode="none" />
                 </>
-              )}
-              <text content={kumaConfigured ? "a — register a homepage monitor in Uptime Kuma" : "a — register a homepage monitor (connects Uptime Kuma first)"} fg={theme.textDim} wrapMode="none" />
-              <text
-                content={registered?.fingerprintId ? "f — recalibrate the front-page check (e.g. after a redesign)" : "f — front-page check: alert when the wrong page is served"}
-                fg={theme.textDim}
-                wrapMode="none"
-              />
-              <text content="n — alerts: choose where this site's checks notify" fg={theme.textDim} wrapMode="none" />
-              <text content="d — doctor: prove whether the cache is serving the wrong page" fg={theme.textDim} wrapMode="none" />
-            </>
-          )}
+              ) : selected ? (
+                <>
+                  <text content={selected.tagline} fg={theme.text} wrapMode="none" />
+                  <box style={{ height: 1 }} />
+                  <text content={selected.detail} fg={theme.textDim} />
+                  <box style={{ height: 1 }} />
+                  <Field label="Status" value={statusFor(selected.key).value} valueColor={statusFor(selected.key).color} />
+                  <Field
+                    label="In Kuma"
+                    value={monitorIdFor(selected.key) != null ? `#${monitorIdFor(selected.key)} · o opens it` : "not registered yet"}
+                    valueColor={monitorIdFor(selected.key) != null ? theme.text : theme.textFaint}
+                  />
+                  <Field
+                    label="Action"
+                    value={(() => {
+                      const removable = (selected.key === "fingerprint" || selected.key === "bypass") && monitorIdFor(selected.key) != null
+                      const base =
+                        selected.key === "fingerprint"
+                          ? registered?.fingerprintId
+                            ? "a — recalibrate"
+                            : "a — calibrate & register"
+                          : selected.key === "bypass"
+                            ? registered?.bypassId
+                              ? "a — recalibrate"
+                              : "a — register (opt-in)"
+                            : statusFor(selected.key).registered
+                              ? "a — repair / re-register"
+                              : "a — register"
+                      return removable ? `${base} · x — remove` : base
+                    })()}
+                  />
+                  {selected.key !== "fingerprint" && selected.key !== "bypass" && statusFor(selected.key).registered && (
+                    <text content="(safe to re-run any time — re-syncs with Kuma, e.g. if a monitor was" fg={theme.textFaint} wrapMode="none" />
+                  )}
+                  {selected.key !== "fingerprint" && selected.key !== "bypass" && statusFor(selected.key).registered && (
+                    <text content="deleted directly in Kuma, or sudo just got connected for PHP-fatal)" fg={theme.textFaint} wrapMode="none" />
+                  )}
+                </>
+              ) : null}
+            </box>
+          </Panel>
+        </box>
+      </box>
+    )
+  }
+
+  function renderRotateConfirm() {
+    return (
+      <Panel title=" Rotate monitoring secrets " active>
+        <box style={{ flexDirection: "column", width: 68, paddingTop: 1, paddingBottom: 1 }}>
+          <text content="Rotate this site's monitoring secrets?" fg={theme.warn} wrapMode="none" />
+          <text content="A new push URL and health key are minted; the old ones stop" fg={theme.textDim} wrapMode="none" />
+          <text content="working immediately. Kuma monitor history is kept." fg={theme.textDim} wrapMode="none" />
+          <box style={{ height: 1 }} />
+          <text content="y / ⏎ rotate · esc cancel" fg={theme.textFaint} wrapMode="none" />
+        </box>
+      </Panel>
+    )
+  }
+
+  function renderRemoveConfirm() {
+    const label = confirmRemove === "fingerprint" ? "front-page" : "cache-bypass"
+    return (
+      <Panel title=" Remove monitor " active>
+        <box style={{ flexDirection: "column", width: 68, paddingTop: 1, paddingBottom: 1 }}>
+          <text content={`Remove the ${label} monitor?`} fg={theme.warn} wrapMode="none" />
+          <text content="Deletes it in Kuma — its history is gone for good. Pressing" fg={theme.textDim} wrapMode="none" />
+          <text content="a afterward re-opens the picker to add it back from scratch." fg={theme.textDim} wrapMode="none" />
+          <box style={{ height: 1 }} />
+          <text content="y / ⏎ remove · esc cancel" fg={theme.textFaint} wrapMode="none" />
         </box>
       </Panel>
     )
@@ -554,16 +916,35 @@ export function KumaSite() {
   function hints() {
     if (connecting) return [{ key: "⏎", label: "next / connect" }, { key: "esc", label: "back" }]
     if (confirmRotate) return [{ key: "y/⏎", label: "rotate" }, { key: "esc", label: "cancel" }]
+    if (confirmRemove) return [{ key: "y/⏎", label: "remove" }, { key: "esc", label: "cancel" }]
     if (doctor) return doctor.kind === "ready" ? [{ key: "d", label: "re-run" }, { key: "esc", label: "back" }] : [{ key: "esc", label: "back" }]
     if (alerts) return alerts.kind === "ready" && alerts.providers.length > 0 ? [{ key: "↑↓", label: "select" }, { key: "⏎", label: "toggle" }, { key: "esc", label: "done" }] : [{ key: "esc", label: "back" }]
     if (fpPick) return [{ key: "←/→", label: "window" }, { key: "⏎", label: "calibrate" }, { key: "esc", label: "cancel" }]
+    if (bypassPick) return [{ key: "←/→", label: "window" }, { key: "⏎", label: "register" }, { key: "esc", label: "cancel" }]
     if (op?.status === "running") return [{ key: "esc", label: "background" }]
-    const base: { key: string; label: string }[] = []
+    const base: { key: string; label: string }[] = [{ key: "↑↓", label: "select monitor" }]
     if (isVanity) base.push({ key: "R", label: kumaConfigured ? "refresh page + monitors" : "refresh page" })
     if (isVanity) base.push({ key: "r", label: "rotate secrets" })
-    base.push({ key: "a", label: registered ? "repair monitors" : "add monitors" })
-    if (!isVanity) base.push({ key: "f", label: registered?.fingerprintId ? "recalibrate front page" : "front-page check" })
+    base.push({
+      key: "a",
+      label:
+        selected?.key === "fingerprint"
+          ? registered?.fingerprintId
+            ? "recalibrate front page"
+            : "front-page check"
+          : selected?.key === "bypass"
+            ? registered?.bypassId
+              ? "recalibrate cache-bypass"
+              : "cache-bypass check"
+            : statusFor(selected?.key ?? "").registered
+              ? "repair monitors"
+              : "add monitors",
+    })
+    if (selected && (selected.key === "fingerprint" || selected.key === "bypass") && monitorIdFor(selected.key) != null) {
+      base.push({ key: "x", label: "remove monitor" })
+    }
     if (!isVanity) base.push({ key: "d", label: "doctor" })
+    if (selected && monitorIdFor(selected.key) != null) base.push({ key: "o", label: "open in Kuma" })
     base.push({ key: "n", label: "alerts" })
     base.push({ key: "c", label: kumaConfigured ? "reconnect Kuma" : "connect Kuma" })
     return [...base, { key: "esc", label: "close" }]


### PR DESCRIPTION
## Summary
- **`spinuptui ssh <domain>`** / **`spinuptui incidents <domain>` / `--all`** — non-interactive CLI subcommands so external tooling (e.g. an incident-diagnostics agent handed only a domain) can get a live SSH target and Uptime Kuma down/up history without a human doing the lookup first.
- **Server-wide PHP-fatal sentinel** (root cron, one per server) + **opt-in per-site cache-bypass monitor** — close a real page-cache blind spot: SpinupWP's page cache can keep serving 200s while PHP is fataling behind it, invisible to the existing health/fingerprint checks.
- **Site/server monitoring overlay rebuilt** as a full-screen two-pane browser (monitor list + live status dot on the left, in-context explanation/status/action on the right) replacing a small popover that had outgrown six monitor kinds across two site contexts. Also: a passive alert-wiring summary in the header, `o` to deep-link to a monitor in Kuma, `x` to remove Front page/Cache bypass (confirm-gated, scoped to the two kinds where it's safe).
- README (Features, Keybindings, CLI subcommands) and `docs/site-monitoring.md` / `docs/uptime-kuma.md` updated to match.
- Version bumped to `0.21.0`, `CHANGELOG.md` rolled.

## Test plan
- [x] `bun run typecheck` green throughout
- [x] `spinuptui ssh <domain>` / `spinuptui incidents` verified against a real SpinupWP account (site-not-found, ambiguous-match, token-rejected, and success paths)
- [x] PHP-fatal sentinel verified live end-to-end on a real test server: sudo install, real induced PHP fatal (temporary mu-plugin) detected and confirmed in Kuma, clean recovery
- [x] Cache-bypass monitor verified live: confirmed `fastcgi-cache-bypass-reason: COOKIE`, real polling, live-fatal detection
- [x] Monitoring overlay manually tested end-to-end in the running TUI across several iterations (status dots, remove/confirm flow, alerts summary, Kuma deep-link)
- [ ] Final `bun run dev` smoke pass before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuDuTrkMX4YugodgyVpNPm