### PR TITLE
fix: Uptime Kuma connect falls back to polling, keeps the real error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+### Fixed
+- **Uptime Kuma connection now falls back to HTTP long-polling.** The client
+  previously connected over WebSocket only; a reverse proxy or CDN in front of
+  a Kuma instance that doesn't forward the WebSocket upgrade headers made the
+  connection fail outright instead of degrading gracefully. It now tries
+  polling as a fallback transport.
+- **Connection failures no longer swallow the real reason.** A failed connect
+  could render as `Couldn't reach Uptime Kuma at https://…: ` with nothing
+  after the colon — the underlying error's message was empty and got used
+  as-is. The error message now falls back through the error's description and
+  code before giving up, so a connection failure is actually diagnosable.
+
 ## [0.21.0] - 2026-07-09
 
 ### Added

--- a/src/lib/uptimeKuma.ts
+++ b/src/lib/uptimeKuma.ts
@@ -67,6 +67,23 @@ interface Ack {
 const ACK_TIMEOUT_MS = 15_000
 const CONNECT_TIMEOUT_MS = 10_000
 
+// engine.io wraps most transport failures in a TransportError whose `.message`
+// is a fixed literal ("websocket error") with the real reason tucked away in
+// `.description`; a few failure modes (a WebSocket constructor throwing
+// synchronously — seen from Bun's net/tls shim on cert issues) skip that
+// wrapper and hand us a bare Error whose `.message` can be empty. Walk every
+// place a reason might live rather than trusting `.message` alone, so a
+// connect failure never renders as a bare trailing colon.
+function describeConnectError(e: unknown): string {
+  const err = e as { message?: string; description?: unknown; code?: string } | undefined
+  if (err?.message) return err.message
+  const desc = err?.description
+  if (desc instanceof Error && desc.message) return desc.message
+  if (typeof desc === "string" && desc) return desc
+  if (err?.code) return err.code
+  return String(e)
+}
+
 // 32 chars, [A-Za-z0-9] — same shape the Kuma UI generates for push monitors.
 // (Kuma stores whatever the client sends; the token is chosen client-side.)
 export function genPushToken(): string {
@@ -155,7 +172,10 @@ export class KumaClient {
 
   static async connect(url: string): Promise<KumaClient> {
     const base = url.replace(/\/+$/, "")
-    const socket = io(base, { transports: ["websocket"], reconnection: false, timeout: CONNECT_TIMEOUT_MS })
+    // Polling as a fallback (not websocket-only): a reverse proxy/CDN in front of
+    // Kuma that doesn't forward the WebSocket Upgrade headers otherwise hard-fails
+    // the connection outright instead of degrading gracefully.
+    const socket = io(base, { transports: ["websocket", "polling"], reconnection: false, timeout: CONNECT_TIMEOUT_MS })
     const client = new KumaClient(socket)
     await new Promise<void>((resolve, reject) => {
       const t = setTimeout(() => {
@@ -169,7 +189,7 @@ export class KumaClient {
       socket.once("connect_error", (e: Error) => {
         clearTimeout(t)
         socket.disconnect()
-        reject(new KumaError(`Couldn't reach Uptime Kuma at ${base}: ${e.message}`))
+        reject(new KumaError(`Couldn't reach Uptime Kuma at ${base}: ${describeConnectError(e)}`))
       })
     })
     return client


### PR DESCRIPTION
## Summary
- WebSocket-only transport hard-failed against a reverse proxy/CDN that doesn't forward the WebSocket upgrade headers — the client now also tries HTTP long-polling as a fallback transport.
- The connect-error path stopped trusting a bare `.message`, which can come back empty (engine.io's fixed `"websocket error"` literal masks the real reason in `.description`; some failure modes skip that wrapper entirely). It now falls back through `.description` and `.code` before giving up, so a failed connect is diagnosable instead of rendering a dangling colon.

Reported by a user seeing `Couldn't reach Uptime Kuma at https://…: ` with nothing after the colon.

## Test plan
- [x] `bun run typecheck` green
- [ ] User re-tests against their instance post-release