### PR TITLE
fix: replace @opentui-ui/toast with a small first-party toast implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+## [0.24.4] - 2026-08-06
+
+### Fixed
+- **The `Unknown component type: toaster` startup crash is now actually
+  fixed for real installs**, not just local project installs. `0.24.3`'s
+  `package.json` `overrides` only take effect when this repo's own
+  `package.json` is the root of the install — they're silently ignored when
+  spinuptui is installed as a dependency of something else, which is exactly
+  what a global `bun add -g` / `npm install -g` does, so the crash persisted
+  for every real user. Root cause traces back to the toast library
+  (`@opentui-ui/toast`) itself: it's stuck on a peer-dependency range from
+  opentui's `0.1.x` days, and no version pin on our side can bind how a
+  downstream install resolves *its* transitive dependencies. Every call site
+  in this app only ever fires a single-line success message, so it's
+  replaced with a small first-party toast implementation (`src/ui/toast.ts`
+  + `src/ui/ToastStack.tsx`) built directly on the `@opentui/core`/
+  `@opentui/react` we already depend on — no external package, no peer-
+  dependency surface for a future version bump to break again.
+
 ## [0.24.3] - 2026-08-06
 
 ### Fixed
@@ -1280,7 +1299,8 @@ Initial tagged release.
 ### Notes
 - Read-only release: works with a SpinupWP **Read Only** API token.
 
-[Unreleased]: https://github.com/mwender/spinupwp-tui/compare/v0.24.3...HEAD
+[Unreleased]: https://github.com/mwender/spinupwp-tui/compare/v0.24.4...HEAD
+[0.24.4]: https://github.com/mwender/spinupwp-tui/compare/v0.24.3...v0.24.4
 [0.24.3]: https://github.com/mwender/spinupwp-tui/compare/v0.24.2...v0.24.3
 [0.24.2]: https://github.com/mwender/spinupwp-tui/compare/v0.24.1...v0.24.2
 [0.24.1]: https://github.com/mwender/spinupwp-tui/compare/v0.24.0...v0.24.1

--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,8 @@
     "": {
       "name": "spinuptui",
       "dependencies": {
-        "@opentui-ui/toast": "^0.0.5",
-        "@opentui/core": "0.4.2",
-        "@opentui/react": "0.4.2",
+        "@opentui/core": "^0.4.1",
+        "@opentui/react": "^0.4.1",
         "react": "^19.0.0",
         "socket.io-client": "^4.8.3",
       },
@@ -18,32 +17,26 @@
       },
     },
   },
-  "overrides": {
-    "@opentui/core": "0.4.2",
-    "@opentui/react": "0.4.2",
-  },
   "packages": {
-    "@opentui-ui/toast": ["@opentui-ui/toast@0.0.5", "", { "peerDependencies": { "@opentui/core": "^0.1.63", "@opentui/react": "^0.1.63", "@opentui/solid": "^0.1.63" }, "optionalPeers": ["@opentui/react", "@opentui/solid"] }, "sha512-LOT5Bw0F5AEyhjSqpKgS7aSe7M7v+ahaAa4t3/K2dtWiT0CJ711UHXqM31KKN6yuHoUKRNs+g+643ety/a3lEw=="],
+    "@opentui/core": ["@opentui/core@0.4.5", "", { "dependencies": { "bun-ffi-structs": "0.2.4", "diff": "9.0.0", "marked": "17.0.1", "string-width": "7.2.0", "strip-ansi": "7.1.2" }, "optionalDependencies": { "@opentui/core-darwin-arm64": "0.4.5", "@opentui/core-darwin-x64": "0.4.5", "@opentui/core-linux-arm64": "0.4.5", "@opentui/core-linux-arm64-musl": "0.4.5", "@opentui/core-linux-x64": "0.4.5", "@opentui/core-linux-x64-musl": "0.4.5", "@opentui/core-win32-arm64": "0.4.5", "@opentui/core-win32-x64": "0.4.5" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-JsgRTPkA6e+Vxmumxai6SElOSlRQkbzNKHlCfemlArRiLhfC1IZ9RXJo2QH4xSu+uBOWAM90uss73/pPlkdEig=="],
 
-    "@opentui/core": ["@opentui/core@0.4.2", "", { "dependencies": { "bun-ffi-structs": "0.2.3", "diff": "9.0.0", "marked": "17.0.1", "string-width": "7.2.0", "strip-ansi": "7.1.2" }, "optionalDependencies": { "@opentui/core-darwin-arm64": "0.4.2", "@opentui/core-darwin-x64": "0.4.2", "@opentui/core-linux-arm64": "0.4.2", "@opentui/core-linux-arm64-musl": "0.4.2", "@opentui/core-linux-x64": "0.4.2", "@opentui/core-linux-x64-musl": "0.4.2", "@opentui/core-win32-arm64": "0.4.2", "@opentui/core-win32-x64": "0.4.2" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-ulx6RMqftf2fm7Itf9e81GcCDMNY6NAhmnKYhllDOMYD+PxYXR+vomy2bxQNV5ow31RE7s8WQFnb7hWTRUbx2g=="],
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.4.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-8KUG0oRidnR+oW1RSZJ72/PhZLl+qRRMk5U/mieF4c0SJ5V3tYACpBZAKzQfHNd1f7QzD8FHZct1lPpQgtmkWg=="],
 
-    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.4.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-is+O+sS/l3E9cZXyM9pRF1WhqnE+hYSPYoZkbseR9CthJcaWPGi3R3jUJa1cLj325252jWgxVupnDqFUtKg36w=="],
+    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.4.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-R2bocsg55gwjOqCp/MWFgFYzRmsduKegB6nzgFAPCvAD/L5Jf30xpWJWFlSg3x8vxe1L9WJ84dfqa4M7mZZ3wA=="],
 
-    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.4.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-ACi42h81DurSeybUAD1XyKT6xmXZcKeTxS54lZFi0CVZh46w0g99vNj8PlQzIFXvvFLT0e0IlRS//eWSWS2zGQ=="],
+    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.4.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-R4MZ25a4CzOAGVjW9aj1hUfzQGVfCJwrwBDbNs2SXaIvzcZqkxCVtU4FoQ5LsaD0j/BdNQVg2CIfFkFsm1fDuQ=="],
 
-    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.4.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-RjOx2HcjLRtGSy9WrAGSdr5M9SpJuPifPORpImx6Mciovw0ltnE0uoYjIyor82uf6/LExWC7YA2AcAl+YBxayA=="],
+    "@opentui/core-linux-arm64-musl": ["@opentui/core-linux-arm64-musl@0.4.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ieqdyKI6EIYPalYAETB2wsdP83hr5Ifi+dFnBFUmdEEFHsoKwBmn2S7bsTOYlX7Bg03F4/YPIg+IvRpeC+cUJw=="],
 
-    "@opentui/core-linux-arm64-musl": ["@opentui/core-linux-arm64-musl@0.4.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-heNciL2ngPU+kq1h01PHLsxn6Fr8iqTFtbxSdVbhaY3XihuIjkuXyEhFeuoa1lsXY7Bb2gpWnX5EQVWnZsAuDQ=="],
+    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.4.5", "", { "os": "linux", "cpu": "x64" }, "sha512-SNyuQoxMKI1vuJhgxSSW96adWM6LqFl2SoS3GM4tGeneGOanVVG2Y06PvlytXvF4cKik97t0rqkVMRetmOs93w=="],
 
-    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.4.2", "", { "os": "linux", "cpu": "x64" }, "sha512-9s0s/ooK+AhWP306By3gu+XhzcVEThC2sqKMPK1nQmGDujQhd+xOrtbtfCVcJSx62UzAovC2VNqypvP8vHByOg=="],
+    "@opentui/core-linux-x64-musl": ["@opentui/core-linux-x64-musl@0.4.5", "", { "os": "linux", "cpu": "x64" }, "sha512-mKVKcIcPiSVVZZsdPSBoWwoa2/TCeQAaMDeHF7PFw2kt5bTXZPP7xxWfRQLCNIcA1eaGl59UuwUWHDR2Ve548Q=="],
 
-    "@opentui/core-linux-x64-musl": ["@opentui/core-linux-x64-musl@0.4.2", "", { "os": "linux", "cpu": "x64" }, "sha512-Cjv6Bv7l3p/KLNJr5RyqCS0FmRlAGJnkA2IK3S+HkHhCOv/O02S1G+DBUY6POnyjp1eNy95vauustApobhdbig=="],
+    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.4.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-GHTTsqeR45q2Iek9Rb7ty+x/hAKn2jZ1ujlCgPR8LBKyF7h0E1dNFryoZ7ehMc3kJndP1sKn836IemKFqxuDdQ=="],
 
-    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.4.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-mfJZrJ0TNPFRZUzXNsxAPe1YdiWsy/vbTl93+yeXGHPI1B8Qnk9V5hpzSxxEyBGhlTHSfGNtgiO+VrrdRC3kZA=="],
+    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.4.5", "", { "os": "win32", "cpu": "x64" }, "sha512-Y8T/yXCDGagRGiQrtmuB6AhRcPucKFs/Dre3v8kJwNYqDccI4FzUPKclZ7djfmRZNjl7JUqPhZZP/PwDpQocMg=="],
 
-    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.4.2", "", { "os": "win32", "cpu": "x64" }, "sha512-P2oguG3ng3OMjAdasFSA3GhHaQXtzDUsIRDGbzWFOimpZ/zMemidp+JQ0V8V6XwK6Utk5G0aQ03oBaRCoLyYDw=="],
-
-    "@opentui/react": ["@opentui/react@0.4.2", "", { "dependencies": { "@opentui/core": "0.4.2", "react-reconciler": "^0.33.0" }, "peerDependencies": { "react": ">=19.2.0", "react-devtools-core": "^7.0.1", "ws": "^8.18.0" } }, "sha512-SsteuclEw72gUBzp/mZjADSNS1jJJr4htB89euicn+Atl62ZvO22wuLE9hBFDCpumtgG3sbSe+7XtV6vW1orXA=="],
+    "@opentui/react": ["@opentui/react@0.4.5", "", { "dependencies": { "@opentui/core": "0.4.5", "react-reconciler": "^0.33.0" }, "peerDependencies": { "react": ">=19.2.0", "react-devtools-core": "^7.0.1", "ws": "^8.18.0" } }, "sha512-n88Vx0cMmAu++/S14WscjvdcT46IDcxve02jMtcfHQ9j6cySRHfILfGEpOB7xxc8RpCwQceEyOjkKkfzPzm6Jg=="],
 
     "@socket.io/component-emitter": ["@socket.io/component-emitter@3.1.2", "", {}, "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="],
 
@@ -55,7 +48,7 @@
 
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
-    "bun-ffi-structs": ["bun-ffi-structs@0.2.3", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-pgJiXP+hEgFo9qG51J6ItfY4ocs3vniwNzJ9WhoakB3QB2GdzQxX2EXssentPYlB2hOfJrTjO6iIQkWYzUodpg=="],
+    "bun-ffi-structs": ["bun-ffi-structs@0.2.4", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-AJzsqoVFs1KBbJbWHIYrVZLDC3NhTqqh25awRXqzoLzmBAKr5oqk6+CwuYHAekKx+VBCYVohBoKuRq40dV+TYg=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spinuptui",
-  "version": "0.24.3",
+  "version": "0.24.4",
   "description": "SpinupTUI — a terminal dashboard for browsing, monitoring, and managing your SpinupWP servers and sites.",
   "type": "module",
   "bin": {
@@ -41,9 +41,8 @@
   "author": "Michael Wender",
   "license": "MIT",
   "dependencies": {
-    "@opentui-ui/toast": "^0.0.5",
-    "@opentui/core": "0.4.2",
-    "@opentui/react": "0.4.2",
+    "@opentui/core": "^0.4.1",
+    "@opentui/react": "^0.4.1",
     "react": "^19.0.0",
     "socket.io-client": "^4.8.3"
   },
@@ -51,9 +50,5 @@
     "@types/bun": "^1.3.14",
     "@types/react": "^19.0.0",
     "typescript": "^5.6.0"
-  },
-  "overrides": {
-    "@opentui/core": "0.4.2",
-    "@opentui/react": "0.4.2"
   }
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react"
 import { useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/react"
-import { Toaster } from "@opentui-ui/toast/react"
+import { ToastStack } from "./ToastStack.tsx"
 import { theme } from "../lib/theme.ts"
 import { useStore } from "./store.tsx"
 import { Splash } from "./Splash.tsx"
@@ -262,10 +262,7 @@ export function App() {
       {store.connectZoneTarget && <ProviderConnect />}
       {store.dnsRecordsTarget && <DnsRecords />}
       {store.kumaSite && <KumaSite />}
-      {/* Async-completion toasts (PHP upgrade, server reboot/restart). Mounted last
-          so it draws over every view + overlay; top-right, nudged clear of the
-          2-row Header. It never takes keyboard focus. */}
-      <Toaster position="top-right" offset={{ top: 2, right: 2 }} />
+      <ToastStack />
     </box>
   )
 }

--- a/src/ui/ToastStack.tsx
+++ b/src/ui/ToastStack.tsx
@@ -1,0 +1,33 @@
+// Renders the toast queue from ./toast.ts. See that file for why this is
+// first-party instead of a dependency. Mounted last in App.tsx so it draws
+// over every view + overlay; top-right, nudged clear of the 2-row Header.
+// It never takes keyboard focus.
+
+import { useSyncExternalStore } from "react"
+import { theme } from "../lib/theme.ts"
+import { getToasts, subscribeToasts } from "./toast.ts"
+
+const TOAST_WIDTH = 60
+
+export function ToastStack() {
+  const toasts = useSyncExternalStore(subscribeToasts, getToasts, getToasts)
+
+  if (toasts.length === 0) return null
+
+  return (
+    <box style={{ position: "absolute", top: 2, right: 2, flexDirection: "column", gap: 1, zIndex: 300 }}>
+      {toasts.map((t) => (
+        <box
+          key={t.id}
+          border
+          borderColor={theme.good}
+          backgroundColor={theme.bgPanel}
+          style={{ flexDirection: "row", gap: 1, maxWidth: TOAST_WIDTH, paddingLeft: 1, paddingRight: 1 }}
+        >
+          <text content="✓" fg={theme.good} />
+          <text content={t.message} fg={theme.text} />
+        </box>
+      ))}
+    </box>
+  )
+}

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -6,7 +6,7 @@
 // trigger a refresh.
 
 import { createContext, useContext, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
-import { toast } from "@opentui-ui/toast"
+import { toast } from "./toast.ts"
 import { SpinupWPClient, ApiError, type ServerService, type SpinupWPClientLike } from "../api/client.ts"
 import { isDevMode } from "../dev/devMode.ts"
 import { createMockClient } from "../dev/mockClient.ts"

--- a/src/ui/toast.ts
+++ b/src/ui/toast.ts
@@ -1,0 +1,49 @@
+// Minimal first-party toast notifications.
+//
+// Replaces the @opentui-ui/toast package, which is stuck on a peer-dependency
+// range from opentui's 0.1.x days and breaks against the @opentui/core 0.4.x
+// line we're on (see CHANGELOG v0.24.2/v0.24.3). Every call site in this app
+// only ever fires a single-line success message, so a small first-party
+// implementation is simpler — and immune to upstream drift — than depending
+// on a package built for a much larger feature set we don't use.
+//
+// A plain module-level subscriber list (rather than React state) so callers
+// outside the component tree — store.tsx's async completion handlers — can
+// fire a toast without needing a ref or context. ToastStack.tsx reads this
+// via useSyncExternalStore.
+
+export interface ToastItem {
+  id: number
+  message: string
+}
+
+const TOAST_DURATION_MS = 4000
+
+let nextId = 1
+let toasts: ToastItem[] = []
+const listeners = new Set<() => void>()
+
+function notify() {
+  for (const listener of listeners) listener()
+}
+
+export function subscribeToasts(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+export function getToasts(): ToastItem[] {
+  return toasts
+}
+
+export const toast = {
+  success(message: string) {
+    const id = nextId++
+    toasts = [...toasts, { id, message }]
+    notify()
+    setTimeout(() => {
+      toasts = toasts.filter((t) => t.id !== id)
+      notify()
+    }, TOAST_DURATION_MS)
+  },
+}


### PR DESCRIPTION
## Summary
- Supersedes #50/#51 (v0.24.2/v0.24.3), which tried to fix the toast crash by pinning/overriding `@opentui/core`/`@opentui/react` versions. That doesn't work: `package.json` `overrides` only apply when this repo's own `package.json` is the install root — they're silently ignored when spinuptui is installed as a dependency of something else (`bun add -g`, `npm install -g`), which is how every real user runs it. Confirmed live on the reporting Mac Mini: `v0.24.3` still crashed with the identical `Unknown component type: toaster` error.
- Real root cause: `@opentui-ui/toast`'s peer-dependency range (`^0.1.63`) predates opentui's current `0.4.x` line, and nothing in our `package.json` can bind how a *downstream* install resolves that library's own transitive peers.
- Every call site in this app only ever fires `toast.success(message)` — 7 call sites, no titles/actions/loading states — so this drops the external dependency entirely and replaces it with a small first-party implementation:
  - `src/ui/toast.ts` — a module-level pub/sub so `store.tsx`'s async completion handlers (PHP upgrade, reboot, purge cache, etc.) can fire a toast without a ref/context, plus auto-dismiss.
  - `src/ui/ToastStack.tsx` — renders the queue with plain `box`/`text` intrinsics via `useSyncExternalStore`, mounted in `App.tsx` where `<Toaster>` used to be.
- No custom component registration, no external package, no peer-dependency surface for a future opentui bump to break again.

## Test plan
- [x] `rm -rf node_modules bun.lock && bun install` — zero `@opentui/*` duplicates anywhere in the tree
- [x] `bun run typecheck` green
- [x] End-to-end live verification in Dev Mode via a temporary debug key (removed before commit): fired two toasts, confirmed they mount, render (green border, checkmark, top-right), and auto-dismiss after 4s with no crash; app quit cleanly afterward
- [x] `npm pack --dry-run` confirms both new files ship in the tarball
- [ ] Reproduce on the Mac Mini post-merge via `bun add -g spinuptui@latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)