### PR TITLE
fix: correct package-install update command to bun add -g @latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,10 @@ bun run build:binary     # produces ./spinuptui — move it onto your PATH
 The app tells you when a newer release exists — a gold `✦ vX.Y.Z` appears next
 to the version in the header (and in the `?` About panel).
 
-- **Package install:** `bun update -g spinuptui` (the About panel shows the
-  same command).
+- **Package install:** `bun add -g spinuptui@latest` (the About panel shows
+  the same command). Don't use `bun update -g` — while spinuptui is pre-1.0,
+  it records a caret range (e.g. `^0.22.2`) that excludes every later minor
+  release, so `update -g` reports success but silently doesn't update.
 - **Source checkout:** press **`u`** in the About panel to update in place
   (`git pull --ff-only`; refuses if you have uncommitted changes, and never
   merges/rebases). It can't hot-reload the already-running process, so it tells

--- a/src/lib/appUpdate.ts
+++ b/src/lib/appUpdate.ts
@@ -139,7 +139,17 @@ export function installChannel(): InstallChannel {
 
 // The one-liner Help shows for a package install (also used by runSelfUpdate's
 // "not a checkout" message so every path names the same command).
-export const PACKAGE_UPDATE_CMD = "bun update -g spinuptui"
+//
+// Deliberately `add ... @latest`, not `update -g`: while spinuptui is pre-1.0,
+// `bun add -g spinuptui` (no version) records a caret range like `^0.22.2`,
+// which per semver only matches 0.22.x. Every minor release (0.23.0, 0.24.0, ...)
+// falls outside that range, so `bun update -g` silently no-ops forever — it
+// re-resolves within the stale range and finds nothing newer. `@latest` bypasses
+// the recorded range entirely and rewrites it to match, so the *next* update
+// hits the same wall until the following minor bump. Verified live against a
+// real stale install (0.22.2 -> 0.24.0): `update -g` exited 0 without updating,
+// `add -g spinuptui@latest` updated correctly.
+export const PACKAGE_UPDATE_CMD = "bun add -g spinuptui@latest"
 
 // The real checkout directory, resolved through Bun's module system rather
 // than process.cwd() — `spinuptui` is typically a global symlink invoked from


### PR DESCRIPTION
`bun update -g spinuptui` _not updating for you?_ I just figured out why...since we're at the pre-release stage (i.e. not yet to `v1.0.0`), that command will silently fail. To pull the latest pre-release version, you must run `bun add -g spinuptui@latest`. More details: 👇

## Summary
- `bun update -g spinuptui` silently no-ops on pre-1.0 installs — `bun add -g spinuptui` records a caret range (`^0.22.2`) that, per semver, only matches patch releases, so every later minor release falls outside it. `update -g` exits 0 without updating.
- Switches the single `PACKAGE_UPDATE_CMD` constant (feeds the Help/About panel and the self-update fallback message) and the README instructions to `bun add -g spinuptui@latest`, which bypasses the stale range.

## Test plan
- [x] Verified live against a real stuck install (MacMini, 0.22.2 → latest 0.24.0): `bun update -g spinuptui` exited 0, stayed on 0.22.2; `bun add -g spinuptui@latest` correctly updated to 0.24.0 and rewrote the manifest range to `^0.24.0`.
- [x] `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s2MeU9Qe5gaAJBixN2GSJ