### PR TITLE
Add server swap management

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@
 - **Purge cache** (`P`) — clear page + object cache together.
 - **Server actions** (`a`) — reboot or restart a service, with the real reason a
   reboot is pending. → [docs/server-actions.md](docs/server-actions.md)
+- **Swap memory** (`a` → Manage swap) — inspect and safely create/enable swap
+  directly over SSH; needs a connected sudo session. → [docs/swap-memory.md](docs/swap-memory.md)
 - **Create & connect a server** (`c` / `V`) — provision a server, then wire it up
   end-to-end (DNS, a vanity site, HTTPS, SSH-key handoff).
   → [docs/creating-connecting-servers.md](docs/creating-connecting-servers.md)
@@ -265,7 +267,7 @@ These can be set in `config.json` or via an environment variable:
 | `P` | Purge a site's page cache + object cache (Servers / Stacks / Search; needs a Read/Write token) |
 | `m` / `M` | Site/server monitoring — a two-pane browser of this site's Uptime Kuma monitors (`M` is an alias, since lowercase `m` is taken in Search/Stacks). Inside: `↑`/`↓` selects a monitor, `a` registers/recalibrates/repairs it (Front page and Cache bypass open a check-window picker), `x` removes Front page or Cache bypass, `o` opens the selected monitor in Kuma, `d` runs the site doctor, `n` shows/edits alert wiring, and vanity sites add `R`/`r` for page refresh/secret rotation (Servers / Stacks / Search) |
 | `R` | Refresh a vanity page's HTML to the currently bundled version — no need to open `m` first. Shown under Vanity in the Servers tab's Control strip and Search's Actions list, for the one site per server whose domain is the server's own hostname |
-| `a` | Server actions: reboot / restart a service (Servers / Search; needs a Read/Write token) |
+| `a` | Server actions: reboot / restart a service / manage swap (Servers / Search; swap needs connected sudo) |
 | `c` | Create a new server (Servers tab; needs a Read/Write token) |
 | `V` | Add a vanity site at the server's own hostname — DNS + site + HTTPS + SSH-key handoff (Servers tab; offered when no hostname site exists; needs a Read/Write token) |
 | `C` | Clone a server's sites to a new/existing destination (Servers tab; needs a Read/Write token + sudo) |
@@ -314,6 +316,16 @@ Full details: [docs/php-upgrade.md](docs/php-upgrade.md).
 `a` on a server reboots it or restarts a service (Nginx/PHP-FPM/MySQL/Redis),
 and shows *why* a reboot is pending (the actual OS packages, read over SSH).
 Needs a Read/Write token. Full details: [docs/server-actions.md](docs/server-actions.md).
+
+## Swap memory
+
+From a selected server, press `a`, choose **Manage swap**, and enter a size in
+GiB. SpinupTUI reads the current swap state over SSH, recommends a size from
+the server's RAM, and—after confirmation—creates, enables, or resizes
+`/swapfile`, turns it on immediately, and persists it in `/etc/fstab`. This is a
+direct server change outside SpinupWP and requires connected sudo (`S`). It
+does not disable or remove existing swap, and it will not resize non-file swap
+devices. Full details: [docs/swap-memory.md](docs/swap-memory.md).
 
 ## Site monitoring
 

--- a/docs/swap-memory.md
+++ b/docs/swap-memory.md
@@ -1,0 +1,28 @@
+# Swap memory
+
+SpinupWP does not expose a swap-management API. SpinupTUI can inspect and
+ensure swap directly over SSH from the server-actions overlay.
+
+Select a server, press `a`, choose **Manage swap**, and enter the requested size
+in GiB. The default is calculated from RAM as half the server's memory, rounded
+up and clamped to 1–4 GiB; if RAM cannot be read, the default is 2 GiB.
+
+The operation requires a connected sudo session (`S`). After confirmation it:
+
+- leaves active swap devices unchanged unless the active setup is exactly `/swapfile`;
+- resizes an active `/swapfile` when a different size is requested, with a
+  brief swap-off interval while the replacement is prepared;
+- reuses a valid inactive `/swapfile`, when present;
+- otherwise creates `/swapfile` with root ownership and mode `0600`;
+- enables it immediately; and
+- adds one idempotent `/swapfile none swap sw 0 0` entry to `/etc/fstab`.
+
+The app verifies that `/swapfile` is active and persistent before reporting
+success. Active swap devices other than a single `/swapfile` are left alone and
+cannot be resized by this flow. It does not disable or remove swap. This is a
+direct OS change, not a SpinupWP API action.
+
+To verify manually, use `sudo swapon --show` and
+`grep -n '/swapfile' /etc/fstab`. To undo it manually, disable the entry with
+`sudo swapoff /swapfile`, remove the `/swapfile` line from `/etc/fstab`, and
+then remove the file with `sudo rm /swapfile`.

--- a/src/lib/swap.test.ts
+++ b/src/lib/swap.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test"
+import { buildSwapEnsureScript, parseSwapStatus, recommendedSwapGiB, validateSwapSizeGiB } from "./swap.ts"
+
+test("swap script is valid shell and validates the requested size", () => {
+  const script = buildSwapEnsureScript(2)
+  expect(Bun.spawnSync(["bash", "-n"], { stdin: new Blob([script]) }).exitCode).toBe(0)
+  expect(script).toContain("swapon --noheadings --show=NAME")
+  expect(script).toContain("fallocate -l 2147483648")
+  expect(() => buildSwapEnsureScript(0)).toThrow()
+  expect(() => buildSwapEnsureScript(1.5)).toThrow()
+  expect(validateSwapSizeGiB(1)).toBe(1)
+  expect(validateSwapSizeGiB(65)).toBeNull()
+})
+
+test("swap script leaves same-sized active swap untouched and protects other devices", () => {
+  const script = buildSwapEnsureScript(4)
+  const guard = "if [ -n \"$ACTIVE\" ] && [ \"$ACTIVE\" != /swapfile ]; then"
+  expect(script).toContain(guard)
+  expect(script.indexOf(guard)).toBeLessThan(script.indexOf("fallocate"))
+  expect(script).toContain("CURRENT=$(stat -c %s /swapfile")
+  expect(script).toContain("swapoff /swapfile")
+  expect(script).toContain("if ! swapon /swapfile; then")
+})
+
+test("swap script reuses valid files and adds fstab idempotently", () => {
+  const script = buildSwapEnsureScript(2)
+  expect(script).toContain("TYPE=$(blkid -p -s TYPE -o value /swapfile")
+  expect(script).toContain("|| printf '%s\\n' '/swapfile none swap sw 0 0' >> /etc/fstab")
+  expect(script).toContain("grep -Eq '^[[:space:]]*/swapfile[[:space:]]+none[[:space:]]+swap")
+  expect(script.lastIndexOf("echo ===SWAP_VERIFIED")).toBeGreaterThan(script.indexOf("swapon --noheadings --show=NAME | grep -Fxq /swapfile"))
+})
+
+test("swap status classifies active, configured-inactive, and absent swap", () => {
+  const active = parseSwapStatus([
+    "===SWAP",
+    "/swapfile 2147483648 0 -2",
+    "===MEM",
+    "4294967296",
+    "===FILE",
+    "2147483648",
+    "===FSTAB",
+    "yes",
+    "===END",
+  ].join("\n"))
+  expect(active.kind).toBe("active")
+  expect(active.recommendedGiB).toBe(2)
+
+  const inactive = parseSwapStatus("===SWAP\n===MEM\n8589934592\n===FILE\n2147483648\n===FSTAB\nno\n===END")
+  expect(inactive.kind).toBe("configured-inactive")
+  expect(inactive.recommendedGiB).toBe(4)
+
+  const none = parseSwapStatus("===SWAP\n===MEM\n\n===FILE\n\n===FSTAB\nno\n===END")
+  expect(none.kind).toBe("none")
+  expect(recommendedSwapGiB(null)).toBe(2)
+})

--- a/src/lib/swap.test.ts
+++ b/src/lib/swap.test.ts
@@ -53,3 +53,21 @@ test("swap status classifies active, configured-inactive, and absent swap", () =
   expect(none.kind).toBe("none")
   expect(recommendedSwapGiB(null)).toBe(2)
 })
+
+test("swap status falls back to /proc/swaps when swapon produces no rows", () => {
+  const status = parseSwapStatus([
+    "===SWAP",
+    "===PROC",
+    "Filename Type Size Used Priority",
+    "/swapfile file 2097148 66048 -2",
+    "===MEM",
+    "4017364992",
+    "===FILE",
+    "2147483648",
+    "===FSTAB",
+    "yes",
+    "===END",
+  ].join("\n"))
+  expect(status.kind).toBe("active")
+  expect(status.entries).toEqual([{ name: "/swapfile", sizeBytes: 2147479552, usedBytes: 67633152, priority: -2 }])
+})

--- a/src/lib/swap.ts
+++ b/src/lib/swap.ts
@@ -1,0 +1,165 @@
+// Inspect and provision Linux swap over SSH.
+//
+// SpinupWP has no swap API. Reads use the normal non-interactive SSH path;
+// writes are performed through the existing connected-sudo runner in ssh.ts.
+
+import type { Server, Site } from "../api/types.ts"
+import { resolveSshTarget, runSudoServerOp, type SudoServerResult } from "./ssh.ts"
+import { SSH_OPTS } from "./probe.ts"
+
+export type SwapKind = "active" | "configured-inactive" | "none"
+
+export interface SwapEntry {
+  name: string
+  sizeBytes: number
+  usedBytes: number
+  priority: number
+}
+
+export interface SwapStatus {
+  kind: SwapKind
+  entries: SwapEntry[]
+  ramBytes: number | null
+  swapfileBytes: number | null
+  persistent: boolean
+  recommendedGiB: number
+}
+
+export type SwapInspectResult =
+  | { ok: true; target: string; status: SwapStatus }
+  | { ok: false; target: string; error: string }
+
+export const MIN_SWAP_GIB = 1
+export const MAX_SWAP_GIB = 64
+
+export function validateSwapSizeGiB(value: number): number | null {
+  if (!Number.isInteger(value) || value < MIN_SWAP_GIB || value > MAX_SWAP_GIB) return null
+  return value
+}
+
+export function recommendedSwapGiB(ramBytes: number | null): number {
+  if (!ramBytes || !Number.isFinite(ramBytes) || ramBytes <= 0) return 2
+  const ramGiB = ramBytes / (1024 ** 3)
+  return Math.min(4, Math.max(1, Math.ceil(ramGiB / 2)))
+}
+
+const SWAP_READ_SCRIPT = [
+  "echo ===SWAP; swapon --show=NAME,SIZE,USED,PRIO --bytes --noheadings 2>/dev/null || true",
+  "echo ===MEM; awk '/^MemTotal:/ {print $2 * 1024}' /proc/meminfo",
+  "echo ===FILE; if [ -f /swapfile ]; then stat -c %s /swapfile 2>/dev/null || true; fi",
+  "echo ===FSTAB; grep -Eq '^[[:space:]]*/swapfile[[:space:]]+none[[:space:]]+swap([[:space:]]|$)' /etc/fstab 2>/dev/null && echo yes || echo no",
+  "echo ===END",
+].join("; ")
+
+export function parseSwapStatus(output: string): SwapStatus {
+  const sections: Record<string, string[]> = {}
+  let current = ""
+  for (const raw of output.split("\n")) {
+    const line = raw.replace(/\r$/, "")
+    const marker = line.match(/^===([A-Z]+)$/)
+    if (marker) {
+      current = marker[1]
+      sections[current] = []
+    } else if (current) {
+      sections[current].push(line)
+    }
+  }
+
+  const entries: SwapEntry[] = []
+  for (const line of sections.SWAP ?? []) {
+    const parts = line.trim().split(/\s+/)
+    if (parts.length < 4) continue
+    const sizeBytes = Number(parts[1])
+    const usedBytes = Number(parts[2])
+    const priority = Number(parts[3])
+    if (parts[0] && Number.isFinite(sizeBytes) && Number.isFinite(usedBytes)) {
+      entries.push({ name: parts[0], sizeBytes, usedBytes, priority: Number.isFinite(priority) ? priority : 0 })
+    }
+  }
+  const ram = Number((sections.MEM?.[0] ?? "").trim())
+  const file = Number((sections.FILE?.[0] ?? "").trim())
+  const persistent = (sections.FSTAB?.[0] ?? "").trim() === "yes"
+  const ramBytes = Number.isFinite(ram) && ram > 0 ? ram : null
+  const swapfileBytes = Number.isFinite(file) && file > 0 ? file : null
+
+  return {
+    kind: entries.length > 0 ? "active" : swapfileBytes != null || persistent ? "configured-inactive" : "none",
+    entries,
+    ramBytes,
+    swapfileBytes,
+    persistent,
+    recommendedGiB: recommendedSwapGiB(ramBytes),
+  }
+}
+
+export async function inspectSwap(server: Server, sites: Site[], sshUser: string | null, sudoUser?: string): Promise<SwapInspectResult> {
+  const target = resolveSshTarget(server, sites, sudoUser ?? sshUser)
+  if (!target) return { ok: false, target: "(no IP)", error: "Server has no IP address." }
+
+  let proc: ReturnType<typeof Bun.spawn>
+  try {
+    proc = Bun.spawn(["ssh", ...SSH_OPTS, target, SWAP_READ_SCRIPT], { stdout: "pipe", stderr: "pipe", stdin: "ignore" })
+  } catch (err) {
+    return { ok: false, target, error: `Failed to launch ssh: ${(err as Error).message}` }
+  }
+  const timer = setTimeout(() => {
+    try { proc.kill() } catch { /* already gone */ }
+  }, 15000)
+  const code = await proc.exited
+  clearTimeout(timer)
+  const stdout = await new Response(proc.stdout as ReadableStream<Uint8Array>).text()
+  const stderr = await new Response(proc.stderr as ReadableStream<Uint8Array>).text()
+  if (code !== 0 || !stdout.includes("===END")) {
+    return { ok: false, target, error: stderr.trim().split("\n").slice(-2).join(" ") || `ssh exited with code ${code}` }
+  }
+  return { ok: true, target, status: parseSwapStatus(stdout) }
+}
+
+function sizeBytes(gib: number): number {
+  return gib * 1024 ** 3
+}
+
+// Active /swapfile can be resized safely by preparing a replacement first,
+// briefly swapping it off, then enabling the replacement. Other active swap
+// devices are never modified.
+export function buildSwapEnsureScript(gib: number): string {
+  const valid = validateSwapSizeGiB(gib)
+  if (valid == null) throw new Error(`Swap size must be a whole number from ${MIN_SWAP_GIB} to ${MAX_SWAP_GIB} GiB.`)
+  const bytes = sizeBytes(valid)
+  return [
+    "set -e",
+    "RESIZED=0",
+    "ACTIVE=$(swapon --noheadings --show=NAME 2>/dev/null || true)",
+    "if [ -n \"$ACTIVE\" ] && [ \"$ACTIVE\" != /swapfile ]; then echo 'Active swap is not exactly /swapfile; refusing to resize it.' >&2; exit 12; fi",
+    "if [ \"$ACTIVE\" = /swapfile ] && [ -f /swapfile ]; then",
+    `  CURRENT=$(stat -c %s /swapfile 2>/dev/null || echo 0); if [ \"$CURRENT\" -eq ${bytes} ]; then echo ===SWAP_ALREADY_ACTIVE; echo ===SWAP_VERIFIED; exit 0; fi`,
+    "  TMP=/swapfile.spinup-tui.$$; OLD=/swapfile.spinup-tui.old.$$; trap 'rm -f \"$TMP\" \"$OLD\"' EXIT",
+    `  fallocate -l ${bytes} \"$TMP\"; chmod 600 \"$TMP\"; chown root:root \"$TMP\"; mkswap \"$TMP\" >/dev/null`,
+    "  swapoff /swapfile",
+    "  mv /swapfile \"$OLD\"",
+    "  if ! mv \"$TMP\" /swapfile; then mv \"$OLD\" /swapfile; swapon /swapfile; exit 13; fi",
+    "  if ! swapon /swapfile; then rm -f /swapfile; mv \"$OLD\" /swapfile; swapon /swapfile; exit 14; fi",
+    "  rm -f \"$OLD\"; trap - EXIT; RESIZED=1",
+    "fi",
+    "if [ -e /swapfile ] && [ ! -f /swapfile ]; then echo 'Existing /swapfile is not a regular file.' >&2; exit 10; fi",
+    "if [ -f /swapfile ]; then",
+    "  TYPE=$(blkid -p -s TYPE -o value /swapfile 2>/dev/null || true)",
+    "  if [ \"$TYPE\" != swap ]; then echo 'Existing /swapfile is not a valid swap area.' >&2; exit 11; fi",
+    "else",
+    `  TMP=/swapfile.spinup-tui.$$; trap 'rm -f \"$TMP\"' EXIT; fallocate -l ${bytes} \"$TMP\"; chmod 600 \"$TMP\"; chown root:root \"$TMP\"; mkswap \"$TMP\" >/dev/null; mv \"$TMP\" /swapfile; trap - EXIT`,
+    "fi",
+    "chmod 600 /swapfile; chown root:root /swapfile",
+    "if [ \"$RESIZED\" -eq 0 ]; then swapon /swapfile; fi",
+    "grep -Eq '^[[:space:]]*/swapfile[[:space:]]+none[[:space:]]+swap([[:space:]]|$)' /etc/fstab || printf '%s\\n' '/swapfile none swap sw 0 0' >> /etc/fstab",
+    "swapon --noheadings --show=NAME | grep -Fxq /swapfile",
+    "grep -Eq '^[[:space:]]*/swapfile[[:space:]]+none[[:space:]]+swap([[:space:]]|$)' /etc/fstab",
+    "echo ===SWAP_VERIFIED",
+  ].join("\n")
+}
+
+export function ensureSwap(
+  server: Server,
+  opts: { sudoUser: string; sudoPassword: string; gib: number },
+): Promise<SudoServerResult> {
+  return runSudoServerOp(server, opts, () => buildSwapEnsureScript(opts.gib), "===SWAP_VERIFIED")
+}

--- a/src/lib/swap.ts
+++ b/src/lib/swap.ts
@@ -4,6 +4,7 @@
 // writes are performed through the existing connected-sudo runner in ssh.ts.
 
 import type { Server, Site } from "../api/types.ts"
+import { sshPort } from "./dbBackup.ts"
 import { resolveSshTarget, runSudoServerOp, type SudoServerResult } from "./ssh.ts"
 import { SSH_OPTS } from "./probe.ts"
 
@@ -45,11 +46,45 @@ export function recommendedSwapGiB(ramBytes: number | null): number {
 
 const SWAP_READ_SCRIPT = [
   "echo ===SWAP; swapon --show=NAME,SIZE,USED,PRIO --bytes --noheadings 2>/dev/null || true",
+  "echo ===PROC; cat /proc/swaps 2>/dev/null || true",
   "echo ===MEM; awk '/^MemTotal:/ {print $2 * 1024}' /proc/meminfo",
   "echo ===FILE; if [ -f /swapfile ]; then stat -c %s /swapfile 2>/dev/null || true; fi",
   "echo ===FSTAB; grep -Eq '^[[:space:]]*/swapfile[[:space:]]+none[[:space:]]+swap([[:space:]]|$)' /etc/fstab 2>/dev/null && echo yes || echo no",
   "echo ===END",
 ].join("; ")
+
+function parseSwapEntries(lines: string[]): SwapEntry[] {
+  const entries: SwapEntry[] = []
+  for (const line of lines) {
+    const parts = line.trim().split(/\s+/)
+    if (parts.length < 4) continue
+    const sizeBytes = Number(parts[1])
+    const usedBytes = Number(parts[2])
+    const priority = Number(parts[3])
+    if (parts[0] && Number.isFinite(sizeBytes) && Number.isFinite(usedBytes)) {
+      entries.push({ name: parts[0], sizeBytes, usedBytes, priority: Number.isFinite(priority) ? priority : 0 })
+    }
+  }
+  return entries
+}
+
+// /proc/swaps reports Size and Used in KiB. It is a reliable fallback for
+// servers whose swapon does not support the requested output flags.
+function parseProcSwapEntries(lines: string[]): SwapEntry[] {
+  const entries: SwapEntry[] = []
+  for (const line of lines) {
+    if (/^Filename\s+Type\s+Size\s+Used\s+Priority\s*$/.test(line.trim())) continue
+    const parts = line.trim().split(/\s+/)
+    if (parts.length < 5) continue
+    const sizeBytes = Number(parts[2]) * 1024
+    const usedBytes = Number(parts[3]) * 1024
+    const priority = Number(parts[4])
+    if (parts[0] && Number.isFinite(sizeBytes) && Number.isFinite(usedBytes)) {
+      entries.push({ name: parts[0], sizeBytes, usedBytes, priority: Number.isFinite(priority) ? priority : 0 })
+    }
+  }
+  return entries
+}
 
 export function parseSwapStatus(output: string): SwapStatus {
   const sections: Record<string, string[]> = {}
@@ -65,17 +100,8 @@ export function parseSwapStatus(output: string): SwapStatus {
     }
   }
 
-  const entries: SwapEntry[] = []
-  for (const line of sections.SWAP ?? []) {
-    const parts = line.trim().split(/\s+/)
-    if (parts.length < 4) continue
-    const sizeBytes = Number(parts[1])
-    const usedBytes = Number(parts[2])
-    const priority = Number(parts[3])
-    if (parts[0] && Number.isFinite(sizeBytes) && Number.isFinite(usedBytes)) {
-      entries.push({ name: parts[0], sizeBytes, usedBytes, priority: Number.isFinite(priority) ? priority : 0 })
-    }
-  }
+  const entries = parseSwapEntries(sections.SWAP ?? [])
+  if (entries.length === 0) entries.push(...parseProcSwapEntries(sections.PROC ?? []))
   const ram = Number((sections.MEM?.[0] ?? "").trim())
   const file = Number((sections.FILE?.[0] ?? "").trim())
   const persistent = (sections.FSTAB?.[0] ?? "").trim() === "yes"
@@ -98,7 +124,7 @@ export async function inspectSwap(server: Server, sites: Site[], sshUser: string
 
   let proc: ReturnType<typeof Bun.spawn>
   try {
-    proc = Bun.spawn(["ssh", ...SSH_OPTS, target, SWAP_READ_SCRIPT], { stdout: "pipe", stderr: "pipe", stdin: "ignore" })
+    proc = Bun.spawn(["ssh", ...SSH_OPTS, ...sshPort(server.ssh_port), target, SWAP_READ_SCRIPT], { stdout: "pipe", stderr: "pipe", stdin: "ignore" })
   } catch (err) {
     return { ok: false, target, error: `Failed to launch ssh: ${(err as Error).message}` }
   }

--- a/src/ui/Help.tsx
+++ b/src/ui/Help.tsx
@@ -36,7 +36,7 @@ const NAV: Section = {
     ["s", "SSH into the site"],
     ["h", "Server health (SSH)"],
     ["w", "Open in SpinupWP web app"],
-    ["a", "Server actions (reboot/restart)"],
+    ["a", "Server actions (reboot/restart/swap)"],
     ["c", "Create a new server"],
     ["C", "Clone this server to a new one"],
     ["S", "Connect sudo on the server"],

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -45,6 +45,7 @@ import { withKuma, KumaClient, registerMonitors, registerFingerprintMonitor, reg
 import { deriveFingerprint } from "../lib/siteFingerprint.ts"
 import type { StoredProviders } from "../config.ts"
 import { fetchRebootInfo, grantSiteSshKey, revokeSiteSshKey, verifySudo, ensureSpinupKey, listPersonalKeys, keyBody, type RebootInfo } from "../lib/ssh.ts"
+import { ensureSwap, inspectSwap, type SwapStatus } from "../lib/swap.ts"
 import { estimateSourceSiteSizes, runStandardWpPull, runBedrockPull, runFilesOnlyPull, verifyClone, verifyFilesClone, preflightBedrockSource, type SudoCtx, type CloneStage, type CloneExecRecord, type VerifyResult as CloneVerifyResult } from "../lib/serverClone.ts"
 import { CloneLogger } from "../lib/cloneLog.ts"
 import { syncAdditionalDomains } from "../lib/cloneDomains.ts"
@@ -127,6 +128,16 @@ export interface ServerOpProgress {
 }
 
 export function isServerOpInFlight(p: ServerOpProgress | undefined): boolean {
+  return p != null && p.status !== UPGRADE_DONE && p.status !== UPGRADE_FAIL
+}
+
+export interface SwapProgress {
+  gib: number
+  status: string
+  error?: string
+}
+
+export function isSwapInFlight(p: SwapProgress | undefined): boolean {
   return p != null && p.status !== UPGRADE_DONE && p.status !== UPGRADE_FAIL
 }
 
@@ -516,6 +527,13 @@ interface StoreValue extends DataState {
   // Fire a server op (reboot or service restart) and poll its event in the background.
   startServerOp: (server: Server, kind: ServerOpKind, label: string) => void
   clearServerOp: (serverId: number) => void
+  swapStatus: Map<number, SwapStatus>
+  swapStatusLoading: Set<number>
+  swapStatusErrors: Map<number, string>
+  loadSwapStatus: (server: Server, sudoUser?: string) => void
+  swapProgress: Map<number, SwapProgress>
+  startSwapEnsure: (server: Server, gib: number) => void
+  clearSwapProgress: (serverId: number) => void
   // Whether the "create a server" overlay is open. Separate from the source so the
   // flow can run with no seed (general "from scratch" create, and the empty-fleet
   // case where there's no server to select).
@@ -937,6 +955,10 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const [purgeCacheProgress, setPurgeCacheProgress] = useState<Map<number, PurgeCacheProgress>>(new Map())
   const [serverActionsServer, setServerActionsServer] = useState<Server | null>(null)
   const [serverOps, setServerOps] = useState<Map<number, ServerOpProgress>>(new Map())
+  const [swapStatus, setSwapStatus] = useState<Map<number, SwapStatus>>(new Map())
+  const [swapStatusLoading, setSwapStatusLoading] = useState<Set<number>>(new Set())
+  const [swapStatusErrors, setSwapStatusErrors] = useState<Map<number, string>>(new Map())
+  const [swapProgress, setSwapProgress] = useState<Map<number, SwapProgress>>(new Map())
   const [newServerOpen, setNewServerOpen] = useState(false)
   const [newServerSource, setNewServerSource] = useState<Server | null>(null)
   const [newServerJob, setNewServerJob] = useState<NewServerJob | null>(null)
@@ -1548,6 +1570,72 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       void run()
     },
     [client, refresh, clearServerOp, serverOps, sitesForServer],
+  )
+
+  // ---- Swap memory (direct privileged SSH; no SpinupWP API surface) ------
+
+  const clearSwapProgress = useCallback(
+    (serverId: number) =>
+      setSwapProgress((prev) => {
+        if (!prev.has(serverId)) return prev
+        const next = new Map(prev)
+        next.delete(serverId)
+        return next
+      }),
+    [],
+  )
+
+  const loadSwapStatus = useCallback(
+    (server: Server, sudoUser?: string) => {
+      if (swapStatusLoading.has(server.id)) return
+      const run = async () => {
+        setSwapStatusLoading((prev) => new Set(prev).add(server.id))
+        setSwapStatusErrors((prev) => {
+          if (!prev.has(server.id)) return prev
+          const next = new Map(prev)
+          next.delete(server.id)
+          return next
+        })
+        const res = await inspectSwap(server, sitesForServer(server.id), cfgRef.current.sshUser, sudoUser)
+        if (res.ok) setSwapStatus((prev) => new Map(prev).set(server.id, res.status))
+        else setSwapStatusErrors((prev) => new Map(prev).set(server.id, res.error))
+        setSwapStatusLoading((prev) => {
+          const next = new Set(prev)
+          next.delete(server.id)
+          return next
+        })
+      }
+      void run()
+    },
+    [sitesForServer, swapStatusLoading],
+  )
+
+  const startSwapEnsure = useCallback(
+    (server: Server, gib: number) => {
+      const existing = swapProgress.get(server.id)
+      if (isSwapInFlight(existing)) return
+      const run = async () => {
+        setSwapProgress((prev) => new Map(prev).set(server.id, { gib, status: "queued" }))
+        const sudoUser = sudoUsers.get(server.id)
+        const sudoPassword = sudoPwRef.current.get(server.id)
+        if (!sudoUser || sudoPassword == null || !sudoConnected.has(server.id)) {
+          setSwapProgress((prev) => new Map(prev).set(server.id, { gib, status: UPGRADE_FAIL, error: "Connect sudo on this server first (press S)." }))
+          return
+        }
+        setSwapProgress((prev) => new Map(prev).set(server.id, { gib, status: "running" }))
+        const res = await ensureSwap(server, { sudoUser, sudoPassword, gib })
+        if (!res.ok) {
+          setSwapProgress((prev) => new Map(prev).set(server.id, { gib, status: UPGRADE_FAIL, error: res.error }))
+          return
+        }
+        setSwapProgress((prev) => new Map(prev).set(server.id, { gib, status: UPGRADE_DONE }))
+        toast.success(`${server.name} swap is enabled`)
+        const status = await inspectSwap(server, sitesForServer(server.id), cfgRef.current.sshUser, sudoUser)
+        if (status.ok) setSwapStatus((prev) => new Map(prev).set(server.id, status.status))
+      }
+      void run()
+    },
+    [sitesForServer, sudoConnected, sudoUsers, swapProgress],
   )
 
   // ---- Create a server (POST /servers) ----------------------------------
@@ -4184,6 +4272,13 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     serverOps,
     startServerOp,
     clearServerOp,
+    swapStatus,
+    swapStatusLoading,
+    swapStatusErrors,
+    loadSwapStatus,
+    swapProgress,
+    startSwapEnsure,
+    clearSwapProgress,
     newServerOpen,
     setNewServerOpen,
     newServerSource,

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -1588,6 +1588,15 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const loadSwapStatus = useCallback(
     (server: Server, sudoUser?: string) => {
       if (swapStatusLoading.has(server.id)) return
+      // Each visit to Manage swap is a live server inspection. Do not let a
+      // previous read (for example, before swap was added manually) masquerade
+      // as the current state.
+      setSwapStatus((prev) => {
+        if (!prev.has(server.id)) return prev
+        const next = new Map(prev)
+        next.delete(server.id)
+        return next
+      })
       const run = async () => {
         setSwapStatusLoading((prev) => new Set(prev).add(server.id))
         setSwapStatusErrors((prev) => {

--- a/src/ui/views/ServerActions.tsx
+++ b/src/ui/views/ServerActions.tsx
@@ -84,6 +84,7 @@ export function ServerActions() {
   const [index, setIndex] = useState(() => (server?.reboot_required ? 0 : 1))
   const [target, setTarget] = useState<Action | null>(null)
   const [swapSizeInput, setSwapSizeInput] = useState("")
+  const [swapSizeSeeded, setSwapSizeSeeded] = useState(false)
   const [swapSizeError, setSwapSizeError] = useState<string | null>(null)
 
   const siteCount = server ? sitesForServer(server.id).length : 0
@@ -106,6 +107,13 @@ export function ServerActions() {
     if (server && sudoConnectedForServer && !swapLoading && (!swap || !!swapError)) loadSwapStatus(server, sudoUser)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [server?.id, sudoConnectedForServer])
+
+  useEffect(() => {
+    if (phase !== "swap" || !swap || swapSizeSeeded) return
+    const current = isResizableSwap(swap) ? Math.round(swap.entries[0].sizeBytes / (1024 ** 3)) : null
+    setSwapSizeInput(String(current || swap.recommendedGiB))
+    setSwapSizeSeeded(true)
+  }, [phase, swap, swapSizeSeeded])
 
   const progress = server ? serverOps.get(server.id) : undefined
   const swapOp = server ? swapProgress.get(server.id) : undefined
@@ -144,9 +152,11 @@ export function ServerActions() {
             const chosen = ACTIONS[index]
             setTarget(chosen)
             if (chosen.kind === "swap") {
-              const current = isResizableSwap(swap) ? Math.round(swap!.entries[0].sizeBytes / (1024 ** 3)) : null
-              const suggested = current || swap?.recommendedGiB || 2
-              setSwapSizeInput(String(suggested))
+              // Refresh on every entry: swap may have been changed outside the
+              // TUI since the server-actions overlay was last opened.
+              if (sudoConnectedForServer) loadSwapStatus(server!, sudoUser)
+              setSwapSizeInput("")
+              setSwapSizeSeeded(false)
               setSwapSizeError(null)
               setPhase("swap")
             } else {
@@ -164,6 +174,7 @@ export function ServerActions() {
         if (name === "r") loadSwapStatus(server!, sudoUser)
         return
       }
+      if (!swap) return
       if (swap?.kind === "active" && !isResizableSwap(swap)) return
       if (name === "backspace" || name === "delete") {
         setSwapSizeInput((v) => v.slice(0, -1))
@@ -303,13 +314,20 @@ export function ServerActions() {
       return (
         <Panel title=" Manage swap memory " active>
           <box style={{ flexDirection: "column", width: 66, paddingTop: 1, paddingBottom: 1 }}>
-            {swapLoading ? (
+            {!sudoConnectedForServer && !swap ? (
+              <>
+                <text content="Connect sudo first to inspect this server's actual swap status." fg={theme.warn} wrapMode="none" />
+                <text content="Press S, then return here." fg={theme.textFaint} wrapMode="none" />
+              </>
+            ) : swapLoading ? (
               <box style={{ flexDirection: "row" }}><Spinner /><text content="  Inspecting swap…" fg={theme.textDim} /></box>
             ) : swapError ? (
               <>
                 <text content={`✕ ${swapError}`} fg={theme.bad} wrapMode="none" />
                 <text content="Press r to retry · Esc to close" fg={theme.textFaint} wrapMode="none" />
               </>
+            ) : !swap ? (
+              <box style={{ flexDirection: "row" }}><Spinner /><text content="  Inspecting swap…" fg={theme.textDim} /></box>
             ) : swap?.kind === "active" && !isResizableSwap(swap) ? (
               <>
                 <text content="Active swap is not a single /swapfile." fg={theme.warn} wrapMode="none" />

--- a/src/ui/views/ServerActions.tsx
+++ b/src/ui/views/ServerActions.tsx
@@ -16,12 +16,22 @@ import { StatusBar } from "../StatusBar.tsx"
 import { useStore } from "../store.tsx"
 import { moveSelection } from "../List.tsx"
 import type { RebootInfo } from "../../lib/ssh.ts"
+import { MAX_SWAP_GIB, MIN_SWAP_GIB, type SwapStatus, validateSwapSizeGiB } from "../../lib/swap.ts"
 import type { ServerOpKind } from "../store.tsx"
 
-type Phase = "pick" | "confirm" | "tracking" | "done" | "error"
+function formatSwapGiB(bytes: number): string {
+  return `${(bytes / (1024 ** 3)).toFixed(1)} GiB`
+}
+
+function isResizableSwap(status: SwapStatus | undefined): boolean {
+  return status?.kind === "active" && status.entries.length === 1 && status.entries[0].name === "/swapfile"
+}
+
+type Phase = "pick" | "swap" | "confirm" | "tracking" | "done" | "error"
+type ActionKind = ServerOpKind | "swap"
 
 interface Action {
-  kind: ServerOpKind
+  kind: ActionKind
   label: string // menu label, e.g. "Restart Nginx"
   verb: string // short progress verb, e.g. "nginx"
 }
@@ -32,6 +42,7 @@ const ACTIONS: Action[] = [
   { kind: "php", label: "Restart PHP-FPM", verb: "php-fpm" },
   { kind: "mysql", label: "Restart MySQL", verb: "mysql" },
   { kind: "redis", label: "Restart Redis", verb: "redis" },
+  { kind: "swap", label: "Manage swap memory", verb: "swap" },
 ]
 
 // Short headline for the menu / detail; the full package list is shown on the
@@ -56,6 +67,15 @@ export function ServerActions() {
     rebootInfoLoading,
     rebootInfoErrors,
     loadRebootInfo,
+    swapStatus,
+    swapStatusLoading,
+    swapStatusErrors,
+    loadSwapStatus,
+    swapProgress,
+    startSwapEnsure,
+    clearSwapProgress,
+    isSudoConnected,
+    sudoUserFor,
   } = store
 
   const rebootRequired = !!server?.reboot_required
@@ -63,11 +83,18 @@ export function ServerActions() {
   // Cursor starts on Reboot when one is pending, else on the first restart.
   const [index, setIndex] = useState(() => (server?.reboot_required ? 0 : 1))
   const [target, setTarget] = useState<Action | null>(null)
+  const [swapSizeInput, setSwapSizeInput] = useState("")
+  const [swapSizeError, setSwapSizeError] = useState<string | null>(null)
 
   const siteCount = server ? sitesForServer(server.id).length : 0
   const info = server ? rebootInfo.get(server.id) : undefined
   const infoLoading = server ? rebootInfoLoading.has(server.id) : false
   const infoError = server ? rebootInfoErrors.get(server.id) : undefined
+  const swap = server ? swapStatus.get(server.id) : undefined
+  const swapLoading = server ? swapStatusLoading.has(server.id) : false
+  const swapError = server ? swapStatusErrors.get(server.id) : undefined
+  const sudoConnectedForServer = server ? isSudoConnected(server.id) : false
+  const sudoUser = server ? sudoUserFor(server.id) : undefined
 
   // Fetch the "why" once when opened on a reboot-required server.
   useEffect(() => {
@@ -75,18 +102,26 @@ export function ServerActions() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [server?.id])
 
+  useEffect(() => {
+    if (server && sudoConnectedForServer && !swapLoading && (!swap || !!swapError)) loadSwapStatus(server, sudoUser)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [server?.id, sudoConnectedForServer])
+
   const progress = server ? serverOps.get(server.id) : undefined
+  const swapOp = server ? swapProgress.get(server.id) : undefined
+  const activeProgress = target?.kind === "swap" ? swapOp : progress
   const dp: Phase =
     phase !== "tracking"
       ? phase
-      : !progress
+      : !activeProgress || activeProgress.status === "deployed"
         ? "done"
-        : progress.status === "failed"
+        : activeProgress.status === "failed"
           ? "error"
           : "tracking"
 
   const close = () => {
     if (server && progress?.status === "failed") clearServerOp(server.id)
+    if (server && swapOp?.status === "failed") clearSwapProgress(server.id)
     setServerActionsServer(null)
   }
 
@@ -105,9 +140,52 @@ export function ServerActions() {
         case "return":
         case "right":
         case "l":
-          setTarget(ACTIONS[index])
-          setPhase("confirm")
+          {
+            const chosen = ACTIONS[index]
+            setTarget(chosen)
+            if (chosen.kind === "swap") {
+              const current = isResizableSwap(swap) ? Math.round(swap!.entries[0].sizeBytes / (1024 ** 3)) : null
+              const suggested = current || swap?.recommendedGiB || 2
+              setSwapSizeInput(String(suggested))
+              setSwapSizeError(null)
+              setPhase("swap")
+            } else {
+              setPhase("confirm")
+            }
+          }
           return
+      }
+      return
+    }
+
+    if (dp === "swap") {
+      if (swapLoading) return
+      if (swapError) {
+        if (name === "r") loadSwapStatus(server!, sudoUser)
+        return
+      }
+      if (swap?.kind === "active" && !isResizableSwap(swap)) return
+      if (name === "backspace" || name === "delete") {
+        setSwapSizeInput((v) => v.slice(0, -1))
+        setSwapSizeError(null)
+        return
+      }
+      if (/^[0-9]$/.test(name)) {
+        setSwapSizeInput((v) => (v === "0" ? name : `${v}${name}`))
+        setSwapSizeError(null)
+        return
+      }
+      if (name === "return" || name === "right" || name === "l") {
+        const parsed = Number(swapSizeInput)
+        if (validateSwapSizeGiB(parsed) == null) {
+          setSwapSizeError(`Enter a whole number from ${MIN_SWAP_GIB} to ${MAX_SWAP_GIB} GiB.`)
+          return
+        }
+        if (!isSudoConnected(server!.id)) {
+          setSwapSizeError("Connect sudo on this server first (press S).")
+          return
+        }
+        setPhase("confirm")
       }
       return
     }
@@ -115,7 +193,8 @@ export function ServerActions() {
     if (dp === "confirm") {
       if (name === "y") {
         if (server && target) {
-          startServerOp(server, target.kind, target.verb)
+          if (target.kind === "swap") startSwapEnsure(server, Number(swapSizeInput))
+          else startServerOp(server, target.kind, target.verb)
           setPhase("tracking")
         }
         return
@@ -126,7 +205,10 @@ export function ServerActions() {
 
     if (dp === "error") {
       if (name === "r") {
-        if (server) clearServerOp(server.id)
+        if (server) {
+          if (target?.kind === "swap") clearSwapProgress(server.id)
+          else clearServerOp(server.id)
+        }
         setPhase("pick")
       }
       return
@@ -201,7 +283,7 @@ export function ServerActions() {
               const selected = i === index
               const recommended = a.kind === "reboot" && rebootRequired
               const fg = selected ? theme.text : recommended ? theme.warn : theme.textDim
-              const icon = a.kind === "reboot" ? "↻ " : "⟳ "
+              const icon = a.kind === "reboot" ? "↻ " : a.kind === "swap" ? "⇄ " : "⟳ "
               return (
                 <box
                   key={a.kind}
@@ -213,17 +295,57 @@ export function ServerActions() {
               )
             })}
           </box>
+              </Panel>
+      )
+    }
+
+    if (dp === "swap") {
+      return (
+        <Panel title=" Manage swap memory " active>
+          <box style={{ flexDirection: "column", width: 66, paddingTop: 1, paddingBottom: 1 }}>
+            {swapLoading ? (
+              <box style={{ flexDirection: "row" }}><Spinner /><text content="  Inspecting swap…" fg={theme.textDim} /></box>
+            ) : swapError ? (
+              <>
+                <text content={`✕ ${swapError}`} fg={theme.bad} wrapMode="none" />
+                <text content="Press r to retry · Esc to close" fg={theme.textFaint} wrapMode="none" />
+              </>
+            ) : swap?.kind === "active" && !isResizableSwap(swap) ? (
+              <>
+                <text content="Active swap is not a single /swapfile." fg={theme.warn} wrapMode="none" />
+                <text content={`  ${swap.entries.map((e) => `${e.name} · ${formatSwapGiB(e.sizeBytes)}`).join("  ")}`} fg={theme.textDim} wrapMode="none" />
+                <box style={{ height: 1 }} />
+                <text content="Resize is only supported for /swapfile; no change will be made." fg={theme.textFaint} wrapMode="none" />
+              </>
+            ) : (
+              <>
+                <text content={swap?.kind === "active" ? `Active /swapfile: ${formatSwapGiB(swap.entries[0].sizeBytes)}.` : swap?.kind === "configured-inactive" ? "A configured /swapfile exists but is inactive." : "No active swap was found."} fg={theme.text} wrapMode="none" />
+                <box style={{ height: 1 }} />
+                <box style={{ flexDirection: "row", height: 1 }}>
+                  <text content="Size (GiB): " fg={theme.textDim} />
+                  <text content={swapSizeInput || "_"} fg={theme.accent} />
+                  <text content={`  recommended ${swap?.recommendedGiB ?? 2}`} fg={theme.textFaint} />
+                </box>
+                {swapSizeError && <text content={`✕ ${swapSizeError}`} fg={theme.bad} wrapMode="none" />}
+                <box style={{ height: 1 }} />
+                <text content={sudoConnectedForServer ? "Press Enter to review the change." : "Connect sudo first with S, then return here; status will be checked after authentication."} fg={sudoConnectedForServer ? theme.textDim : theme.warn} wrapMode="none" />
+                <text content="Type digits · Backspace edits · Esc cancels" fg={theme.textFaint} wrapMode="none" />
+              </>
+            )}
+          </box>
         </Panel>
       )
     }
 
     if (dp === "confirm") {
       const isReboot = target?.kind === "reboot"
+      const isSwap = target?.kind === "swap"
+      const resizingSwap = isSwap && isResizableSwap(swap)
       return (
         <Panel title=" Confirm " active>
           <box style={{ flexDirection: "column", width: 62, paddingTop: 1, paddingBottom: 1 }}>
             <box style={{ flexDirection: "row" }}>
-              <text content={isReboot ? "Reboot " : `${target?.label} on `} fg={theme.text} wrapMode="none" />
+              <text content={isReboot ? "Reboot " : isSwap ? (resizingSwap ? "Resize swap on " : "Enable swap on ") : `${target?.label} on `} fg={theme.text} wrapMode="none" />
               <text content={truncate(server!.name, 30)} fg={theme.accent} wrapMode="none" />
               <text content="?" fg={theme.text} />
             </box>
@@ -251,6 +373,13 @@ export function ServerActions() {
                   <text content="Uptime Kuma monitors enter a maintenance window — no false alerts." fg={theme.textFaint} wrapMode="none" />
                 )}
               </>
+            ) : isSwap ? (
+              <>
+                <text content={resizingSwap ? `Rebuilds /swapfile from ${formatSwapGiB(swap!.entries[0].sizeBytes)} to ${swapSizeInput} GiB.` : `Creates or enables /swapfile at ${swapSizeInput} GiB.`} fg={theme.warn} wrapMode="none" />
+                {resizingSwap && <text content="Swap is briefly disabled while the replacement file is prepared." fg={theme.warn} wrapMode="none" />}
+                <text content="Swap is enabled immediately and persisted in /etc/fstab." fg={theme.textDim} wrapMode="none" />
+                <text content={resizingSwap ? "Only this active /swapfile will be changed." : "Existing active swap will not be changed or duplicated."} fg={theme.textFaint} wrapMode="none" />
+              </>
             ) : (
               <text content="Brief interruption to that one service; sites stay up otherwise." fg={theme.textDim} wrapMode="none" />
             )}
@@ -266,7 +395,7 @@ export function ServerActions() {
         <box style={{ flexDirection: "column", alignItems: "center" }}>
           <box style={{ flexDirection: "row" }}>
             <Spinner />
-            <text content={`  ${target?.label ?? "Working"} — ${progress?.status ?? "queued"}…`} fg={theme.textDim} />
+            <text content={`  ${target?.label ?? "Working"} — ${activeProgress?.status ?? "queued"}…`} fg={theme.textDim} />
           </box>
           <box style={{ height: 1 }} />
           <text content="You can press Esc — it keeps running in the background." fg={theme.textFaint} wrapMode="none" />
@@ -294,7 +423,7 @@ export function ServerActions() {
     return (
       <Panel title=" Action failed " active>
         <box style={{ flexDirection: "column", width: 66, paddingTop: 1, paddingBottom: 1 }}>
-          <text content={`✕ ${progress?.error ?? "Something went wrong."}`} fg={theme.bad} />
+            <text content={`✕ ${activeProgress?.error ?? "Something went wrong."}`} fg={theme.bad} />
           <box style={{ height: 1 }} />
           <text content="Press r to choose another action · Esc to close" fg={theme.textFaint} wrapMode="none" />
         </box>
@@ -314,6 +443,12 @@ export function ServerActions() {
         return [
           { key: "y", label: "confirm" },
           { key: "←", label: "back" },
+          { key: "esc", label: "cancel" },
+        ]
+      case "swap":
+        return [
+          { key: "digits", label: "size" },
+          { key: "⏎", label: "review" },
           { key: "esc", label: "cancel" },
         ]
       case "error":


### PR DESCRIPTION
## Summary

Adds guided swap-memory management to the server-actions TUI.

- Inspects current swap over SSH and recommends a size from RAM.
- Requires the existing connected sudo session before making direct server changes.
- Creates, enables, or safely resizes /swapfile, then verifies active swap and an idempotent /etc/fstab entry.
- Documents that swap is managed directly on the server, outside the SpinupWP API.

## Validation

- bun run typecheck
- bun test (4 swap tests)
- git diff --check

Rebased onto current main (45de2ea), preserving the recently added vanity-refresh shortcut in the README.