### PR TITLE
fix: restore K (grant SSH key) to Site/Server Control drawers

### DIFF
--- a/src/ui/Details.tsx
+++ b/src/ui/Details.tsx
@@ -106,7 +106,7 @@ function serverControlGroups(
 // Labels stay terse and avoid repeating their group's title — see siteGroups().
 export const SERVER_CONTROL: ActionGroup[] = [
   { title: "Clone", items: [["C", "Clone →"]] },
-  { title: "Access", items: [["S", "Sudo"]] },
+  { title: "Access", items: [["S", "Sudo"], ["K", "Grant SSH key"]] },
   {
     title: "Manage",
     items: [

--- a/src/ui/components.tsx
+++ b/src/ui/components.tsx
@@ -436,6 +436,7 @@ export function ControlPanel({ heading, groups, layout = "list" }: { heading: st
 export function siteGroups(isWordpress: boolean, localSync: boolean, isVanity: boolean): ActionGroup[] {
   const remote: [string, string][] = [
     ["s", "SSH"],
+    ["K", "Grant SSH key"],
     ["n", "DNS"],
   ]
   if (isWordpress) {

--- a/src/ui/views/Browser.tsx
+++ b/src/ui/views/Browser.tsx
@@ -128,12 +128,17 @@ export function Browser({ rows }: { rows: number }) {
         }
         return
       }
-      case "K":
-        // Grant Spinup's machine key to the selected site over SSH (privileged
-        // write via the server's sudo user — the API can't do this). Capital K
-        // (like L/V/N) since lowercase k is the vim "move up" binding.
-        if (focus === "sites" && sites[siteIndex]) setGrantKeySite(sites[siteIndex])
+      case "K": {
+        // Grant Spinup's machine key to a site over SSH (privileged write via the
+        // server's sudo user — the API can't do this). Capital K (like L/V/N)
+        // since lowercase k is the vim "move up" binding. Site-anchored (the
+        // overlay itself picks the scope: just this site, or every site on the
+        // server) but works from either pane like S/h — the Servers pane falls
+        // back to the server's first key-eligible site as the anchor.
+        const anchor = focus === "sites" ? sites[siteIndex] : server ? sitesForServer(server.id).find((s) => s.site_user) : undefined
+        if (anchor) setGrantKeySite(anchor)
         return
+      }
       case "L":
         // Link / view the selected site's local working copy (Phase 1).
         if (focus === "sites" && sites[siteIndex]) setLocalLinkSite(sites[siteIndex])


### PR DESCRIPTION
## Summary
- The v0.22.0 Control-strip rebuild (#42) dropped `K` (grant SSH key) from both `siteGroups()` and `SERVER_CONTROL`, even though the keybinding itself kept working — the action became undiscoverable without prior knowledge.
- Widened the Servers-pane `K` handler to fall back to the server's first key-eligible site as an anchor, so it also works from the Servers pane (matching how `S`/`h` already behave from either pane), and listed it in Server Control's "Access" group next to `S`.
- Listed `K` in Site Control's "Remote" group next to `s` (SSH), matching its existing site-anchored trigger.

## Test plan
- [x] `bun run typecheck` passes
- [x] Manually verified `K` now appears and works from both the Sites pane and the Servers pane in a running instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zqMk4fuUjpKpmbMQSJeps