### PR TITLE
fix: surface Keychain save failures in the Connect sudo overlay

### DIFF
--- a/src/lib/keychain.ts
+++ b/src/lib/keychain.ts
@@ -27,11 +27,20 @@ async function security(args: string[]): Promise<{ ok: boolean; stdout: string; 
   }
 }
 
-// Store (or update) a server's sudo password. Returns false off macOS / on failure.
-export async function setSudoPassword(serverId: number, password: string): Promise<boolean> {
-  if (!keychainAvailable()) return false
+export interface KeychainWriteResult {
+  ok: boolean
+  // `security`'s own error line (e.g. "User interaction is not allowed." when the
+  // login keychain is locked) — set whenever ok is false and on macOS, so the
+  // caller can show the real reason instead of a silent no-op.
+  error?: string
+}
+
+// Store (or update) a server's sudo password. ok:false off macOS / on failure.
+export async function setSudoPassword(serverId: number, password: string): Promise<KeychainWriteResult> {
+  if (!keychainAvailable()) return { ok: false }
   const r = await security(["add-generic-password", "-U", "-s", SERVICE, "-a", account(serverId), "-w", password])
-  return r.ok
+  if (r.ok) return { ok: true }
+  return { ok: false, error: r.stderr.trim().replace(/^security:\s*/, "") || "the Keychain write failed" }
 }
 
 // Retrieve a server's sudo password, or null if absent / denied / off macOS. The first

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -649,8 +649,8 @@ interface StoreValue extends DataState {
   sudoConnectServer: Server | null
   setSudoConnectServer: (s: Server | null) => void
   isSudoConnected: (serverId: number) => boolean
-  connectSudo: (server: Server, user: string, password: string, remember?: boolean) => Promise<{ ok: true } | { ok: false; error: string }>
-  connectSudoFromKeychain: (server: Server) => Promise<{ ok: true } | { ok: false; error: string }>
+  connectSudo: (server: Server, user: string, password: string, remember?: boolean) => Promise<{ ok: true; keychainError?: string } | { ok: false; error: string }>
+  connectSudoFromKeychain: (server: Server) => Promise<{ ok: true; keychainError?: string } | { ok: false; error: string }>
   disconnectSudo: (serverId: number) => void
   sudoSavedFor: (serverId: number) => boolean // a sudo password is saved in the Keychain
   forgetSudoKeychain: (serverId: number) => Promise<void>
@@ -1783,17 +1783,21 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   // (opt-in, macOS) the password into the Keychain. `remember` toggles Keychain
   // storage — unchecking it on a server that had one saved removes it.
   const finishConnect = useCallback(
-    async (server: Server, sudoUser: string, password: string, remember: boolean) => {
+    async (server: Server, sudoUser: string, password: string, remember: boolean): Promise<{ keychainError?: string }> => {
       sudoPwRef.current.set(server.id, password)
       setSudoConnected((prev) => new Set(prev).add(server.id))
       const users = new Map(sudoUsers).set(server.id, sudoUser)
       setSudoUsers(users)
       let saved = sudoSaved
+      let keychainError: string | undefined
       if (keychainAvailable()) {
         if (remember && !sudoSaved.has(server.id)) {
-          if (await setSudoPassword(server.id, password)) saved = new Set(sudoSaved).add(server.id)
+          const r = await setSudoPassword(server.id, password)
+          if (r.ok) saved = new Set(sudoSaved).add(server.id)
+          else keychainError = r.error
         } else if (remember && sudoSaved.has(server.id)) {
-          await setSudoPassword(server.id, password) // refresh in case the password changed
+          const r = await setSudoPassword(server.id, password) // refresh in case the password changed
+          if (!r.ok) keychainError = r.error
         } else if (!remember && sudoSaved.has(server.id)) {
           await deleteSudoPassword(server.id)
           saved = new Set(sudoSaved)
@@ -1802,6 +1806,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         if (saved !== sudoSaved) setSudoSaved(saved)
       }
       persistSudoMeta(users, saved)
+      return { keychainError }
     },
     [sudoUsers, sudoSaved, persistSudoMeta],
   )
@@ -1810,13 +1815,13 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   // connected, hold the password in memory, persist the username, and optionally save
   // the password to the Keychain. Returns the verify result so the overlay shows pass/fail.
   const connectSudo = useCallback(
-    async (server: Server, user: string, password: string, remember = false): Promise<{ ok: true } | { ok: false; error: string }> => {
+    async (server: Server, user: string, password: string, remember = false): Promise<{ ok: true; keychainError?: string } | { ok: false; error: string }> => {
       const sudoUser = user.trim()
       if (!sudoUser) return { ok: false, error: "Enter a sudo username." }
       const res = await verifySudo(server, { sudoUser, sudoPassword: password })
       if (!res.ok) return res
-      await finishConnect(server, sudoUser, password, remember)
-      return { ok: true }
+      const { keychainError } = await finishConnect(server, sudoUser, password, remember)
+      return { ok: true, keychainError }
     },
     [finishConnect],
   )
@@ -1824,15 +1829,15 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   // Auto-connect from the Keychain (the `S` overlay calls this on open when a password
   // is saved). Retrieve → verify → connect, all without prompting for the password.
   const connectSudoFromKeychain = useCallback(
-    async (server: Server): Promise<{ ok: true } | { ok: false; error: string }> => {
+    async (server: Server): Promise<{ ok: true; keychainError?: string } | { ok: false; error: string }> => {
       const sudoUser = sudoUsers.get(server.id)
       if (!sudoUser) return { ok: false, error: "No saved sudo user for this server." }
       const password = await getSudoPassword(server.id)
       if (password == null) return { ok: false, error: "Couldn't read the saved password from the Keychain." }
       const res = await verifySudo(server, { sudoUser, sudoPassword: password })
       if (!res.ok) return res
-      await finishConnect(server, sudoUser, password, true)
-      return { ok: true }
+      const { keychainError } = await finishConnect(server, sudoUser, password, true)
+      return { ok: true, keychainError }
     },
     [sudoUsers, finishConnect],
   )

--- a/src/ui/views/SudoConnect.tsx
+++ b/src/ui/views/SudoConnect.tsx
@@ -46,6 +46,9 @@ export function SudoConnect() {
   const [pwInput, setPwInput] = useState("")
   const [remember, setRemember] = useState(saved) // keep the box checked for already-saved servers
   const [error, setError] = useState<string | null>(null)
+  // Sudo itself connected fine, but "Remember in Keychain" silently failed (e.g. a
+  // locked login keychain) — distinct from `error`, which blocks the connection.
+  const [keychainWarning, setKeychainWarning] = useState<string | null>(null)
 
   // Auto-unlock from the Keychain once, when we open on a saved server.
   const unlockTried = useRef(false)
@@ -53,8 +56,10 @@ export function SudoConnect() {
     if (unlockTried.current || phase !== "unlocking" || !server) return
     unlockTried.current = true
     void connectSudoFromKeychain(server).then((res) => {
-      if (res.ok) setPhase("connected")
-      else {
+      if (res.ok) {
+        setKeychainWarning(res.keychainError ?? null)
+        setPhase("connected")
+      } else {
         setError(`Keychain unlock failed: ${res.error}`)
         setUserInput(savedUser ?? "")
         setField("password")
@@ -84,9 +89,11 @@ export function SudoConnect() {
       setPwInput("") // don't keep the secret in component state past the attempt
       if (res.ok) {
         setError(null)
+        setKeychainWarning(res.keychainError ?? null)
         setPhase("connected")
       } else {
         setError(res.error)
+        setKeychainWarning(null)
         setPhase("error")
       }
     })
@@ -99,6 +106,7 @@ export function SudoConnect() {
     if (phase === "connected") {
       if ((name === "x" || name === "d") && server) {
         disconnectSudo(server.id)
+        setKeychainWarning(null)
         // Saved in the Keychain → drop the session but offer a no-password
         // reconnect instead of making them re-type a password we already hold.
         if (saved && keychainAvailable) return setPhase("reconnect")
@@ -211,7 +219,13 @@ export function SudoConnect() {
             <text content="Privileged actions on this server run for the rest of this" fg={theme.textDim} wrapMode="none" />
             <text content="session — press K on a site to grant SpinupTUI's SSH key." fg={theme.textDim} wrapMode="none" />
             <box style={{ height: 1 }} />
-            {saved ? (
+            {keychainWarning ? (
+              <>
+                <text content={`⚠ Couldn't save to the Keychain: ${keychainWarning}`} fg={theme.warn} wrapMode="none" />
+                <text content="Connected for this session only — check whether your login" fg={theme.textFaint} wrapMode="none" />
+                <text content="keychain is locked, then reconnect." fg={theme.textFaint} wrapMode="none" />
+              </>
+            ) : saved ? (
               <>
                 <text content="Saved in the macOS Keychain — sudo unlocks automatically" fg={theme.textFaint} wrapMode="none" />
                 <text content="next time you open this server. Press f to forget it." fg={theme.textFaint} wrapMode="none" />


### PR DESCRIPTION
## Summary
- `setSudoPassword()` discarded the `security` CLI's stderr and returned a bare boolean, so a locked login keychain (or any other Keychain write failure) failed silently — the "Remember in macOS Keychain" checkbox looked accepted but nothing persisted, and the connected panel fell back to the generic "kept in memory only" copy with no indication anything had gone wrong.
- `setSudoPassword` now returns `{ ok, error? }` carrying the real `security` error line (e.g. "User interaction is not allowed." when the login keychain is locked).
- `connectSudo`/`connectSudoFromKeychain` thread it through as a non-fatal `keychainError` — the sudo connection itself still succeeds even if the Keychain write failed — and the "Sudo connected" panel now shows it as a distinct amber warning instead of silently reverting to the unsaved-password message.

## Test plan
- [x] `bun run typecheck` passes
- [ ] Live-verify on the machine that surfaced this (locked login keychain) once released

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zqMk4fuUjpKpmbMQSJeps