### PR TITLE
fix: replace broken API token link with generic settings instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+### Fixed
+- **Onboarding's API token link was a 404.** `https://spinupwp.app/account/api/`
+  no longer resolves, and the correct URL is account-specific (a company slug
+  we can't know before the user has a token) — replaced with generic
+  "Settings → API Tokens" navigation instructions in onboarding and the README.
+
 ## [0.21.1] - 2026-07-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -96,10 +96,9 @@
   ```sh
   curl -fsSL https://bun.sh/install | bash
   ```
-- A SpinupWP API token — create one at
-  [spinupwp.app/account/api](https://spinupwp.app/account/api/). **Read Only**
-  scope is enough to browse; use **Read/Write** if you want to upgrade a site's
-  PHP version.
+- A SpinupWP API token — create one in your SpinupWP dashboard under
+  **Settings → API Tokens**. **Read Only** scope is enough to browse; use
+  **Read/Write** if you want to upgrade a site's PHP version.
 
 ## Install & run
 

--- a/src/ui/Onboarding.tsx
+++ b/src/ui/Onboarding.tsx
@@ -55,7 +55,7 @@ export function Onboarding({ onComplete }: { onComplete: () => void }) {
       >
         <text content="Let's connect this tool to your SpinupWP account." fg={theme.text} />
         <box style={{ height: 1 }} />
-        <text content="1. Open https://spinupwp.app/account/api/" fg={theme.textDim} />
+        <text content="1. In SpinupWP: Settings → API Tokens" fg={theme.textDim} />
         <text content="2. Create a token (Read Only to browse; Read/Write to upgrade PHP)" fg={theme.textDim} />
         <text content="3. Paste it below and press Enter" fg={theme.textDim} />
         <box style={{ height: 1 }} />


### PR DESCRIPTION
## Summary
- `https://spinupwp.app/account/api/` 404s — reported in #35.
- The correct page is account-specific (`/{company-slug}/settings#api-tokens`), and onboarding runs before the user has a token, so there's no way to know their slug and build a real deep link for them.
- Replaced the raw URL in both `src/ui/Onboarding.tsx` and `README.md` with generic "Settings → API Tokens" navigation instructions.

Fixes #35

## Test plan
- [x] `bun run typecheck` green
- [ ] Visual check: onboarding screen reads correctly