### PR TITLE
feat: add spinuptui ssh-exec — gated, read-only SSH command execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+### Added
+- **`spinuptui ssh-exec <domain> -- <command>`** — resolves the domain's SSH
+  target (same as `spinuptui ssh`) and runs `<command>` on it, but only if
+  it's read-only: anything matching a write/restart/destructive pattern
+  (plugin/theme changes, DB writes, service restarts, redirecting output to
+  a real file, package installs, etc.) is denied before it ever reaches the
+  server. Built for external tooling that needs to run diagnostic commands
+  unattended — any agent configured to touch a server only through this
+  command inherits the read-only guarantee without building its own guard.
+  Prints structured JSON (`stdout`/`stderr`/`exitCode` on success,
+  `reason:"command_denied"` on refusal) and logs every attempt — allowed,
+  denied, or unresolved — to `<config dir>/logs/ssh-exec-audit.jsonl`.
+
 ## [0.21.2] - 2026-07-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -74,10 +74,13 @@
   [docs/uptime-kuma.md](docs/uptime-kuma.md)
 - **Non-interactive CLI subcommands for external tooling** — `spinuptui ssh <domain>`
   resolves a domain to a live SSH target with a live connectivity probe;
-  `spinuptui incidents <domain>` / `--all` surfaces Uptime Kuma's down/up
-  history as JSON. Built so another agent/script can go from just a domain to
-  "what's wrong and how do I get in" with no manual lookup.
-  → [CLI subcommands](#cli-subcommands)
+  `spinuptui ssh-exec <domain> -- <command>` runs a command over SSH, but only
+  if it's read-only — anything that looks like a write/restart/destructive
+  action is denied rather than run, so any agent using it inherits that
+  guarantee without building its own guard; `spinuptui incidents <domain>` /
+  `--all` surfaces Uptime Kuma's down/up history as JSON. Built so another
+  agent/script can go from just a domain to "what's wrong and how do I get
+  in" with no manual lookup. → [CLI subcommands](#cli-subcommands)
 - **Completion toasts** — a non-focus-stealing toast when a background write
   (PHP upgrade, reboot, DNS resolve, …) finishes.
 - **Release notes** — an in-app "what's new" after every update, sourced
@@ -166,6 +169,17 @@ spinuptui ssh <domain>  Print SSH access info for a site as JSON (resolves the
                      site's server, builds its SSH target, and runs a live
                      connectivity probe — for external tooling, e.g. an
                      incident-diagnostics agent handed only a domain)
+spinuptui ssh-exec <domain> -- <command>  Resolve the domain's SSH target and
+                     run <command> on it, but only if the command is
+                     read-only — anything matching a write/restart/destructive
+                     pattern (plugin/theme changes, DB writes, service
+                     restarts, file redirection to a real path, etc.) is
+                     denied instead of run. Prints JSON: on success,
+                     {ok:true, exitCode, stdout, stderr, ...}; on denial,
+                     {ok:false, reason:"command_denied", message}. Every
+                     attempt (allowed, denied, or unresolved) is appended to
+                     <config dir>/logs/ssh-exec-audit.jsonl. Quote <command>
+                     as one shell argument if it needs pipes or redirects.
 spinuptui incidents <domain> | --all [--hours N]  Print Uptime Kuma down/up
                      incidents as JSON, scoped to sites SpinupTUI manages
                      monitoring for (config.json's kumaMonitors) — --all

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,7 @@ import { isDevMode } from "./dev/devMode.ts"
 import { SpinupWPClient } from "./api/client.ts"
 import { resolveSshAccess } from "./lib/cliSsh.ts"
 import { resolveIncidents } from "./lib/cliIncidents.ts"
+import { execSshCommand } from "./lib/sshExec.ts"
 
 const args = process.argv.slice(2)
 const positionals = args.filter((a) => !a.startsWith("-"))
@@ -29,6 +30,8 @@ Usage:
   spinuptui login      Set or update your saved API token
   spinuptui where      Print the config file path and token source
   spinuptui ssh <domain>  Print SSH access info for a site (JSON)
+  spinuptui ssh-exec <domain> -- <command>  Run a read-only command over SSH
+                       (JSON); denies anything that looks like a remote write
   spinuptui incidents <domain> | --all [--hours N]  Print Uptime Kuma
                        down/up incidents for a site or the whole fleet (JSON)
   spinuptui --version  Print the version
@@ -64,6 +67,23 @@ if (command === "ssh") {
   const cfg = loadConfig()
   const client = new SpinupWPClient(cfg)
   const result = await resolveSshAccess(domain, client, cfg)
+  console.log(JSON.stringify(result))
+  process.exit(result.ok ? 0 : 1)
+}
+
+if (command === "ssh-exec") {
+  const dashIdx = args.indexOf("--")
+  const domain = positionals[1]
+  const remoteCmd = dashIdx !== -1 ? args.slice(dashIdx + 1).join(" ") : ""
+  if (!domain || dashIdx === -1 || !remoteCmd.trim()) {
+    console.error(
+      JSON.stringify({ ok: false, reason: "usage", message: "Usage: spinuptui ssh-exec <domain> -- <command>" }),
+    )
+    process.exit(1)
+  }
+  const cfg = loadConfig()
+  const client = new SpinupWPClient(cfg)
+  const result = await execSshCommand(domain, remoteCmd, client, cfg)
   console.log(JSON.stringify(result))
   process.exit(result.ok ? 0 : 1)
 }

--- a/src/lib/cliSsh.ts
+++ b/src/lib/cliSsh.ts
@@ -40,13 +40,32 @@ export type SshAccessResult =
 const GRANT_KEY_REMEDY =
   "Run `spinuptui`, select this site in the Browser view, and press K to grant this device's key (sudo must be connected on the server first — press S)."
 
-export async function resolveSshAccess(
+// Resolved SSH connection details for a domain, without having tested them.
+export interface SshTargetInfo {
+  domain: string
+  primaryDomain: string
+  sshTarget: string
+  port: number | null
+  server: string
+}
+
+export type SshTargetResolution =
+  | { ok: true; info: SshTargetInfo }
+  | { ok: false; result: SshAccessResult & { ok: false } }
+
+// Domain -> site -> server -> SSH target/port, with no live connectivity check.
+// Split out of resolveSshAccess so callers that are about to run a real command
+// (which is itself a connectivity test) don't pay for a redundant probe first.
+export async function resolveSshTargetInfo(
   domain: string,
   client: SpinupWPClientLike,
   cfg: AppConfig,
-): Promise<SshAccessResult> {
+): Promise<SshTargetResolution> {
   if (!cfg.token) {
-    return { ok: false, domain, reason: "no_token", message: "No API token configured. Run `spinuptui login`." }
+    return {
+      ok: false,
+      result: { ok: false, domain, reason: "no_token", message: "No API token configured. Run `spinuptui login`." },
+    }
   }
 
   let site
@@ -59,9 +78,12 @@ export async function resolveSshAccess(
     if (matches.length === 0) {
       return {
         ok: false,
-        domain,
-        reason: "site_not_found",
-        message: `No site matching "${domain}" found in this SpinupWP account.`,
+        result: {
+          ok: false,
+          domain,
+          reason: "site_not_found",
+          message: `No site matching "${domain}" found in this SpinupWP account.`,
+        },
       }
     }
     if (matches.length > 1) {
@@ -73,10 +95,13 @@ export async function resolveSshAccess(
       )
       return {
         ok: false,
-        domain,
-        reason: "multiple_matches",
-        message: `"${domain}" matches ${matches.length} sites in this account — cannot pick one automatically.`,
-        candidates,
+        result: {
+          ok: false,
+          domain,
+          reason: "multiple_matches",
+          message: `"${domain}" matches ${matches.length} sites in this account — cannot pick one automatically.`,
+          candidates,
+        },
       }
     }
     site = matches[0]
@@ -85,27 +110,48 @@ export async function resolveSshAccess(
     if (err instanceof ApiError && err.status === 401) {
       return {
         ok: false,
-        domain,
-        reason: "token_rejected",
-        message: "Saved API token was rejected (401) — it may be expired or revoked.",
-        remedy: "Run `spinuptui login` to save a fresh token.",
+        result: {
+          ok: false,
+          domain,
+          reason: "token_rejected",
+          message: "Saved API token was rejected (401) — it may be expired or revoked.",
+          remedy: "Run `spinuptui login` to save a fresh token.",
+        },
       }
     }
     const message = err instanceof ApiError ? err.message : `Unexpected error: ${(err as Error).message}`
-    return { ok: false, domain, reason: "api_error", message }
+    return { ok: false, result: { ok: false, domain, reason: "api_error", message } }
   }
 
   if (!server.ip_address) {
     return {
       ok: false,
-      domain,
-      reason: "server_has_no_ip",
-      message: `Server "${server.name}" has no IP address on file.`,
+      result: {
+        ok: false,
+        domain,
+        reason: "server_has_no_ip",
+        message: `Server "${server.name}" has no IP address on file.`,
+      },
     }
   }
 
   const target = resolveSiteSshTarget(site, server, cfg.sshUser)
   const port = server.ssh_port && server.ssh_port !== 22 ? server.ssh_port : null
+
+  return {
+    ok: true,
+    info: { domain, primaryDomain: site.domain, sshTarget: target, port, server: server.name },
+  }
+}
+
+export async function resolveSshAccess(
+  domain: string,
+  client: SpinupWPClientLike,
+  cfg: AppConfig,
+): Promise<SshAccessResult> {
+  const resolution = await resolveSshTargetInfo(domain, client, cfg)
+  if (!resolution.ok) return resolution.result
+  const { primaryDomain, sshTarget: target, port, server: serverName } = resolution.info
   const portOpt = port ? ["-p", String(port)] : []
 
   let proc: ReturnType<typeof Bun.spawn>
@@ -132,7 +178,7 @@ export async function resolveSshAccess(
   const stderr = await new Response(proc.stderr as ReadableStream<Uint8Array>).text()
 
   if (exitCode === 0) {
-    return { ok: true, domain, primaryDomain: site.domain, sshTarget: target, port, server: server.name }
+    return { ok: true, domain, primaryDomain, sshTarget: target, port, server: serverName }
   }
 
   if (/permission denied/i.test(stderr)) {

--- a/src/lib/sshExec.ts
+++ b/src/lib/sshExec.ts
@@ -1,0 +1,93 @@
+// `spinuptui ssh-exec <domain> -- <command>` — gated, read-only SSH command
+// execution for external tooling (e.g. a diagnostics agent). Resolves domain ->
+// SSH target the same way `spinuptui ssh` does, checks the command against the
+// read-only allowlist (sshExecPolicy.ts), and only then runs it. Every attempt —
+// allowed, denied, or a resolution failure — is written to the audit log
+// (sshExecLog.ts) so the answer to "did this ever touch a server" doesn't depend
+// on the calling agent's own report.
+
+import type { AppConfig } from "../config.ts"
+import type { SpinupWPClientLike } from "../api/client.ts"
+import { resolveSshTargetInfo, type SshAccessReason, type SshAccessCandidate } from "./cliSsh.ts"
+import { SSH_OPTS } from "./probe.ts"
+import { classifySshCommand } from "./sshExecPolicy.ts"
+import { logSshExecAttempt } from "./sshExecLog.ts"
+
+export type SshExecReason = SshAccessReason | "command_denied"
+
+export type SshExecResult =
+  | {
+      ok: true
+      domain: string
+      primaryDomain: string
+      sshTarget: string
+      command: string
+      exitCode: number
+      stdout: string
+      stderr: string
+      durationMs: number
+    }
+  | {
+      ok: false
+      domain: string
+      reason: SshExecReason
+      message: string
+      command?: string
+      remedy?: string
+      candidates?: SshAccessCandidate[]
+    }
+
+const EXEC_TIMEOUT_MS = 30_000
+
+export async function execSshCommand(
+  domain: string,
+  command: string,
+  client: SpinupWPClientLike,
+  cfg: AppConfig,
+): Promise<SshExecResult> {
+  const resolution = await resolveSshTargetInfo(domain, client, cfg)
+  if (!resolution.ok) {
+    logSshExecAttempt({ domain, command, decision: "error", reason: resolution.result.reason, message: resolution.result.message })
+    return { ...resolution.result, command }
+  }
+  const { primaryDomain, sshTarget, port } = resolution.info
+
+  const verdict = classifySshCommand(command)
+  if (verdict.decision === "deny") {
+    logSshExecAttempt({ domain: primaryDomain, command, decision: "denied", reason: verdict.reason })
+    return { ok: false, domain, reason: "command_denied", message: verdict.reason, command }
+  }
+
+  const portOpt = port ? ["-p", String(port)] : []
+  const start = Date.now()
+  let proc: ReturnType<typeof Bun.spawn>
+  try {
+    proc = Bun.spawn(["ssh", ...SSH_OPTS, ...portOpt, sshTarget, command], {
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    })
+  } catch (err) {
+    const message = `Failed to launch ssh: ${(err as Error).message}`
+    logSshExecAttempt({ domain: primaryDomain, command, decision: "error", reason: "ssh_error", message })
+    return { ok: false, domain, reason: "ssh_error", message, command }
+  }
+
+  const timeout = setTimeout(() => {
+    try {
+      proc.kill()
+    } catch {
+      /* already gone */
+    }
+  }, EXEC_TIMEOUT_MS)
+
+  const exitCode = await proc.exited
+  clearTimeout(timeout)
+  const stdout = await new Response(proc.stdout as ReadableStream<Uint8Array>).text()
+  const stderr = await new Response(proc.stderr as ReadableStream<Uint8Array>).text()
+  const durationMs = Date.now() - start
+
+  logSshExecAttempt({ domain: primaryDomain, command, decision: "allowed", exitCode, stdout, stderr, durationMs })
+
+  return { ok: true, domain, primaryDomain, sshTarget, command, exitCode, stdout, stderr, durationMs }
+}

--- a/src/lib/sshExecLog.ts
+++ b/src/lib/sshExecLog.ts
@@ -1,0 +1,31 @@
+// Audit trail for `spinuptui ssh-exec` — one JSONL line per attempt (allowed,
+// denied, or a resolution failure), so "did this ever write to a server" has a
+// durable answer independent of whatever the calling agent reports. Modeled on
+// src/lib/cloneLog.ts's JSONL-under-configDir/logs pattern.
+
+import { appendFileSync, mkdirSync } from "node:fs"
+import { join } from "node:path"
+import { configDir } from "../config.ts"
+
+const FIELD_CAP = 2_000
+
+function auditLogPath(): string {
+  return join(configDir(), "logs", "ssh-exec-audit.jsonl")
+}
+
+function cap(v: unknown): unknown {
+  if (typeof v !== "string" || v.length <= FIELD_CAP) return v
+  return `${v.slice(0, FIELD_CAP)}…[${v.length - FIELD_CAP} chars trimmed]`
+}
+
+export function logSshExecAttempt(entry: Record<string, unknown>): void {
+  try {
+    const dir = join(configDir(), "logs")
+    mkdirSync(dir, { recursive: true })
+    const out: Record<string, unknown> = { ts: new Date().toISOString() }
+    for (const [k, v] of Object.entries(entry)) out[k] = cap(v)
+    appendFileSync(auditLogPath(), JSON.stringify(out) + "\n")
+  } catch {
+    /* audit logging is best-effort — must never break a diagnostic command */
+  }
+}

--- a/src/lib/sshExecPolicy.ts
+++ b/src/lib/sshExecPolicy.ts
@@ -1,0 +1,51 @@
+// Read-only allowlist for `spinuptui ssh-exec`. Ported from the WordPress Site
+// Diagnostics playbook's Claude-Code-specific PreToolUse hook (guard-ssh-hook.py),
+// which classified raw `ssh ...` Bash invocations for an unattended agent. Moving
+// this into SpinupTUI itself means the guarantee holds for any agent that's
+// configured to touch servers only through `ssh-exec`, not just Claude Code.
+
+const DANGEROUS_PATTERNS: RegExp[] = [
+  /\b(rm|mv|chmod|chown|reboot|shutdown|kill|truncate)\b/i,
+  /systemctl\s+(restart|stop|reload)\b/i,
+  /service\s+\S+\s+restart\b/i,
+  /wp\s+plugin\s+(activate|deactivate|install|update|delete)\b/i,
+  /wp\s+theme\s+(activate|delete|install)\b/i,
+  /wp\s+db\s+(query|import|reset)\b/i,
+  /wp\s+option\s+(update|delete|add)\b/i,
+  /wp\s+user\b/i,
+  /wp\s+core\s+(update|install)\b/i,
+  /wp\s+(rewrite\s+flush|cache\s+flush)\b/i,
+  /crontab\s+-[re]\b/i,
+  /sed\s+-i\b/i,
+  /\b(DROP\s+TABLE|INSERT\s+INTO|DELETE\s+FROM)\b/i,
+  /UPDATE\s+\S+\s+SET\b/i,
+  /\b(apt(-get)?|yum|brew)\s+install\b/i,
+]
+
+// The Python hook's original check `(?<!=)>{1,2}` denied any `>`/`>>` unless
+// immediately preceded by `=` — which wrongly caught `2>/dev/null`/`2>&1` (the
+// character before `>` there is the fd digit, not `=`). Fix: strip known-safe
+// redirects (discard to /dev/null, or an fd-to-fd dup like `2>&1`) first, then
+// flag anything that still looks like a write to a real path.
+function hasUnsafeRedirect(cmd: string): boolean {
+  const stripped = cmd.replace(/\d?>{1,2}\s*(\/dev\/null\b|&\d+)/g, "")
+  return />/.test(stripped)
+}
+
+export interface SshCommandVerdict {
+  decision: "allow" | "deny"
+  reason: string
+}
+
+export function classifySshCommand(cmd: string): SshCommandVerdict {
+  if (DANGEROUS_PATTERNS.some((re) => re.test(cmd)) || hasUnsafeRedirect(cmd)) {
+    return {
+      decision: "deny",
+      reason: "This command looks like a remote write/restart/destructive action — spinuptui ssh-exec only runs read-only diagnostic commands.",
+    }
+  }
+  return {
+    decision: "allow",
+    reason: "Read-only diagnostic command, no write/restart/destructive pattern detected.",
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `spinuptui ssh-exec <domain> -- <command>`: resolves the SSH target the same way `spinuptui ssh <domain>` does, checks the command against a read-only allowlist, and only then runs it — a write/restart/destructive command is denied before it ever reaches the server.
- Moves this enforcement out of any one agent's own hook system (previously a Claude-Code-specific PreToolUse hook in a separate diagnostics playbook) and into SpinupTUI itself, so it holds regardless of which agent is driving.
- Adds a JSONL audit trail of every attempt (allowed/denied/unresolved) under `<config dir>/logs/`.

## Testing
- Live-tested against wp.spinuptui.com: real read commands ran and returned true stdout/stderr, a destructive-looking command was denied, an fd-redirect false-positive (`2>/dev/null`, `2>&1`) was fixed and confirmed, and the audit log recorded every attempt.
- `bun run typecheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)