### PR TITLE
fix: unify Site Control keys between the Servers and Search tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+### Fixed
+- **Site Control keys now behave the same in the Servers tab and Search.** The
+  shared Site Control legend was written against Search's bindings, but the
+  Servers tab silently diverged on several of them:
+  - `p` pulls the production DB in both views (Servers tab had it opening the
+    plugins/themes inventory instead, despite the legend saying "Pull prod.
+    DB"); plugins/themes moves to `e` in both.
+  - `d` runs a DB backup in both views (Servers tab had it running the Tier-2
+    stack-identify probe instead); that probe moves to `f`, added to Search
+    too (previously Servers-tab-only and not listed anywhere).
+  - `m` runs the production media-fallback action in both views (Servers tab
+    had no such binding at all; `m` aliased to Monitoring there instead).
+  - `a` (reboot/restart) now works with a site focused in the Servers tab, not
+    just the top-level server list — it was a silent no-op in that context.
+  - `K` (grant SSH key) is now wired up in Search — it was in the legend but
+    had no handler there at all.
+
 ## [0.22.2] - 2026-07-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -247,30 +247,31 @@ These can be set in `config.json` or via an environment variable:
 | `g` / `G` | Jump to top / bottom |
 | `o` | Open the selected site in your browser |
 | `s` | Open a terminal and SSH into the selected site |
-| `d` | Download a production DB backup into the linked copy (Search; WordPress + linked) |
-| `p` | Pull the production DB into the linked copy — overwrites local; opt-in via `localSync` (Search) |
-| `m` | Production media fallback: serve missing-locally images from production (Search; WordPress + linked) |
+| `d` | Download a production DB backup into the linked copy (Servers / Search; WordPress + linked) |
+| `p` | Pull the production DB into the linked copy — overwrites local; opt-in via `localSync` (Servers / Search) |
+| `m` | Production media fallback: serve missing-locally images from production (Servers / Search; WordPress + linked) |
 | `L` | Link / edit a site's local working copy |
 | `t` / `v` | Open the linked copy in a terminal / its local URL in your browser |
 | `n` | DNS migration view for a site — its records + TTLs (`⏎` edits a TTL; `p` repoints the record; `a` shows the whole server) |
 | `N` | DNS migration view for the whole server |
 | `h` | Live server health (CPU/mem/disk over SSH) |
-| `p` | List a site's installed plugins & themes over SSH — version + updates (Servers tab, sites pane) |
-| `d` | Detect a site's stack via SSH (Servers / Stacks tabs) |
-| `D` | Detect every site in the selected stack (Stacks tab) |
+| `e` | List a site's installed plugins & themes over SSH — version + updates (Servers / Search) |
+| `f` | Identify a site's stack via SSH (Servers / Search) — same action as Stacks' `d`/`D` below |
+| `d` | Identify a site's stack via SSH (Stacks tab only — `d` is DB backup in Servers/Search, above) |
+| `D` | Identify every site in the selected stack (Stacks tab) |
 | `S` | Auto-discover & batch-link local copies (Stacks tab) |
-| `f` | Report sites with no usable local copy (Stacks tab) |
+| `f` | Report sites with no usable local copy (Stacks tab only — `f` identifies a site's stack in Servers/Search, above) |
 | `u` | Upgrade a site's PHP version (Servers / Stacks / Search; needs a Read/Write token) |
 | `H` | Enable / disable HTTPS on a site (Servers / Stacks / Search; needs a Read/Write token) |
 | `P` | Purge a site's page cache + object cache (Servers / Stacks / Search; needs a Read/Write token) |
-| `m` / `M` | Site/server monitoring — a two-pane browser of this site's Uptime Kuma monitors (`M` is an alias, since lowercase `m` is taken in Search/Stacks). Inside: `↑`/`↓` selects a monitor, `a` registers/recalibrates/repairs it (Front page and Cache bypass open a check-window picker), `x` removes Front page or Cache bypass, `o` opens the selected monitor in Kuma, `d` runs the site doctor, `n` shows/edits alert wiring, and vanity sites add `R`/`r` for page refresh/secret rotation (Servers / Stacks / Search) |
-| `R` | Refresh a vanity page's HTML to the currently bundled version — no need to open `m` first. Shown under Vanity in the Servers tab's Control strip and Search's Actions list, for the one site per server whose domain is the server's own hostname |
+| `M` | Site/server monitoring — a two-pane browser of this site's Uptime Kuma monitors (capital, since lowercase `m` is media fallback in Servers/Search). Inside: `↑`/`↓` selects a monitor, `a` registers/recalibrates/repairs it (Front page and Cache bypass open a check-window picker), `x` removes Front page or Cache bypass, `o` opens the selected monitor in Kuma, `d` runs the site doctor, `n` shows/edits alert wiring, and vanity sites add `R`/`r` for page refresh/secret rotation (Servers / Stacks / Search) |
+| `R` | Refresh a vanity page's HTML to the currently bundled version — no need to open `M` first. Shown under Vanity in the Servers tab's Control strip and Search's Actions list, for the one site per server whose domain is the server's own hostname |
 | `a` | Server actions: reboot / restart a service (Servers / Search; needs a Read/Write token) |
 | `c` | Create a new server (Servers tab; needs a Read/Write token) |
 | `V` | Add a vanity site at the server's own hostname — DNS + site + HTTPS + SSH-key handoff (Servers tab; offered when no hostname site exists; needs a Read/Write token) |
 | `C` | Clone a server's sites to a new/existing destination (Servers tab; needs a Read/Write token + sudo) |
 | `S` | Connect sudo on a server for privileged writes — optionally remembered in the macOS Keychain (Servers tab) |
-| `K` | Grant / revoke an SSH key on a site, or every site on the server (needs sudo connected) |
+| `K` | Grant / revoke an SSH key on a site, or every site on the server (Servers / Search; needs sudo connected) |
 | `w` | Open the selected server/site in the SpinupWP web app |
 | `/` | Jump to global search |
 | `r` | Refresh data from the API |

--- a/src/ui/components.tsx
+++ b/src/ui/components.tsx
@@ -427,9 +427,10 @@ export function ControlPanel({ heading, groups, layout = "list" }: { heading: st
 // since the group label is always visible right next to them (as its own column
 // in layout="flow", or its own line in layout="list").
 //
-// The DB backup/sync use wp-cli, so they only apply to WordPress sites — omitted
-// for non-WP sites (their `d`/`p` keypresses are also guarded in the handler). DNS
-// (`n`) and the rest apply to any site. `isVanity` (the site's domain equals its
+// The DB backup/sync and plugins/themes inventory all use wp-cli, so they only
+// apply to WordPress sites — omitted for non-WP sites (their `d`/`p`/`e`
+// keypresses are also guarded in the handler). DNS (`n`) and the rest apply to
+// any site. `isVanity` (the site's domain equals its
 // own server's name, per `isVanityPair`) adds the one-off page-refresh action —
 // vanity pages seeded before this app existed need a way to pick up the current
 // bundled HTML.
@@ -442,6 +443,7 @@ export function siteGroups(isWordpress: boolean, localSync: boolean, isVanity: b
   if (isWordpress) {
     remote.push(["d", "↓ DB backup"])
     if (localSync) remote.push(["p", "Pull prod. DB"])
+    remote.push(["e", "Plugins & themes"])
   }
   const local: [string, string][] = [
     ["t", "Terminal"],

--- a/src/ui/components.tsx
+++ b/src/ui/components.tsx
@@ -439,6 +439,7 @@ export function siteGroups(isWordpress: boolean, localSync: boolean, isVanity: b
     ["s", "SSH"],
     ["K", "Grant SSH key"],
     ["n", "DNS"],
+    ["f", "Identify app"],
   ]
   if (isWordpress) {
     remote.push(["d", "↓ DB backup"])

--- a/src/ui/views/Browser.tsx
+++ b/src/ui/views/Browser.tsx
@@ -23,7 +23,7 @@ type Focus = "servers" | "sites"
 
 export function Browser({ rows }: { rows: number }) {
   const store = useStore()
-  const { servers, sitesForServer, route, inputMode, overlayOpen, setHealthServer, setWpInventorySite, runProbe, probes, accountSlug, setPhpUpgradeSite, phpUpgrades, setHttpsToggleSite, setPurgeCacheSite, setGrantKeySite, setSudoConnectServer, isSudoConnected, setServerActionsServer, serverOps, setLocalLinkSite, openLocalTerminal, openLocalUrl, sshSite, setDnsInventoryServer, setNewServerSource, setNewServerOpen, setVanityServer, vanityJob, beginClone, isServerOsEol, setKumaSite, kumaConfigured, startKumaSetup, startVanityReseed, setDbSyncSite, localSync, localLinks } = store
+  const { servers, sitesForServer, route, inputMode, overlayOpen, setHealthServer, setWpInventorySite, runProbe, probes, accountSlug, setPhpUpgradeSite, phpUpgrades, setHttpsToggleSite, setPurgeCacheSite, setGrantKeySite, setSudoConnectServer, isSudoConnected, setServerActionsServer, serverOps, setLocalLinkSite, openLocalTerminal, openLocalUrl, sshSite, setDnsInventoryServer, setNewServerSource, setNewServerOpen, setVanityServer, vanityJob, beginClone, isServerOsEol, setKumaSite, kumaConfigured, startKumaSetup, startVanityReseed, setDbSyncSite, localSync, localLinks, setDbBackupSite, setMediaFallbackSite } = store
 
   const [serverIndex, setServerIndex] = useState(0)
   const [siteIndex, setSiteIndex] = useState(0)
@@ -89,8 +89,25 @@ export function Browser({ rows }: { rows: number }) {
           setTimeout(() => setFlash(null), 1500)
         }
         return
-      case "d":
-        // Detect the selected site's stack via SSH (Tier 2); shows in Details.
+      case "d": {
+        // DB backup uses wp-cli on the remote and downloads into the linked copy,
+        // so it needs a WordPress site and a local link. Same gate as Search's d.
+        const s = focus === "sites" ? sites[siteIndex] : undefined
+        if (!s) return
+        if (!s.is_wordpress) {
+          setFlash("Database backup needs WordPress (wp-cli) — this isn't a WP site")
+        } else if (!localLinks.has(s.id)) {
+          setFlash("Not linked — press L to link a local copy")
+        } else {
+          setDbBackupSite(s)
+          return
+        }
+        setTimeout(() => setFlash(null), 1500)
+        return
+      }
+      case "f":
+        // Identify the selected site's stack via SSH (Tier 2); shows in Details.
+        // Same action as Search's f and Stacks' d/D.
         if (focus === "sites" && sites[siteIndex]) {
           const s = sites[siteIndex]
           runProbe(s)
@@ -110,13 +127,27 @@ export function Browser({ rows }: { rows: number }) {
         // Purge page cache + object cache on the selected site.
         if (focus === "sites" && sites[siteIndex]) setPurgeCacheSite(sites[siteIndex])
         return
-      case "m":
       case "M":
         // Uptime Kuma monitoring for the selected site (connect on first use).
-        // M is an alias: it's the binding Search/Stacks use (their lowercase m
-        // is taken), so the capital works everywhere.
+        // Capital because lowercase m is media fallback here, matching Search.
         if (focus === "sites" && sites[siteIndex]) setKumaSite(sites[siteIndex])
         return
+      case "m": {
+        // Production media fallback: drops a mu-plugin into the linked local copy,
+        // so it needs a WordPress site and a local link (same gate as d).
+        const s = focus === "sites" ? sites[siteIndex] : undefined
+        if (!s) return
+        if (!s.is_wordpress) {
+          setFlash("Media fallback needs WordPress — this isn't a WP site")
+        } else if (!localLinks.has(s.id)) {
+          setFlash("Not linked — press L to link a local copy")
+        } else {
+          setMediaFallbackSite(s)
+          return
+        }
+        setTimeout(() => setFlash(null), 1500)
+        return
+      }
       case "R": {
         // Refresh a vanity page's HTML — only the one site per server whose
         // domain equals the server's own name. Same binding/behavior as the
@@ -202,10 +233,11 @@ export function Browser({ rows }: { rows: number }) {
         if (server) setSudoConnectServer(server)
         return
       case "a":
-        // Server actions (reboot / restart) are server-scoped, so only offered
-        // when the Servers pane is focused — when you've drilled into a site,
-        // the context is the site (server actions are dropped there).
-        if (focus === "servers" && server) setServerActionsServer(server)
+        // Server actions (reboot / restart) — on the server, or a site's server
+        // (mirrors Search's a, which derives the server from whichever result
+        // kind is selected). `server` is already scoped to whichever server the
+        // focused pane's rows belong to, so this works unchanged from either pane.
+        if (server) setServerActionsServer(server)
         return
       case "c":
         // Create a new server. Seed from the highlighted server when there is one;

--- a/src/ui/views/Browser.tsx
+++ b/src/ui/views/Browser.tsx
@@ -23,7 +23,7 @@ type Focus = "servers" | "sites"
 
 export function Browser({ rows }: { rows: number }) {
   const store = useStore()
-  const { servers, sitesForServer, route, inputMode, overlayOpen, setHealthServer, setWpInventorySite, runProbe, probes, accountSlug, setPhpUpgradeSite, phpUpgrades, setHttpsToggleSite, setPurgeCacheSite, setGrantKeySite, setSudoConnectServer, isSudoConnected, setServerActionsServer, serverOps, setLocalLinkSite, openLocalTerminal, openLocalUrl, sshSite, setDnsInventoryServer, setNewServerSource, setNewServerOpen, setVanityServer, vanityJob, beginClone, isServerOsEol, setKumaSite, kumaConfigured, startKumaSetup, startVanityReseed } = store
+  const { servers, sitesForServer, route, inputMode, overlayOpen, setHealthServer, setWpInventorySite, runProbe, probes, accountSlug, setPhpUpgradeSite, phpUpgrades, setHttpsToggleSite, setPurgeCacheSite, setGrantKeySite, setSudoConnectServer, isSudoConnected, setServerActionsServer, serverOps, setLocalLinkSite, openLocalTerminal, openLocalUrl, sshSite, setDnsInventoryServer, setNewServerSource, setNewServerOpen, setVanityServer, vanityJob, beginClone, isServerOsEol, setKumaSite, kumaConfigured, startKumaSetup, startVanityReseed, setDbSyncSite, localSync, localLinks } = store
 
   const [serverIndex, setServerIndex] = useState(0)
   const [siteIndex, setSiteIndex] = useState(0)
@@ -168,7 +168,27 @@ export function Browser({ rows }: { rows: number }) {
         // DNS inventory scoped to the selected site (its domains + records).
         if (focus === "sites" && sites[siteIndex] && server) setDnsInventoryServer(server, sites[siteIndex].id)
         return
-      case "p":
+      case "p": {
+        // Pull production → local (opt-in, overwrites the local DB): needs a
+        // WordPress site, localSync enabled, and a linked local copy. Same
+        // gate as Search's `p` (Search.tsx) so the Site Control legend's
+        // "Pull prod. DB" label is accurate here too.
+        const s = focus === "sites" ? sites[siteIndex] : undefined
+        if (!s) return
+        if (!localSync) {
+          setFlash('Local sync is off — set "localSync": true in config to enable')
+        } else if (!s.is_wordpress) {
+          setFlash("Sync needs WordPress (wp-cli) — this isn't a WP site")
+        } else if (!localLinks.has(s.id)) {
+          setFlash("Not linked — press L to link a local copy")
+        } else {
+          setDbSyncSite(s)
+          return
+        }
+        setTimeout(() => setFlash(null), 1500)
+        return
+      }
+      case "e":
         // Plugins & themes (wp-cli over SSH) for the selected site.
         if (focus === "sites" && sites[siteIndex]) setWpInventorySite(sites[siteIndex])
         return

--- a/src/ui/views/Search.tsx
+++ b/src/ui/views/Search.tsx
@@ -35,7 +35,7 @@ function score(haystack: string, q: string): number | null {
 
 export function Search({ rows }: { rows: number }) {
   const store = useStore()
-  const { servers, sites, serverById, setInputMode, setRoute, route, overlayOpen, setHealthServer, setPhpUpgradeSite, setHttpsToggleSite, setPurgeCacheSite, setServerActionsServer, accountSlug, localLinks, setLocalLinkSite, openLocalTerminal, openLocalUrl, sshSite, setDnsInventoryServer, setDbBackupSite, dbBackups, setDbSyncSite, dbSyncs, localSync, setMediaFallbackSite, beginClone, setSudoConnectServer, setKumaSite, kumaConfigured, startKumaSetup, startVanityReseed } = store
+  const { servers, sites, serverById, setInputMode, setRoute, route, overlayOpen, setHealthServer, setPhpUpgradeSite, setHttpsToggleSite, setPurgeCacheSite, setServerActionsServer, accountSlug, localLinks, setLocalLinkSite, openLocalTerminal, openLocalUrl, sshSite, setDnsInventoryServer, setDbBackupSite, dbBackups, setDbSyncSite, dbSyncs, localSync, setMediaFallbackSite, beginClone, setSudoConnectServer, setKumaSite, kumaConfigured, startKumaSetup, startVanityReseed, setWpInventorySite } = store
   const [query, setQuery] = useState("")
   const [selected, setSelected] = useState(0)
   // "query" = typing/filtering (input focused); "actions" = input blurred so the
@@ -181,6 +181,10 @@ export function Search({ rows }: { rows: number }) {
           else if (!localLinks.has(current.site.id)) flashMsg("Not linked — press L to link a local copy")
           else setDbSyncSite(current.site)
         }
+        return
+      case "e":
+        // Plugins & themes (wp-cli over SSH) for the selected site.
+        if (current?.kind === "site") setWpInventorySite(current.site)
         return
       case "m":
         // Production media fallback: drops a mu-plugin into the linked local copy,

--- a/src/ui/views/Search.tsx
+++ b/src/ui/views/Search.tsx
@@ -35,7 +35,7 @@ function score(haystack: string, q: string): number | null {
 
 export function Search({ rows }: { rows: number }) {
   const store = useStore()
-  const { servers, sites, serverById, setInputMode, setRoute, route, overlayOpen, setHealthServer, setPhpUpgradeSite, setHttpsToggleSite, setPurgeCacheSite, setServerActionsServer, accountSlug, localLinks, setLocalLinkSite, openLocalTerminal, openLocalUrl, sshSite, setDnsInventoryServer, setDbBackupSite, dbBackups, setDbSyncSite, dbSyncs, localSync, setMediaFallbackSite, beginClone, setSudoConnectServer, setKumaSite, kumaConfigured, startKumaSetup, startVanityReseed, setWpInventorySite } = store
+  const { servers, sites, serverById, setInputMode, setRoute, route, overlayOpen, setHealthServer, setPhpUpgradeSite, setHttpsToggleSite, setPurgeCacheSite, setServerActionsServer, accountSlug, localLinks, setLocalLinkSite, openLocalTerminal, openLocalUrl, sshSite, setDnsInventoryServer, setDbBackupSite, dbBackups, setDbSyncSite, dbSyncs, localSync, setMediaFallbackSite, beginClone, setSudoConnectServer, setKumaSite, kumaConfigured, startKumaSetup, startVanityReseed, setWpInventorySite, setGrantKeySite, runProbe } = store
   const [query, setQuery] = useState("")
   const [selected, setSelected] = useState(0)
   // "query" = typing/filtering (input focused); "actions" = input blurred so the
@@ -160,6 +160,11 @@ export function Search({ rows }: { rows: number }) {
       case "L":
         if (current?.kind === "site") setLocalLinkSite(current.site)
         return
+      case "K":
+        // Grant Spinup's machine key to the selected site over SSH — matches
+        // Browser's K binding, which was already in the shared legend here.
+        if (current?.kind === "site") setGrantKeySite(current.site)
+        return
       case "s":
         if (current?.kind === "site") flashMsg(sshSite(current.site.id))
         return
@@ -214,6 +219,14 @@ export function Search({ rows }: { rows: number }) {
         if (current?.kind === "site") {
           const srv = serverById(current.site.server_id)
           if (srv) setDnsInventoryServer(srv, current.site.id)
+        }
+        return
+      case "f":
+        // Identify the selected site's stack via SSH (Tier 2) — same action as
+        // Browser's f and Stacks' d/D.
+        if (current?.kind === "site") {
+          runProbe(current.site)
+          flashMsg(`Identifying the app on ${current.site.domain}…`)
         }
         return
       case "h": {


### PR DESCRIPTION
## Summary

- `p` in the Servers tab was labeled "Pull prod. DB" in the shared Site Control legend but actually opened the plugins/themes inventory instead — DB pull was never wired up there at all. `p` now pulls the production DB in both the Servers and Search tabs; plugins/themes moves to `e` in both.
- Auditing that bug turned up the same pattern on more keys: the shared legend was written against Search's bindings, and the Servers tab silently diverged on several of them.
  - `d` now runs a DB backup in both views (Servers tab had it running the Tier-2 stack-identify probe instead); that probe moves to `f`, and is now also available in Search (previously Servers-tab-only and not listed anywhere).
  - `m` now runs the production media-fallback action in both views (Servers tab had no such binding at all; `m` aliased to Monitoring there instead).
  - `a` (reboot/restart) now works with a site focused in the Servers tab, not just the top-level server list — it was a silent no-op in that context before.
  - `K` (grant SSH key) is now wired up in Search — it was in the legend but had no handler there at all.
- CHANGELOG and README's Keybindings table updated to match.

## Test plan

- [x] Live-tested `p` (pull prod DB) end-to-end against a real site, including diagnosing and fixing two unrelated local-environment blockers along the way (a stale PATH resolving an old PHP/wp-cli via login shells, and a keg-only `mysql-client` Homebrew formula missing `mysqldump` from PATH)
- [x] Live-verified `e` (plugins/themes), `f` (identify stack), and the Site Control legend now show accurate labels in both the Servers and Search tabs
- [x] `bun run typecheck` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qqYUreRV622799pV5u3rG