### PR TITLE
fix: Bedrock detection and clone at any files-root nesting depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,50 @@ versions; such changes are called out here.
   no longer resolves, and the correct URL is account-specific (a company slug
   we can't know before the user has a token) — replaced with generic
   "Settings → API Tokens" navigation instructions in onboarding and the README.
+- **Bedrock detection now works at any nesting depth, everywhere it matters.**
+  A Bedrock install whose project root isn't directly under the site's files
+  root (e.g. moved into its own subdirectory) could go undetected — the
+  plugins/themes view (`p`) reported "no WordPress core found" even though the
+  site worked fine and SpinupWP itself knew it was WordPress. Detection now
+  anchors on the site's configured Public Folder (falling back to a bounded
+  search only when that's unset) instead of a fixed, shallow search depth:
+  - `p` (plugins/themes) finds core correctly.
+  - `d` (identify app) correctly labels it "Bedrock" again, not just generic
+    WordPress.
+  - The clone wizard's Bedrock pull no longer hardcodes `web/`. It detects the
+    real project root independently on both source and destination — they're
+    not assumed to match, since the destination's layout comes from the git
+    repo's own committed content, not the source's on-disk state. A cheap
+    pre-flight check also catches a source whose files don't match its own
+    configured Public Folder *before* a destination site gets created for a
+    clone that can't succeed; the pull chain's own detection step is the
+    real, authoritative check either way.
+  - The Stacks tab's default (pre-probe) "Bedrock" label also recognizes a
+    webroot like `site/web`, not just an exact `web`.
+- **A first-time local Bedrock pull now explains itself.** "Pull production →
+  local" (`p` in Search) backs up the local database before overwriting it —
+  on a fresh Bedrock checkout with no `vendor/` yet, that step failed with
+  wp-cli's generic "not a WordPress install" error. The message now adds
+  "Run `composer install` in your local checkout first" when that's the
+  likely cause.
+- **Clone-wizard error messages no longer get cut off at a fixed, often-too-
+  short length.** The site roster, Git-access deploy-key list, and DNS
+  cutover roster all truncated error text to a small fixed character count
+  regardless of how much space was actually available. Errors now fill
+  whatever room the row has, so a full-sentence error like the Bedrock
+  layout mismatch above is far more likely to be readable inline instead of
+  needing a drill-down for basic context.
+
+### Notes
+- Nested Bedrock layouts (where the project root isn't directly under the
+  site's files root) are now correctly detected in the plugins/themes view,
+  app identification, and the clone wizard's size estimate — all live-
+  tested. A standard (non-nested) Bedrock clone through the rewritten pull
+  chain was also live-tested end to end, including a real DNS cutover. The
+  clone wizard's pull for a *nested* Bedrock site detects a source/repo
+  mismatch and refuses cleanly before creating anything, but the success
+  path — a genuinely nested repo cloning through to completion — hasn't
+  been live-validated yet. If you hit this, we'd welcome a report.
 
 ## [0.21.1] - 2026-07-10
 

--- a/src/lib/dbSync.ts
+++ b/src/lib/dbSync.ts
@@ -15,7 +15,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from "node:fs"
 import { join, dirname } from "node:path"
 import type { Server, Site } from "../api/types.ts"
-import { expandPath, findProjectRoot, type LocalLink } from "./local.ts"
+import { expandPath, findProjectRoot, resolveLocalLink, type LocalKind, type LocalLink } from "./local.ts"
 import { remoteDocRoot, backupBaseName, SSH_OPTS, sshPort, scpPort, runProcess, meaningfulError } from "./dbBackup.ts"
 
 // Read a KEY=value from a dotenv file, tolerating surrounding quotes. null if absent.
@@ -99,6 +99,7 @@ export interface DbSyncPlan {
   localHost: string // bare local host (hook env)
   hookPath: string | null // bin/sync.d/post-import.sh, if present
   prefixWarning: string | null // set when remote/local table prefixes differ
+  localKind: LocalKind // for a tailored hint if local wp-cli can't find an install (e.g. fresh Bedrock checkout)
 }
 
 export type SyncPlanResult = { ok: true; plan: DbSyncPlan } | { ok: false; error: string }
@@ -161,6 +162,7 @@ export function planDbSync(
         ? join(localRoot, "bin", "sync.d", "post-import.sh")
         : null,
       prefixWarning,
+      localKind: resolveLocalLink(link).kind,
     },
   }
 }
@@ -209,7 +211,15 @@ export async function runDbSync(plan: DbSyncPlan, domain: string, onProgress: (p
   }
   const localSql = plan.localBackupPath.replace(/\.gz$/, "")
   const lb = await wp(`wp db export "${localSql}" >/dev/null && gzip -f "${localSql}"`, 300_000)
-  if (lb.code !== 0) return stageFail("Local DB backup failed", lb.stderr, "couldn't export the local database.", "local-backup")
+  if (lb.code !== 0) {
+    // wp-cli's own "not a WordPress install" error is a common first-pull snag on a
+    // fresh checkout — a Bedrock project needs `composer install` to build vendor/ +
+    // web/wp before wp-cli (or wp-cli.yml) can find anything there at all. Appended
+    // after meaningfulError's own pick (not passed as its fallback), since that's
+    // only used when stderr has NO meaningful line — not the case here.
+    const hint = plan.localKind === "bedrock" && /does not seem to be a WordPress install/i.test(lb.stderr) ? " Run `composer install` in your local checkout first." : ""
+    return fail(`Local DB backup failed — ${meaningfulError(lb.stderr, "couldn't export the local database.")}${hint}`, "local-backup")
+  }
 
   // 2) Export prod + download the gzip (same remote pipeline as the backup).
   onProgress({ stage: "export", domain })

--- a/src/lib/probe.ts
+++ b/src/lib/probe.ts
@@ -17,6 +17,7 @@
 // view's SSH usage.
 
 import type { Server, Site } from "../api/types.ts"
+import { detectWpDirScript } from "./serverClone.ts"
 import { theme } from "./theme.ts"
 
 export type ProbeKind = "wordpress" | "bedrock" | "whmcs" | "laravel" | "static" | "unknown"
@@ -76,12 +77,21 @@ function safePublicFolder(pf: string | null): string {
   return pf
 }
 
-function buildRemoteScript(publicFolder: string | null): string {
+function buildRemoteScript(domain: string, publicFolder: string | null): string {
   const pf = safePublicFolder(publicFolder)
+  const root = `/sites/${domain}/files`
   return [
+    // detectWpDirScript anchors on the configured public folder (falling back to a
+    // bounded find), so Bedrock's project root — one level above wherever its core
+    // actually lives — is found at any nesting depth, not just when composer.json
+    // sits directly in the files root. $D/$W from this are shadowed below by the
+    // probe's own "webroot per public_folder" variables, which the rest of this
+    // script (WHMCS/index/WP-version checks) intentionally keeps using as-is.
+    detectWpDirScript(root, publicFolder ?? undefined),
+    `BEDROCKROOT="$B"`,
     'F="$HOME/files"',
     `W="$HOME/files${pf}"`,
-    'echo ===BEDROCK; grep -q "roots/bedrock" "$F/composer.json" 2>/dev/null && echo yes || echo no',
+    'echo ===BEDROCK; [ -n "$BEDROCKROOT" ] && echo yes || echo no',
     'echo ===APPLICATION; test -f "$F/config/application.php" && echo yes || echo no',
     'echo ===ARTISAN; test -f "$F/artisan" && echo yes || echo no',
     'echo ===WHMCSCONF; test -f "$W/configuration.php" && echo yes || echo no',
@@ -103,7 +113,7 @@ export async function probeSite(
 
   let proc: ReturnType<typeof Bun.spawn>
   try {
-    proc = Bun.spawn(["ssh", ...SSH_OPTS, target, buildRemoteScript(site.public_folder)], {
+    proc = Bun.spawn(["ssh", ...SSH_OPTS, target, buildRemoteScript(site.domain, site.public_folder)], {
       stdout: "pipe",
       stderr: "pipe",
       stdin: "ignore",

--- a/src/lib/serverClone.ts
+++ b/src/lib/serverClone.ts
@@ -189,21 +189,55 @@ export function pollTransferSize(ctx: SudoCtx, path: string, onBytes: (bytes: nu
 export function publicFolderRel(publicFolder?: string): string {
   return (publicFolder ?? "/").replace(/^\/+|\/+$/g, "")
 }
-function webrootFor(root: string, publicFolder?: string): string {
+export function webrootFor(root: string, publicFolder?: string): string {
   const pf = publicFolderRel(publicFolder)
   return pf ? `${root}/${pf}` : root
 }
 
 // Bash fragment: set W to the dir under $D (the files root) that holds
-// wp-settings.php — configured-candidate first, then the root, then a bounded find.
-// Leaves W empty when no WordPress core exists. Exported for the test harness.
+// wp-settings.php — configured-candidate first, then Bedrock's convention
+// relative to that candidate, then the root, then a bounded find. Also sets B to
+// the Bedrock PROJECT root (composer.json, .env, wp-cli.yml) when core was found
+// nested inside a directory literally named "wp" — derived from W rather than a
+// second blind search, so it's correct at whatever depth W was actually found,
+// and confirmed against composer.json content so a coincidental "wp"-named dir
+// in some other stack doesn't get misidentified.
+// Leaves W (and B) empty when no WordPress core exists. Exported for the test harness.
 export function detectWpDirScript(root: string, publicFolder?: string): string {
   const candidate = webrootFor(root, publicFolder)
   return [
     `D=${shq(root)}; W=""`,
     `[ -f ${shq(candidate)}/wp-settings.php ] && W=${shq(candidate)}`,
+    // Bedrock never puts core directly in the public folder — it lives one level
+    // down, at {public_folder}/wp/ (the whole point of Bedrock's web/wp + web/app
+    // split). Anchoring on the CONFIGURED public folder here — rather than relying
+    // solely on the blind find below — finds Bedrock core at any nesting depth,
+    // not just the couple of levels the bounded find happens to reach.
+    `[ -z "$W" ] && [ -f ${shq(candidate)}/wp/wp-settings.php ] && W=${shq(candidate)}/wp`,
     `[ -z "$W" ] && [ -f "$D/wp-settings.php" ] && W="$D"`,
     `[ -z "$W" ] && { F=$(find "$D" -maxdepth 3 -name wp-settings.php -not -path "*/wp-content/*" -print -quit 2>/dev/null); [ -n "$F" ] && W=$(dirname "$F"); }`,
+    `B=""`,
+    `[ -n "$W" ] && [ "$(basename "$W")" = "wp" ] && { P=$(dirname "$(dirname "$W")"); [ -f "$P/composer.json" ] && grep -q "roots/bedrock" "$P/composer.json" 2>/dev/null && B="$P"; }`,
+  ].join("; ")
+}
+
+// Bash fragment: set B to the Bedrock PROJECT root via composer.json — for a
+// FRESH git clone, before `composer install` has run. detectWpDirScript's B
+// anchors on WordPress core (a directory literally named "wp"), which doesn't
+// exist yet at this point — Bedrock's core is a composer dependency, never
+// committed to git. composer.json IS present immediately post-clone, so this
+// anchors on that instead: the configured public folder's PARENT first (that's
+// where composer.json sits, by Bedrock convention — one level above the public
+// folder), then the files root itself, then a bounded find. Leaves B empty when
+// no Bedrock project is found. Exported for the test harness.
+export function detectBedrockRootScript(root: string, publicFolder?: string): string {
+  const candidate = webrootFor(root, publicFolder)
+  const parent = candidate === root ? root : candidate.slice(0, candidate.lastIndexOf("/"))
+  return [
+    `D=${shq(root)}; P=${shq(parent)}; B=""`,
+    `[ -f "$P/composer.json" ] && grep -q "roots/bedrock" "$P/composer.json" 2>/dev/null && B="$P"`,
+    `[ -z "$B" ] && [ "$P" != "$D" ] && [ -f "$D/composer.json" ] && grep -q "roots/bedrock" "$D/composer.json" 2>/dev/null && B="$D"`,
+    `[ -z "$B" ] && { F=$(find "$D" -maxdepth 3 -name composer.json -not -path "*/vendor/*" -print -quit 2>/dev/null); [ -n "$F" ] && grep -q "roots/bedrock" "$F" 2>/dev/null && B=$(dirname "$F"); }`,
   ].join("; ")
 }
 
@@ -417,8 +451,12 @@ export async function runStandardWpPull(
 // we `composer install` ourselves over SSH to build vendor/ + web/wp. Only the
 // gitignored artifacts come from the source: web/app/uploads, auth.json, .env, and the
 // DB. The .env is pulled verbatim and its DB_* creds swapped to the dest's (so salts /
-// WP_HOME / custom vars are preserved — a true clone of the same domain). wp-cli runs
-// from the Bedrock root (files/, where wp-cli.yml points at web/wp).
+// WP_HOME / custom vars are preserved — a true clone of the same domain).
+//
+// The Bedrock project's actual location under files/ is DETECTED independently on
+// each end, not assumed to match — see the "0. detect" step below. wp-cli runs from
+// whichever project root was detected there (where wp-cli.yml lives), not a
+// hardcoded files/.
 
 export interface BedrockPullSpec {
   domain: string
@@ -428,6 +466,7 @@ export interface BedrockPullSpec {
   destDbUser: string
   destDbPassword: string
   excludeUploads: boolean
+  publicFolder?: string // a signal, not a fact (CLAUDE.md) — re-verified below, independently, on both ends
 }
 
 export async function runBedrockPull(
@@ -439,7 +478,7 @@ export async function runBedrockPull(
   onTransfer?: CloneTransfer,
 ): Promise<{ ok: boolean; error?: string }> {
   const srcIp = source.server.ip_address ?? ""
-  const root = `/sites/${spec.domain}/files` // Bedrock project root (composer.json, web/, .env)
+  const root = `/sites/${spec.domain}/files` // files root — the Bedrock project itself may be nested under this
   const home = `/sites/${spec.domain}`
   const su = spec.sourceSiteUser
   const du = spec.destSiteUser
@@ -460,6 +499,46 @@ export async function runBedrockPull(
   }
 
   try {
+    // 0. detect — locate the real Bedrock project root on BOTH ends independently
+    //    (public_folder is a setting, not a fact — see CLAUDE.md). The two ends need
+    //    different anchors: the SOURCE already has WordPress core built, so it
+    //    anchors on wp-settings.php (detectWpDirScript). The DEST was just git-cloned
+    //    and has NOT run `composer install` yet — core doesn't exist there (it's a
+    //    composer dependency, never committed), so nothing to anchor detection on
+    //    except composer.json, which IS present immediately post-clone
+    //    (detectBedrockRootScript). We do NOT assume the dest mirrors whatever the
+    //    source happened to detect — its structure comes from the git repo's own
+    //    content, which can legitimately diverge from the source's on-disk state.
+    onProgress("detect", "start")
+    const det = await run("detect", source, `${detectWpDirScript(root, spec.publicFolder)}; echo "WPCORE:$W"; echo "BEDROCKROOT:$B"`, 30_000)
+    const wpCore = (det.stdout.match(/^WPCORE:(.*)$/m)?.[1] ?? "").trim()
+    const srcProjectRoot = (det.stdout.match(/^BEDROCKROOT:(.*)$/m)?.[1] ?? "").trim()
+    if (!det.ok || !wpCore || !srcProjectRoot) {
+      return fail("detect", `couldn't find a Bedrock project (composer.json + WordPress core) under ${root} on the source — is the public folder set correctly?`)
+    }
+    const webDir = wpCore.slice(0, wpCore.lastIndexOf("/")) // wpCore's parent — the public folder, whatever it's actually named
+
+    // The dest's webroot is fixed by what we told SpinupWP at site-creation time
+    // (public_folder), which is what nginx will actually serve — composer install
+    // MUST target here for the site to work, regardless of the repo's own internal
+    // wordpress-install-dir config. Its PARENT (the project root: composer.json,
+    // .env) is what needs re-detecting, since that's a fact about the repo's
+    // content, not something either of us configured.
+    const destWebDir = webrootFor(root, spec.publicFolder)
+    const destProjectRootExpected = destWebDir === root ? root : destWebDir.slice(0, destWebDir.lastIndexOf("/"))
+    const destDet = await run("detect", dest, `${detectBedrockRootScript(root, spec.publicFolder)}; echo "BEDROCKROOT:$B"`, 30_000)
+    const destProjectRoot = (destDet.stdout.match(/^BEDROCKROOT:(.*)$/m)?.[1] ?? "").trim()
+    if (!destDet.ok || !destProjectRoot) {
+      return fail("detect", `couldn't find a Bedrock project (composer.json) under ${root} on the destination — did the git clone complete?`)
+    }
+    if (destProjectRoot !== destProjectRootExpected) {
+      return fail(
+        "detect",
+        `the site's git repo layout doesn't match its configured Public Folder (repo has composer.json at ${destProjectRoot}, but Public Folder implies ${destProjectRootExpected}) — align them and retry`,
+      )
+    }
+    onProgress("detect", "ok")
+
     // 1. auth — ephemeral key on dest, granted onto the source site user.
     onProgress("auth", "start")
     const gen = await run("auth", dest, `rm -f ${KEY} ${KEY}.pub; ssh-keygen -t ed25519 -f ${KEY} -N "" -C ${MARKER} >/dev/null 2>&1 && cat ${KEY}.pub`, 30_000)
@@ -480,28 +559,33 @@ export async function runBedrockPull(
     const authPull = await run(
       "build",
       dest,
-      `set -e; ${remote(`cat ${shq(`${root}/auth.json`)} 2>/dev/null`)} > ${tmp}_auth.json || true; if [ -s ${tmp}_auth.json ]; then install -m 640 -o ${shq(du)} -g ${shq(du)} ${tmp}_auth.json ${shq(`${root}/auth.json`)}; fi; rm -f ${tmp}_auth.json`,
+      `set -e; ${remote(`cat ${shq(`${srcProjectRoot}/auth.json`)} 2>/dev/null`)} > ${tmp}_auth.json || true; if [ -s ${tmp}_auth.json ]; then install -m 640 -o ${shq(du)} -g ${shq(du)} ${tmp}_auth.json ${shq(`${destProjectRoot}/auth.json`)}; fi; rm -f ${tmp}_auth.json`,
       120_000,
     )
     if (!authPull.ok) return fail("build", authPull.stderr.trim() || "auth.json pull failed")
     const composer = await run(
       "build",
       dest,
-      `set -e; cd ${shq(root)}; sudo -u ${shq(du)} -H bash -lc 'composer install -o --no-dev --no-interaction' 2>&1; test -d ${shq(`${root}/web/wp`)}`,
+      `set -e; cd ${shq(destProjectRoot)}; sudo -u ${shq(du)} -H bash -lc 'composer install -o --no-dev --no-interaction' 2>&1; test -d ${shq(`${destWebDir}/wp`)}`,
       600_000,
     )
     if (!composer.ok) return fail("build", (composer.stdout + composer.stderr).trim().split("\n").slice(-3).join(" ") || "composer install failed")
     onProgress("build", "ok")
 
-    // 3. files — pull web/app/uploads (unless excluded). Best-effort: a site with no
-    //    uploads dir yields an empty stream we simply skip.
+    // 3. files — pull {web}/app/uploads (unless excluded), `web` being whatever the
+    //    detected public folder is actually named — which can differ in nesting
+    //    depth between source and dest (the repo's own content vs. how deep the
+    //    source's on-disk state happens to be). Archiving/extracting relative to
+    //    EACH side's own web dir (not `root`) with a fixed member name sidesteps
+    //    that — the two ends never need to agree on a shared relative path. Best-
+    //    effort: a site with no uploads dir yields an empty stream we simply skip.
     onProgress("files", "start")
     if (!spec.excludeUploads) {
       const stopUpPoll = pollTransferSize(dest, `${tmp}_up.tgz`, (b) => onTransfer?.("files", b))
       const up = await run(
         "files",
         dest,
-        `set -e; timeout -k 5 3600 ${remote(`[ -d ${shq(`${root}/web/app/uploads`)} ] && tar -C ${shq(root)} --warning=no-file-changed -czf - web/app/uploads || true`)} > ${tmp}_up.tgz; if [ -s ${tmp}_up.tgz ]; then tar -C ${shq(root)} -xzf ${tmp}_up.tgz && chown -R ${shq(du)}:${shq(du)} ${shq(`${root}/web/app/uploads`)}; fi; rm -f ${tmp}_up.tgz`,
+        `set -e; timeout -k 5 3600 ${remote(`[ -d ${shq(`${webDir}/app/uploads`)} ] && tar -C ${shq(webDir)} --warning=no-file-changed -czf - app/uploads || true`)} > ${tmp}_up.tgz; if [ -s ${tmp}_up.tgz ]; then tar -C ${shq(destWebDir)} -xzf ${tmp}_up.tgz && chown -R ${shq(du)}:${shq(du)} ${shq(`${destWebDir}/app/uploads`)}; fi; rm -f ${tmp}_up.tgz`,
         3_660_000, // outer must exceed the in-script `timeout 3600` so the inner reports a clean 124
       )
       stopUpPoll()
@@ -517,14 +601,14 @@ export async function runBedrockPull(
       dest,
       [
         `set -e`,
-        `${remote(`cat ${shq(`${root}/.env`)}`)} > ${tmp}_env`,
+        `${remote(`cat ${shq(`${srcProjectRoot}/.env`)}`)} > ${tmp}_env`,
         `test -s ${tmp}_env`,
         // drop existing DB assignments (commented or not) + DATABASE_URL, then append canonical creds.
         `sed -i -E '/^[[:space:]]*#?[[:space:]]*(DB_NAME|DB_USER|DB_PASSWORD|DB_HOST|DATABASE_URL)[[:space:]]*=/d' ${tmp}_env`,
         `printf "\\nDB_NAME='%s'\\nDB_USER='%s'\\nDB_PASSWORD='%s'\\nDB_HOST='localhost'\\n" ${shq(spec.destDbName)} ${shq(spec.destDbUser)} ${shq(spec.destDbPassword)} >> ${tmp}_env`,
-        `install -m 640 -o ${shq(du)} -g ${shq(du)} ${tmp}_env ${shq(`${root}/.env`)}`,
+        `install -m 640 -o ${shq(du)} -g ${shq(du)} ${tmp}_env ${shq(`${destProjectRoot}/.env`)}`,
         `rm -f ${tmp}_env`,
-        `cd ${shq(root)}; sudo -u ${shq(du)} -H wp db check >/dev/null 2>&1`,
+        `cd ${shq(destProjectRoot)}; sudo -u ${shq(du)} -H wp db check >/dev/null 2>&1`,
       ].join("; "),
       60_000,
     )
@@ -536,7 +620,7 @@ export async function runBedrockPull(
     const dump = await run(
       "db",
       source,
-      `sudo -u ${shq(su)} -H bash -c "cd ${shq(root)} && wp --skip-plugins --skip-themes db export ${shq(home)}/.clone_db.sql 2>/dev/null && gzip -f ${shq(home)}/.clone_db.sql && stat -c %s ${shq(home)}/.clone_db.sql.gz"`,
+      `sudo -u ${shq(su)} -H bash -c "cd ${shq(srcProjectRoot)} && wp --skip-plugins --skip-themes db export ${shq(home)}/.clone_db.sql 2>/dev/null && gzip -f ${shq(home)}/.clone_db.sql && stat -c %s ${shq(home)}/.clone_db.sql.gz"`,
       900_000,
     )
     if (!dump.ok) return fail("db", dump.stderr.trim() || "source db export failed")
@@ -545,7 +629,7 @@ export async function runBedrockPull(
     const imp = await run(
       "db",
       dest,
-      `set -e; timeout -k 5 300 ${remote(`cat ${shq(`${home}/.clone_db.sql.gz`)}`)} > ${tmp}.sql.gz; gunzip -f ${tmp}.sql.gz; chmod 644 ${tmp}.sql; cd ${shq(root)}; sudo -u ${shq(du)} -H wp db import ${tmp}.sql >/dev/null; rm -f ${tmp}.sql`,
+      `set -e; timeout -k 5 300 ${remote(`cat ${shq(`${home}/.clone_db.sql.gz`)}`)} > ${tmp}.sql.gz; gunzip -f ${tmp}.sql.gz; chmod 644 ${tmp}.sql; cd ${shq(destProjectRoot)}; sudo -u ${shq(du)} -H wp db import ${tmp}.sql >/dev/null; rm -f ${tmp}.sql`,
       360_000, // outer must exceed the in-script `timeout 300`
     )
     stopDbPoll()
@@ -554,7 +638,7 @@ export async function runBedrockPull(
 
     // 6. verify — wp-cli on the dest (HTTP --resolve is the caller's).
     onProgress("verify", "start")
-    const ver = await run("verify", dest, `cd ${shq(root)}; sudo -u ${shq(du)} -H wp core is-installed`, 30_000)
+    const ver = await run("verify", dest, `cd ${shq(destProjectRoot)}; sudo -u ${shq(du)} -H wp core is-installed`, 30_000)
     if (!ver.ok) return fail("verify", "wp core is-installed returned false on the dest")
     onProgress("verify", "ok")
 
@@ -566,6 +650,32 @@ export async function runBedrockPull(
     await run("revoke", dest, `rm -f ${KEY} ${KEY}.pub ${tmp}_auth.json ${tmp}_up.tgz ${tmp}_env ${tmp}.sql.gz ${tmp}.sql`, 30_000).catch(() => {})
     onProgress("revoke", "ok")
   }
+}
+
+// Cheap pre-flight, before a Bedrock clone creates anything: does the SOURCE's
+// on-disk project match its OWN configured Public Folder? A heuristic, not a
+// guarantee — the destination's real structure comes from the git repo's
+// committed content, which this can't inspect directly, so it can't promise the
+// clone will succeed. But in the ordinary case (the source's files came from
+// composer-installing that same repo) the two agree, so a mismatch here reliably
+// predicts the same failure runBedrockPull's own "detect" step would hit later —
+// just BEFORE a destination site (and its git clone) gets created for nothing.
+// Silent no-op for anything that isn't a detectable Bedrock install; that's
+// covered by the pull chain's own detection, not this pre-check's job.
+export async function preflightBedrockSource(source: SudoCtx, spec: { domain: string; publicFolder?: string }): Promise<{ ok: true } | { ok: false; error: string }> {
+  const root = `/sites/${spec.domain}/files`
+  const expectedWebDir = webrootFor(root, spec.publicFolder)
+  const expectedProjectRoot = expectedWebDir === root ? root : expectedWebDir.slice(0, expectedWebDir.lastIndexOf("/"))
+  const r = await exec(source, `${detectWpDirScript(root, spec.publicFolder)}; echo "BEDROCKROOT:$B"`, 30_000)
+  const detected = (r.stdout.match(/^BEDROCKROOT:(.*)$/m)?.[1] ?? "").trim()
+  if (!r.ok || !detected) return { ok: true }
+  if (detected !== expectedProjectRoot) {
+    return {
+      ok: false,
+      error: `this site's actual files (Bedrock project at ${detected}) don't match its configured Public Folder (implies ${expectedProjectRoot}) — align them and retry`,
+    }
+  }
+  return { ok: true }
 }
 
 // ---- Files-only pull chain (non-WP sites: redirect shells, static/PHP sites) --

--- a/src/lib/stack.ts
+++ b/src/lib/stack.ts
@@ -2,20 +2,25 @@
 // fetch (no SSH, no extra API calls). Signals: `is_wordpress` and
 // `public_folder` on the Site object, validated against the live fleet.
 //
-//   is_wordpress === false      → Non-WP
-//   is_wordpress && "/web/"      → Bedrock
-//   is_wordpress && anything else → Standard WP
+//   is_wordpress === false           → Non-WP
+//   is_wordpress && webroot ends "web" → Bedrock
+//   is_wordpress && anything else     → Standard WP
 //
 // Important: `public_folder` is the user-set "Public Folder" (the suffix after
 // `~/sites/{domain}/files`), NOT a SpinupWP-enforced stack flag. So this is a
-// heuristic keyed on a convention: webroot `/web/` means Bedrock. The
-// is_wordpress guard matters — a couple of non-WP custom apps also use "/web/",
-// so Bedrock requires WP too. Any other WP webroot (incl. the bare `~/files`
-// default, `/public/`, `/`) is treated as Standard WP. Tier-2 (on-demand SSH
-// probe that inspects the filesystem) is the authoritative correction layer.
+// heuristic keyed on a convention: a webroot named `web` means Bedrock — checked
+// by its LAST path segment (not an exact "/web/" match), so a nested layout like
+// `/site/web/` (the Bedrock project moved into a subdirectory — a real, seen
+// layout, see the WP-core-detection fix in serverClone.ts) still buckets
+// correctly instead of falling through to Standard WP. The is_wordpress guard
+// matters — a couple of non-WP custom apps also use a `web` webroot, so Bedrock
+// requires WP too. Any other WP webroot (incl. the bare `~/files` default,
+// `/public/`, `/`) is treated as Standard WP. Tier-2 (on-demand SSH probe that
+// inspects the filesystem) is the authoritative correction layer regardless.
 
 import type { Site } from "../api/types.ts"
 import type { ProbeKind } from "./probe.ts"
+import { publicFolderRel } from "./serverClone.ts"
 import { theme } from "./theme.ts"
 
 export type Stack = "Standard WP" | "Bedrock" | "Non-WP"
@@ -25,7 +30,8 @@ export const STACKS: Stack[] = ["Standard WP", "Bedrock", "Non-WP"]
 
 export function classifyStack(site: Site): Stack {
   if (!site.is_wordpress) return "Non-WP"
-  if (site.public_folder === "/web/") return "Bedrock"
+  const rel = publicFolderRel(site.public_folder ?? undefined) // e.g. "web" or "site/web"
+  if (rel === "web" || rel.endsWith("/web")) return "Bedrock"
   return "Standard WP"
 }
 

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -45,7 +45,7 @@ import { withKuma, KumaClient, registerMonitors, registerFingerprintMonitor, reg
 import { deriveFingerprint } from "../lib/siteFingerprint.ts"
 import type { StoredProviders } from "../config.ts"
 import { fetchRebootInfo, grantSiteSshKey, revokeSiteSshKey, verifySudo, ensureSpinupKey, listPersonalKeys, keyBody, type RebootInfo } from "../lib/ssh.ts"
-import { estimateSourceSiteSizes, runStandardWpPull, runBedrockPull, runFilesOnlyPull, verifyClone, verifyFilesClone, type SudoCtx, type CloneStage, type CloneExecRecord, type VerifyResult as CloneVerifyResult } from "../lib/serverClone.ts"
+import { estimateSourceSiteSizes, runStandardWpPull, runBedrockPull, runFilesOnlyPull, verifyClone, verifyFilesClone, preflightBedrockSource, type SudoCtx, type CloneStage, type CloneExecRecord, type VerifyResult as CloneVerifyResult } from "../lib/serverClone.ts"
 import { CloneLogger } from "../lib/cloneLog.ts"
 import { syncAdditionalDomains } from "../lib/cloneDomains.ts"
 import { parseRepo, deployKeysSettingsUrl, ghAvailable, ghDeployKeyPresent, ghAddDeployKey, generateDeployKeypair, type RepoHost } from "../lib/gitDeployKey.ts"
@@ -3679,6 +3679,15 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       }
       try {
         if (site.stack === "bedrock" && !site.gitRepo) return fail("create", "the source Bedrock site has no git repo to clone from.")
+        // Cheap pre-flight, before creating anything: catches a source whose actual
+        // files don't match its own configured Public Folder — the same mismatch
+        // runBedrockPull's own detect step would hit later, just before wasting a
+        // site-creation + auth cycle on a clone that can't succeed. Not a guarantee
+        // (see preflightBedrockSource) — the real check is still the one after create.
+        if (site.stack === "bedrock") {
+          const pre = await preflightBedrockSource(source, { domain: site.domain, publicFolder: site.publicFolder })
+          if (!pre.ok) return fail("create", pre.error)
+        }
         // create — Bedrock → `git` site (SpinupWP clones the repo); Standard WP →
         // blank + database; files-only → blank with NO database (nothing to import).
         set((s) => ({ ...s, step: "create", error: undefined, failedStep: undefined, detail: undefined, stageStartedAt: Date.now() }))
@@ -3803,7 +3812,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         const onExec = logger ? (e: CloneExecRecord) => logger.log({ event: "exec", ...e }) : undefined
         const res =
           site.stack === "bedrock"
-            ? await runBedrockPull(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, destDbName: dbName, destDbUser: dbName, destDbPassword: dbPw, excludeUploads: site.excludeUploads }, onProgress, onExec, onTransfer)
+            ? await runBedrockPull(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, destDbName: dbName, destDbUser: dbName, destDbPassword: dbPw, excludeUploads: site.excludeUploads, publicFolder: site.publicFolder }, onProgress, onExec, onTransfer)
             : site.stack === "files"
               ? await runFilesOnlyPull(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, approxFilesBytes: site.sizeWebBytes }, onProgress, onExec, onTransfer)
               : await runStandardWpPull(source, dest, { domain: site.domain, sourceSiteUser: site.siteUser, destSiteUser: site.siteUser, destDbName: dbName, destDbUser: dbName, destDbPassword: dbPw, publicFolder: site.publicFolder, approxFilesBytes: site.sizeWebBytes }, onProgress, onExec, onTransfer)

--- a/src/ui/views/CloneWizard.tsx
+++ b/src/ui/views/CloneWizard.tsx
@@ -562,7 +562,7 @@ export function CloneWizard() {
         case "adding":
           return "adding…"
         case "error":
-          return truncate(k.error ?? "failed", 36)
+          return k.error ?? "failed"
         default:
           return "add the key by hand, then r to re-check"
       }
@@ -579,9 +579,8 @@ export function CloneWizard() {
             return (
               <box key={k.repo} style={{ flexDirection: "row", height: 1 }}>
                 <text content={`${g} `} fg={c} style={{ flexShrink: 0 }} />
-                <text content={`${k.owner}/${k.name}`} fg={theme.text} wrapMode="none" style={{ flexShrink: 1 }} />
-                <box style={{ flexGrow: 1 }} />
-                <text content={label(k)} fg={k.status === "error" ? theme.bad : k.status === "present" || k.status === "added" ? theme.good : theme.textFaint} wrapMode="none" style={{ flexShrink: 0 }} />
+                <text content={`${k.owner}/${k.name}`} fg={theme.text} wrapMode="none" style={{ flexShrink: 0 }} />
+                <text content={" " + label(k)} fg={k.status === "error" ? theme.bad : k.status === "present" || k.status === "added" ? theme.good : theme.textFaint} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
               </box>
             )
           })}
@@ -682,15 +681,14 @@ export function CloneWizard() {
         : st === "done" ? `now → ${r.targetValue ?? targetIp}`
         : st === "ready" ? `${r.currentValue ?? "?"} → ${r.targetValue ?? targetIp}${r.excluded ? "  (skipped)" : ""}`
         : st === "manual" ? `manual: ${r.reason ?? "edit by hand"}`
-        : st === "error" ? truncate(r.error ?? "failed", 28)
+        : st === "error" ? (r.error ?? "failed")
         : "pending"
       const dcolor = st === "error" ? theme.bad : st === "done" ? theme.good : st === "manual" ? theme.warn : cur ? theme.text : theme.textFaint
       return (
         <box key={`${siteId}|${r.name}`} style={{ flexDirection: "row", height: 1, backgroundColor: cur ? theme.bgAlt : undefined }}>
           {busy ? <Spinner color={theme.brand} /> : <text content={glyph} fg={gcolor} style={{ flexShrink: 0 }} />}
-          <text content={` ${r.name}`} fg={theme.text} wrapMode="none" style={{ flexShrink: 1 }} />
-          <box style={{ flexGrow: 1 }} />
-          <text content={detail} fg={dcolor} wrapMode="none" style={{ flexShrink: 0 }} />
+          <text content={` ${r.name}`} fg={theme.text} wrapMode="none" style={{ flexShrink: 0 }} />
+          <text content={" " + detail} fg={dcolor} wrapMode="none" style={{ flexGrow: 1, flexShrink: 1 }} />
         </box>
       )
     }
@@ -732,13 +730,12 @@ export function CloneWizard() {
             return (
               <box key={s.sourceSiteId} style={{ flexDirection: "row", height: 1, backgroundColor: cur ? theme.bgAlt : undefined }}>
                 {active ? <Spinner color={theme.brand} /> : <text content={s.step === "done" ? "✓" : s.step === "error" ? "✕" : "○"} fg={s.step === "done" ? theme.good : s.step === "error" ? theme.bad : theme.textFaint} style={{ flexShrink: 0 }} />}
-                <text content={` ${s.domain}`} fg={cur || s.step === "error" || s.step === "done" ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 1 }} />
-                <box style={{ flexGrow: 1 }} />
+                <text content={` ${s.domain}`} fg={cur || s.step === "error" || s.step === "done" ? theme.text : theme.textDim} wrapMode="none" style={{ flexShrink: 0 }} />
                 <text
-                  content={(s.step === "error" ? truncate(s.error ?? "failed", 24) : s.step === "done" ? "done" : s.step === "queued" ? "queued" : `${s.step}${s.detail ? " · " + s.detail : ""}${s.transferBytes != null ? ` · ${formatBytes(s.transferBytes)}${s.transferTarget ? ` of ${s.transferExact ? "" : "~"}${formatBytes(s.transferTarget)}` : ""}${s.transferExact && s.transferTarget ? ` (${Math.min(100, Math.round((s.transferBytes / s.transferTarget) * 100))}%)` : ""}${s.transferRate ? ` · ${formatBytes(s.transferRate)}/s` : ""}` : ""}${s.stageStartedAt ? " · " + fmtElapsed(now - s.stageStartedAt) : ""}`) + vmark}
+                  content={" " + ((s.step === "error" ? s.error ?? "failed" : s.step === "done" ? "done" : s.step === "queued" ? "queued" : `${s.step}${s.detail ? " · " + s.detail : ""}${s.transferBytes != null ? ` · ${formatBytes(s.transferBytes)}${s.transferTarget ? ` of ${s.transferExact ? "" : "~"}${formatBytes(s.transferTarget)}` : ""}${s.transferExact && s.transferTarget ? ` (${Math.min(100, Math.round((s.transferBytes / s.transferTarget) * 100))}%)` : ""}${s.transferRate ? ` · ${formatBytes(s.transferRate)}/s` : ""}` : ""}${s.stageStartedAt ? " · " + fmtElapsed(now - s.stageStartedAt) : ""}`) + vmark)}
                   fg={s.step === "error" || (s.verify && !s.verify.ok) ? theme.bad : s.verify?.ok ? theme.good : s.step === "done" ? theme.good : theme.textFaint}
                   wrapMode="none"
-                  style={{ flexShrink: 0 }}
+                  style={{ flexGrow: 1, flexShrink: 1 }}
                 />
               </box>
             )


### PR DESCRIPTION
## Summary
Bedrock installs whose project root isn't directly under the site's files root (e.g. moved into its own subdirectory) went undetected — the plugins/themes view reported no core found even though the site worked fine, app identification fell back to generic WordPress, and the clone wizard's Bedrock pull hardcoded `web/` and could fail partway through against a real destination site.

- `detectWpDirScript` now anchors on the site's configured Public Folder at any nesting depth (falling back to a bounded search only when unset), shared by the plugins/themes view (`p`), app identification (`d`), and the clone wizard's size estimate.
- The clone wizard's Bedrock pull no longer assumes the destination mirrors the source's detected path. It re-detects the project root independently on each end — composer.json-anchored on the destination, since WordPress core doesn't exist there yet on a fresh clone — and fails cleanly at a new `detect` stage if the two disagree, instead of failing opaquely partway through `build`.
- A pre-flight check catches the common case of a source/Public-Folder mismatch before a destination site is even created (heuristic, not a guarantee — documented in the code).
- A first-time local Bedrock pull ("Pull production → local") now hints at `composer install` when that's the likely cause of a local DB backup failure.
- The Stacks tab's pre-probe "Bedrock" label now recognizes a nested webroot like `site/web`, not just an exact `web`.
- Clone-wizard error rows (site roster, Git-access deploy-key list, DNS cutover roster) no longer truncate to a fixed, often-too-short character count — they fill whatever width the row actually has.

Related to #34.

## Test plan
- [x] `bun run typecheck` green
- [x] Live-tested against a real nested Bedrock reproduction on the dedicated test boxes: `p`, `d`, and Search's "Pull production DB to local" all confirmed working
- [x] Live-tested a standard (non-nested) Bedrock clone through the fully rewritten pull chain, end to end including a real DNS cutover to the new server
- [ ] Nested-repo clone success path (a genuinely nested Bedrock *repo* cloning through to completion) not yet live-validated — see CHANGELOG Notes; the failure path (clean refusal on mismatch) IS validated