### PR TITLE
feat: detect and label Radicle as its own stack (Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+### Added
+- **Radicle sites are now detected and labeled as their own stack**, instead of
+  being misclassified as Bedrock. Radicle (Roots' Bedrock+Sage+Acorn+Trellis
+  starter) shares Bedrock's `roots/bedrock-autoloader` dependency, which was
+  tripping a naive `roots/bedrock` string match; detection now keys off
+  `roots/acorn` instead — the package that actually makes a site Radicle.
+  Radicle only surfaces via the on-demand SSH probe (`f` in the Servers/Search
+  tabs, `d`/`D` in Stacks) — its `/public/` webroot alone is indistinguishable
+  from a hardened Standard-WP `/public/` layout. DB backup/sync, plugin/theme
+  inventory, and local working-copy linking already worked on Radicle sites
+  (their path detection was already stack-agnostic); this release just adds
+  the missing name. Clone-wizard support for Radicle is a separate, not-yet-
+  built follow-up.
+
+### Fixed
+- A few README/docs mentions of `p` (plugins & themes) and `m` (monitoring)
+  that slipped through the previous release's key-unification work —
+  corrected to `e` and `M`, and scope notes broadened from "Search tab" to
+  "Servers / Search tabs" where applicable.
+
 ## [0.22.3] - 2026-07-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -34,23 +34,23 @@
   whatever's selected — Site Control or Server Control, grouped and always
   visible, no hidden key combos.
 - **Stack detection & fleet composition** — classifies every site as Standard WP,
-  Bedrock, or Non-WP, with a PHP-version breakdown and an on-demand SSH probe for
-  precise identification. → [docs/stack-detection.md](docs/stack-detection.md)
+  Bedrock, Radicle, or Non-WP, with a PHP-version breakdown and an on-demand SSH
+  probe for precise identification. → [docs/stack-detection.md](docs/stack-detection.md)
 - **Global search** — fuzzy search across every server and site by name, domain,
   or IP, with inline actions on the result.
 - **Events feed** — recent provisioning/operation activity with per-event detail.
 - **Live server health** (`h`) — real-time CPU/load/memory/disk over SSH.
   → [docs/server-health.md](docs/server-health.md)
-- **Installed plugins & themes** (`p`) — real `wp plugin`/`theme list` over SSH,
+- **Installed plugins & themes** (`e`) — real `wp plugin`/`theme list` over SSH,
   with per-item version and update status. → [docs/plugins-themes.md](docs/plugins-themes.md)
 - **Open in browser** (`o`) / **SSH into a site** (`s`) — one-key shortcuts.
 - **Link local working copies** (`L`) — link a site to its local checkout, with
   auto-discovery and git-drift indicators. → [docs/local-working-copies.md](docs/local-working-copies.md)
 - **DNS migration lens** (`n` / `N`) — see and edit a site's hosting records,
   repoint it to another server. → [docs/dns-access-editing.md](docs/dns-access-editing.md)
-- **Database backup & sync** (`d` / `p`, Search tab) — download or pull a
-  production DB into a linked local copy. → [docs/database-backup-sync.md](docs/database-backup-sync.md)
-- **Production media fallback** (`m`, Search tab) — serve missing-locally images
+- **Database backup & sync** (`d` / `p`, Servers / Search tabs) — download or
+  pull a production DB into a linked local copy. → [docs/database-backup-sync.md](docs/database-backup-sync.md)
+- **Production media fallback** (`m`, Servers / Search tabs) — serve missing-locally images
   from production after a DB pull. → [docs/production-media-fallback.md](docs/production-media-fallback.md)
 - **Upgrade a site's PHP version** (`u`) — pick a version, apply it, watch the
   event complete. → [docs/php-upgrade.md](docs/php-upgrade.md)
@@ -67,7 +67,7 @@
   [how it works](docs/clone-wizard-explained.md)
 - **Privileged writes over SSH** (`S` / `K`) — grant or revoke SSH keys directly,
   since the API can't. → [docs/privileged-ssh-writes.md](docs/privileged-ssh-writes.md)
-- **Site & server monitoring** (`m`) — a two-pane browser of a site's Uptime
+- **Site & server monitoring** (`M`) — a two-pane browser of a site's Uptime
   Kuma monitors (health, front-page fingerprint, an opt-in cache-bypass
   check, and, for vanity/server sites, load/Redis/PHP-fatal sentinels), each
   with a live status dot, an in-context explanation, and one action key to
@@ -292,14 +292,15 @@ processes — read-only, using your local SSH keys. Full details:
 
 ## Stack detection
 
-The **Stacks** tab (`3`) classifies every site as Standard WP, Bedrock, or Non-WP
-from API data alone, then lets you SSH-probe (`d` / `D`) for a precise ID (WHMCS,
-Laravel, Static HTML, WordPress version) that overrides a mislabeled guess. Full
-details: [docs/stack-detection.md](docs/stack-detection.md).
+The **Stacks** tab (`3`) classifies every site as Standard WP, Bedrock, Radicle,
+or Non-WP from API data alone (Radicle needs a probe to surface — see below),
+then lets you SSH-probe (`d` / `D`) for a precise ID (WHMCS, Laravel, Static
+HTML, WordPress version) that overrides a mislabeled guess. Full details:
+[docs/stack-detection.md](docs/stack-detection.md).
 
 ## Installed plugins & themes
 
-`p` on a site (Servers tab) lists its real `wp plugin`/`theme list` over SSH —
+`e` on a site (Servers / Search tabs) lists its real `wp plugin`/`theme list` over SSH —
 status, version, and available updates — the detail the API only gives as bare
 counts. Read-only, works on Bedrock and misclassified sites too. Full details:
 [docs/plugins-themes.md](docs/plugins-themes.md).
@@ -359,10 +360,10 @@ Stacks tab can auto-discover copies (`S`) and report sites still missing one
 
 ## Database backup & sync
 
-On a linked WordPress site (Search tab), `d` downloads a gzipped production DB
-backup into `sql/`; `p` (opt-in via `localSync`) pulls production into your
-**local** database, backing it up first and rewriting URLs. Works with
-Standard WP and Bedrock. Full details:
+On a linked WordPress site (Servers or Search tab), `d` downloads a gzipped
+production DB backup into `sql/`; `p` (opt-in via `localSync`) pulls production
+into your **local** database, backing it up first and rewriting URLs. Works
+with Standard WP, Bedrock, and Radicle. Full details:
 [docs/database-backup-sync.md](docs/database-backup-sync.md).
 
 ## Production media fallback

--- a/docs/database-backup-sync.md
+++ b/docs/database-backup-sync.md
@@ -1,6 +1,7 @@
 # Database backup & sync
 
-For a WordPress site you've **linked** to a local copy, the Search tab can pull
+For a WordPress site you've **linked** to a local copy, the Servers or Search tab
+can pull
 the production database down — the same idea as a hand-rolled `wp db export` +
 `scp`, without leaving the dashboard. Both actions are **read-only on production**
 (they export; they never write to the live site) and run `ssh`/`scp`

--- a/docs/plugins-themes.md
+++ b/docs/plugins-themes.md
@@ -1,6 +1,6 @@
 # Installed plugins & themes
 
-Press `p` on a site (Servers tab, sites pane) to list its installed plugins and
+Press `e` on a site (Servers / Search tabs) to list its installed plugins and
 themes over SSH — the `wp plugin list` / `wp theme list` detail the SpinupWP API
 never exposes (it only gives you *counts* of pending updates). You see every
 plugin and theme with its **status** (active / inactive / must-use / dropin),

--- a/docs/stack-detection.md
+++ b/docs/stack-detection.md
@@ -7,15 +7,21 @@ actually running where. It works in two tiers:
   already returns: **Non-WP**, **Bedrock** (WordPress with a `/web/` webroot), or
   **Standard WP**. The left pane shows counts and bars; the right pane shows the
   fleet-wide **PHP version distribution** with end-of-life versions flagged.
+  **Radicle** (Roots' Bedrock+Sage+Acorn starter) isn't in this tier — its
+  `/public/` webroot is indistinguishable at a glance from a hardened Standard-WP
+  `/public/` layout, so it only surfaces once Tier 2 confirms it.
 
-- **Tier 2 — on-demand SSH probe.** Press `d` on a site (in the Stacks or
-  Servers tab) to inspect its filesystem **read-only** and identify it precisely:
-  **WordPress** (with version), **Bedrock**, **WHMCS**, **Laravel**, or
-  **Static HTML**. Press `D` to probe an entire stack in list order (bounded SSH
-  concurrency). A conclusive probe **overrides** the Tier-1 guess — so a site the
-  API mislabels (e.g. WordPress installed outside SpinupWP's installer reports
-  `is_wordpress=false`) moves into its true bucket. The Non-WP bucket expands
-  into named sub-rows (WHMCS / Laravel / Static HTML / Unknown / unprobed).
+- **Tier 2 — on-demand SSH probe.** Press `d` on a site (Stacks tab) or `f`
+  (Servers / Search tabs) to inspect its filesystem **read-only** and identify it
+  precisely: **WordPress** (with version), **Bedrock**, **Radicle**, **WHMCS**,
+  **Laravel**, or **Static HTML**. Press `D` to probe an entire stack in list
+  order (bounded SSH concurrency). A conclusive probe **overrides** the Tier-1
+  guess — so a site the API mislabels (e.g. WordPress installed outside
+  SpinupWP's installer reports `is_wordpress=false`) moves into its true bucket.
+  Radicle is distinguished from Bedrock by its `roots/acorn` Composer dependency
+  — a bare `roots/bedrock` string match isn't enough, since Radicle also pulls
+  in `roots/bedrock-autoloader`. The Non-WP bucket expands into named sub-rows
+  (WHMCS / Laravel / Static HTML / Unknown / unprobed).
 
 Probes reuse the same SSH access as the health view (`site_user@ip`, your local
 keys, `BatchMode`) and are **read-only**. Results are cached to

--- a/src/lib/dbSync.ts
+++ b/src/lib/dbSync.ts
@@ -213,11 +213,13 @@ export async function runDbSync(plan: DbSyncPlan, domain: string, onProgress: (p
   const lb = await wp(`wp db export "${localSql}" >/dev/null && gzip -f "${localSql}"`, 300_000)
   if (lb.code !== 0) {
     // wp-cli's own "not a WordPress install" error is a common first-pull snag on a
-    // fresh checkout — a Bedrock project needs `composer install` to build vendor/ +
-    // web/wp before wp-cli (or wp-cli.yml) can find anything there at all. Appended
-    // after meaningfulError's own pick (not passed as its fallback), since that's
-    // only used when stderr has NO meaningful line — not the case here.
-    const hint = plan.localKind === "bedrock" && /does not seem to be a WordPress install/i.test(lb.stderr) ? " Run `composer install` in your local checkout first." : ""
+    // fresh checkout — a Bedrock or Radicle project needs `composer install` to
+    // build vendor/ + web/wp (or public/wp) before wp-cli (or wp-cli.yml) can find
+    // anything there at all. Appended after meaningfulError's own pick (not passed
+    // as its fallback), since that's only used when stderr has NO meaningful line
+    // — not the case here.
+    const needsComposer = plan.localKind === "bedrock" || plan.localKind === "radicle"
+    const hint = needsComposer && /does not seem to be a WordPress install/i.test(lb.stderr) ? " Run `composer install` in your local checkout first." : ""
     return fail(`Local DB backup failed — ${meaningfulError(lb.stderr, "couldn't export the local database.")}${hint}`, "local-backup")
   }
 

--- a/src/lib/local.ts
+++ b/src/lib/local.ts
@@ -34,7 +34,7 @@ export function normalizeLink(raw: LocalLink & { valetUrl?: string }): LocalLink
 
 // Resolution of a link against the filesystem, computed on demand (cheap — one
 // focused site at a time). `kind` mirrors the stack buckets used elsewhere.
-export type LocalKind = "bedrock" | "wp" | "unknown"
+export type LocalKind = "bedrock" | "radicle" | "wp" | "unknown"
 export interface LocalState {
   exists: boolean
   kind: LocalKind
@@ -82,6 +82,11 @@ export function findProjectRoot(dir: string): string {
 }
 
 // Classify a local working copy by reading a few marker files (read-only):
+//   Radicle = composer.json requiring roots/acorn (checked first: Radicle's
+//     composer.json also requires roots/bedrock-autoloader, so a bare
+//     "roots/bedrock" substring match below would misclassify it as Bedrock —
+//     roots/acorn is the package that actually makes a site Radicle, since
+//     plain Bedrock never requires it)
 //   Bedrock = composer.json requiring roots/bedrock, or config/application.php
 //   WordPress = wp-config.php at the root (or a public/ webroot)
 // Anything that exists but matches neither is "unknown".
@@ -89,7 +94,9 @@ function classify(dir: string): LocalKind {
   const composer = join(dir, "composer.json")
   if (existsSync(composer)) {
     try {
-      if (readFileSync(composer, "utf8").includes("roots/bedrock")) return "bedrock"
+      const contents = readFileSync(composer, "utf8")
+      if (contents.includes("roots/acorn")) return "radicle"
+      if (contents.includes("roots/bedrock")) return "bedrock"
     } catch {
       // unreadable composer.json — fall through to other markers
     }
@@ -101,6 +108,7 @@ function classify(dir: string): LocalKind {
 
 const KIND_LABEL: Record<LocalKind, string> = {
   bedrock: "Bedrock",
+  radicle: "Radicle",
   wp: "WordPress",
   unknown: "unrecognized",
 }

--- a/src/lib/probe.ts
+++ b/src/lib/probe.ts
@@ -20,7 +20,7 @@ import type { Server, Site } from "../api/types.ts"
 import { detectWpDirScript } from "./serverClone.ts"
 import { theme } from "./theme.ts"
 
-export type ProbeKind = "wordpress" | "bedrock" | "whmcs" | "laravel" | "static" | "unknown"
+export type ProbeKind = "wordpress" | "bedrock" | "radicle" | "whmcs" | "laravel" | "static" | "unknown"
 
 // `onSelection` brightens the colors that are too low-contrast on the focused
 // (bright-green) selection background — green-on-green and the faint greys.
@@ -30,6 +30,8 @@ export function probeKindColor(kind: ProbeKind, onSelection = false): string {
       return theme.accent
     case "bedrock":
       return onSelection ? theme.text : theme.good
+    case "radicle":
+      return onSelection ? theme.text : theme.purple
     case "whmcs":
       return theme.purple
     case "laravel":
@@ -89,8 +91,10 @@ function buildRemoteScript(domain: string, publicFolder: string | null): string 
     // script (WHMCS/index/WP-version checks) intentionally keeps using as-is.
     detectWpDirScript(root, publicFolder ?? undefined),
     `BEDROCKROOT="$B"`,
+    `RADICLEROOT="$RD"`,
     'F="$HOME/files"',
     `W="$HOME/files${pf}"`,
+    'echo ===RADICLE; [ -n "$RADICLEROOT" ] && echo yes || echo no',
     'echo ===BEDROCK; [ -n "$BEDROCKROOT" ] && echo yes || echo no',
     'echo ===APPLICATION; test -f "$F/config/application.php" && echo yes || echo no',
     'echo ===ARTISAN; test -f "$F/artisan" && echo yes || echo no',
@@ -169,6 +173,16 @@ export function classify(sig: Record<string, string>): ProbeResult {
 
   if (sig.WHMCSCONF === "yes" && sig.WHMCSVENDOR === "yes") {
     return { kind: "whmcs", app: "WHMCS", version: null, label: "WHMCS" }
+  }
+  // Checked before BEDROCK: Radicle's composer.json also requires
+  // roots/bedrock-autoloader, so it would otherwise match the Bedrock signal too.
+  if (sig.RADICLE === "yes") {
+    return {
+      kind: "radicle",
+      app: "Radicle",
+      version: wpVersion,
+      label: wpVersion ? `Radicle · WP ${wpVersion}` : "Radicle",
+    }
   }
   if (sig.BEDROCK === "yes" || sig.APPLICATION === "yes") {
     return {

--- a/src/lib/serverClone.ts
+++ b/src/lib/serverClone.ts
@@ -216,8 +216,12 @@ export function detectWpDirScript(root: string, publicFolder?: string): string {
     `[ -z "$W" ] && [ -f ${shq(candidate)}/wp/wp-settings.php ] && W=${shq(candidate)}/wp`,
     `[ -z "$W" ] && [ -f "$D/wp-settings.php" ] && W="$D"`,
     `[ -z "$W" ] && { F=$(find "$D" -maxdepth 3 -name wp-settings.php -not -path "*/wp-content/*" -print -quit 2>/dev/null); [ -n "$F" ] && W=$(dirname "$F"); }`,
-    `B=""`,
-    `[ -n "$W" ] && [ "$(basename "$W")" = "wp" ] && { P=$(dirname "$(dirname "$W")"); [ -f "$P/composer.json" ] && grep -q "roots/bedrock" "$P/composer.json" 2>/dev/null && B="$P"; }`,
+    `B=""; RD=""`,
+    // Radicle's composer.json also requires roots/bedrock-autoloader, so a bare
+    // "roots/bedrock" substring match (below) can't tell the two apart — check
+    // for roots/acorn first, the package that actually makes a site Radicle
+    // (plain Bedrock never requires it). $P is set by the same lookup either way.
+    `[ -n "$W" ] && [ "$(basename "$W")" = "wp" ] && { P=$(dirname "$(dirname "$W")"); [ -f "$P/composer.json" ] && { grep -q "roots/acorn" "$P/composer.json" 2>/dev/null && RD="$P"; grep -q "roots/bedrock" "$P/composer.json" 2>/dev/null && B="$P"; }; }`,
   ].join("; ")
 }
 

--- a/src/lib/stack.ts
+++ b/src/lib/stack.ts
@@ -23,10 +23,10 @@ import type { ProbeKind } from "./probe.ts"
 import { publicFolderRel } from "./serverClone.ts"
 import { theme } from "./theme.ts"
 
-export type Stack = "Standard WP" | "Bedrock" | "Non-WP"
+export type Stack = "Standard WP" | "Bedrock" | "Radicle" | "Non-WP"
 
 // All buckets in display order (kept stable so the Stacks view doesn't reflow).
-export const STACKS: Stack[] = ["Standard WP", "Bedrock", "Non-WP"]
+export const STACKS: Stack[] = ["Standard WP", "Bedrock", "Radicle", "Non-WP"]
 
 export function classifyStack(site: Site): Stack {
   if (!site.is_wordpress) return "Non-WP"
@@ -46,6 +46,11 @@ export function effectiveStack(site: Site, probeKind?: ProbeKind | null): Stack 
       return "Standard WP"
     case "bedrock":
       return "Bedrock"
+    case "radicle":
+      // Radicle's public/ webroot is indistinguishable from a hardened
+      // Standard-WP public/ layout at Tier-1 (public_folder alone), so this
+      // bucket only exists once Tier-2 (SSH probe) confirms roots/acorn.
+      return "Radicle"
     case "whmcs":
     case "laravel":
     case "static":
@@ -75,6 +80,10 @@ export function cloneStackFor(site: Site, probeKind?: ProbeKind | null): "wp" | 
     if (probeKind === "whmcs" || probeKind === "laravel" || probeKind === "static") return "files"
     return "bedrock"
   }
+  // A "radicle" probe never falls into "wp" here since effectiveStack maps it
+  // to "Radicle", not "Standard WP" — deliberate: the Standard-WP pull chain
+  // assumes a flat webroot and would corrupt a Radicle clone. Real Radicle
+  // clone-wizard support is a separate, not-yet-built phase (issue #38).
   return effectiveStack(site, probeKind) === "Standard WP" ? "wp" : "files"
 }
 
@@ -86,6 +95,8 @@ export function stackColor(stack: Stack, onSelection = false): string {
       return theme.accent // blue
     case "Bedrock":
       return onSelection ? theme.text : theme.good // green
+    case "Radicle":
+      return onSelection ? theme.text : theme.purple
     case "Non-WP":
       return onSelection ? theme.text : theme.textDim // gray
   }
@@ -98,6 +109,8 @@ export function stackTag(stack: Stack): string {
       return "wp"
     case "Bedrock":
       return "bedrock"
+    case "Radicle":
+      return "radicle"
     case "Non-WP":
       return "app"
   }

--- a/src/ui/Details.tsx
+++ b/src/ui/Details.tsx
@@ -6,7 +6,7 @@ import { formatBytes, diskUsedPct, bar, formatDate, timeAgo, truncate } from "..
 import { Field, StatusBadge, ControlPanel, siteGroups, type ActionGroup } from "./components.tsx"
 import { effectiveStack, stackColor } from "../lib/stack.ts"
 import { probeKindColor } from "../lib/probe.ts"
-import { resolveLocalLink, type LocalLink } from "../lib/local.ts"
+import { resolveLocalLink, type LocalLink, type LocalKind } from "../lib/local.ts"
 import { normalizeDomain } from "../lib/dns.ts"
 import { isVanityPair } from "../lib/vanitySite.ts"
 import type { Drift } from "../lib/gitStatus.ts"
@@ -320,8 +320,17 @@ function SiteDnsSection({ site }: { site: Site }) {
 }
 
 // Color for a resolved local stack label.
-function localLabelColor(kind: "bedrock" | "wp" | "unknown"): string {
-  return kind === "bedrock" ? theme.good : kind === "wp" ? theme.accent : theme.warn
+function localLabelColor(kind: LocalKind): string {
+  switch (kind) {
+    case "bedrock":
+      return theme.good
+    case "radicle":
+      return theme.purple
+    case "wp":
+      return theme.accent
+    case "unknown":
+      return theme.warn
+  }
 }
 
 // Compact, self-explaining git-drift label for a linked copy's line, e.g.

--- a/src/ui/views/Forgotten.tsx
+++ b/src/ui/views/Forgotten.tsx
@@ -30,7 +30,7 @@ interface Entry {
 }
 
 // Stack filter options the report can cycle through (← / →). null = all stacks.
-const STACK_FILTERS: (Stack | null)[] = [null, "Standard WP", "Bedrock", "Non-WP"]
+const STACK_FILTERS: (Stack | null)[] = [null, "Standard WP", "Bedrock", "Radicle", "Non-WP"]
 
 export function Forgotten() {
   const { sites, localLinks, probes, setForgottenOpen, setLocalLinkSite, forgottenStack, setLinkReturnToForgotten } = useStore()

--- a/src/ui/views/KumaSite.tsx
+++ b/src/ui/views/KumaSite.tsx
@@ -40,7 +40,7 @@ import { useStore, type KumaAlertProvider } from "../store.tsx"
 import { isVanityPair } from "../../lib/vanitySite.ts"
 import { openUrl } from "../../lib/open.ts"
 import { runSiteDoctor, type DoctorReport } from "../../lib/siteDoctor.ts"
-import { classifyStack } from "../../lib/stack.ts"
+import { effectiveStack } from "../../lib/stack.ts"
 
 const BASE_FIELDS = ["url", "username", "password"] as const
 // Fixed input width: the panel body is 66 wide, the label gutter is 12 ("❯ " +
@@ -152,7 +152,7 @@ type AlertsState =
 type AlertSummary = null | { kind: "loading" } | { kind: "error"; error: string } | { kind: "ready"; providers: KumaAlertProvider[] }
 
 export function KumaSite() {
-  const { kumaSite: site, setKumaSite, kumaConfigured, kumaUrl, connectKuma, kumaMonitorFor, kumaOps, startKumaSetup, startVanityReseed, startKumaRotate, startFingerprintSetup, startBypassMonitorSetup, removeSiteMonitor, fetchKumaAlerts, toggleKumaAlert, clearKumaOp, kumaStatus, servers, setInputMode } = useStore()
+  const { kumaSite: site, setKumaSite, kumaConfigured, kumaUrl, connectKuma, kumaMonitorFor, kumaOps, startKumaSetup, startVanityReseed, startKumaRotate, startFingerprintSetup, startBypassMonitorSetup, removeSiteMonitor, fetchKumaAlerts, toggleKumaAlert, clearKumaOp, kumaStatus, servers, setInputMode, probes } = useStore()
 
   const [draft, setDraft] = useState({ url: "", username: "", password: "" })
   const [fieldIdx, setFieldIdx] = useState(0)
@@ -371,8 +371,14 @@ export function KumaSite() {
       pageCacheEnabled: site.page_cache?.enabled ?? null,
       sshTarget: site.site_user && server ? `${site.site_user}@${server.name}` : null,
       isWordPress: !!site.is_wordpress,
-      // Bedrock relocates the login under /wp/ — aim the door probe there.
-      loginPath: classifyStack(site) === "Bedrock" ? "/wp/wp-login.php" : "/wp-login.php",
+      // Bedrock and Radicle both nest core under a wp/ folder, relocating the
+      // login there — aim the door probe at it. Uses effectiveStack (Tier-2
+      // probe when available) since Radicle's public/ webroot alone is
+      // indistinguishable at Tier-1 from a hardened Standard-WP public/ layout.
+      loginPath: (() => {
+        const stack = effectiveStack(site, probes.get(site.id)?.result.kind)
+        return stack === "Bedrock" || stack === "Radicle" ? "/wp/wp-login.php" : "/wp-login.php"
+      })(),
     }).then((report) => setDoctor((prev) => (prev ? { kind: "ready", report } : prev)))
   }
 


### PR DESCRIPTION
## Summary

Closes the detection half of #38 — Radicle (Roots' Bedrock+Sage+Acorn+Trellis starter) was being misclassified as Bedrock everywhere the app does stack detection. Both share the `roots/bedrock-autoloader` dependency, which was tripping a naive `roots/bedrock` composer.json substring match. Detection now checks for `roots/acorn` first — the package that actually makes a site Radicle, since plain Bedrock never requires it.

- Radicle only surfaces via the Tier-2 SSH probe (`f` in Servers/Search, `d`/`D` in Stacks) — its `/public/` webroot alone is indistinguishable at Tier-1 from a hardened Standard-WP `/public/` layout (the wp-config-above-webroot convention).
- Once probed, the label carries through the Stacks tab, Site Control panel, the Forgotten report's stack filter, and the monitoring doctor's login-path guess (Radicle nests core under `wp/`, same as Bedrock).
- DB backup/sync, plugin/theme inventory, and local working-copy linking already worked on Radicle sites — their path detection was already stack-agnostic. This PR just adds the missing name.
- Clone-wizard support for Radicle is a separate, not-yet-built follow-up (Phase 2) — deliberately out of scope here per the plan agreed on the issue.
- README/docs updated, plus a few stale `p`/`m` key mentions that slipped through the previous release's key-unification work.

## Test plan

- [x] Live-verified against a real Radicle site: the SSH probe now correctly reports "Radicle" (previously misreported "Bedrock")
- [x] Live-verified the Stacks tab buckets it under the new Radicle group
- [x] Live-verified DB backup/sync (`d`/`p`) already worked end-to-end on the same site
- [x] `bun run typecheck` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qqYUreRV622799pV5u3rG