### PR TITLE
Surface pending SpinupWP upgrades in Server actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+### Added
+- **Server actions now surfaces a pending SpinupWP platform upgrade**, not just
+  a silent badge. The overlay (`a`) shows a banner explaining the API only
+  exposes it as a flag with no actionable detail, and `w` jumps straight to the
+  server's page in the SpinupWP web app to run it.
+- **App version on the splash screen**, shown below the tagline while the first
+  batch of data loads.
+
+### Fixed
+- **The reboot-pending detail line now shows the real reason when the SSH probe
+  fails**, instead of a generic "couldn't read detail over SSH" message — e.g.
+  an SSH auth failure now shows the actual error. Both this and the new upgrade
+  banner wrap across lines instead of overflowing the panel on longer text.
+
 ## [0.24.4] - 2026-08-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -320,8 +320,10 @@ Full details: [docs/php-upgrade.md](docs/php-upgrade.md).
 ## Server actions
 
 `a` on a server reboots it or restarts a service (Nginx/PHP-FPM/MySQL/Redis),
-and shows *why* a reboot is pending (the actual OS packages, read over SSH).
-Needs a Read/Write token. Full details: [docs/server-actions.md](docs/server-actions.md).
+shows *why* a reboot is pending (the actual OS packages, read over SSH), and for
+a pending SpinupWP platform upgrade — which the API can't act on — offers `w` to
+jump straight to it in the SpinupWP web app. Needs a Read/Write token. Full
+details: [docs/server-actions.md](docs/server-actions.md).
 
 ## Site monitoring
 

--- a/docs/server-actions.md
+++ b/docs/server-actions.md
@@ -22,3 +22,9 @@ server's row keeps a spinner).
 - **A toast on completion.** A reboot can take minutes; when it (or a restart)
   finishes, a non-focus-stealing toast tells you (`example.com rebooted` /
   `Nginx restarted on example.com`), so you don't have to keep checking.
+- **SpinupWP platform upgrades aren't actionable here.** Servers with a pending
+  SpinupWP upgrade show an `↑upg` badge, same as reboot. Unlike a reboot, the API
+  only exposes this as a flag — no title, no description, no endpoint to run it.
+  The overlay shows a banner and lets you press `w` to jump straight to the
+  server's page in the SpinupWP web app, where the upgrade (and what it does) is
+  visible and runnable.

--- a/src/ui/Splash.tsx
+++ b/src/ui/Splash.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useState } from "react"
 import { theme } from "../lib/theme.ts"
 import { Spinner } from "./components.tsx"
+import { APP_VERSION } from "../version.ts"
 
 const TAGLINE = "Terminal control center for your SpinupWP fleet"
 
@@ -39,6 +40,8 @@ export function Splash({ status }: { status: string }) {
       <ascii-font text="SPINUPTUI" font="block" color={[theme.brand, theme.accent]} />
       <box style={{ height: 1 }} />
       <text content={TAGLINE} fg={theme.text} />
+      <box style={{ height: 1 }} />
+      <text content={`Version ${APP_VERSION}`} fg={theme.brand} />
       <box style={{ height: 1 }} />
       <Pulse />
       <box style={{ height: 2 }} />

--- a/src/ui/views/ServerActions.tsx
+++ b/src/ui/views/ServerActions.tsx
@@ -15,6 +15,9 @@ import { Panel, Spinner, Centered } from "../components.tsx"
 import { StatusBar } from "../StatusBar.tsx"
 import { useStore } from "../store.tsx"
 import { moveSelection } from "../List.tsx"
+import { openUrl } from "../../lib/open.ts"
+import { serverWebUrl } from "../../lib/spinupweb.ts"
+import { toast } from "../toast.ts"
 import type { RebootInfo } from "../../lib/ssh.ts"
 import type { ServerOpKind } from "../store.tsx"
 
@@ -56,9 +59,11 @@ export function ServerActions() {
     rebootInfoLoading,
     rebootInfoErrors,
     loadRebootInfo,
+    accountSlug,
   } = store
 
   const rebootRequired = !!server?.reboot_required
+  const upgradeRequired = !!server?.upgrade_required
   const [phase, setPhase] = useState<Phase>("pick")
   // Cursor starts on Reboot when one is pending, else on the first restart.
   const [index, setIndex] = useState(() => (server?.reboot_required ? 0 : 1))
@@ -107,6 +112,12 @@ export function ServerActions() {
         case "l":
           setTarget(ACTIONS[index])
           setPhase("confirm")
+          return
+        case "w":
+          if (upgradeRequired && server) {
+            openUrl(serverWebUrl(server.id, accountSlug))
+            toast.success(accountSlug ? "Opening in SpinupWP…" : "Set accountSlug for deep links — opening dashboard")
+          }
           return
       }
       return
@@ -179,20 +190,34 @@ export function ServerActions() {
             {/* Reboot "why" context */}
             {rebootRequired && (
               <>
-                <box style={{ flexDirection: "row", height: 1 }}>
-                  <text content="⚠ reboot pending — " fg={theme.warn} style={{ flexShrink: 0 }} />
+                <box style={{ flexDirection: "column" }}>
+                  <text content="⚠ reboot pending" fg={theme.warn} wrapMode="none" />
                   {infoLoading ? (
                     <box style={{ flexDirection: "row" }}>
                       <Spinner interval={120} />
                       <text content=" checking what's pending…" fg={theme.textDim} wrapMode="none" />
                     </box>
                   ) : info ? (
-                    <text content={rebootSummary(info)} fg={theme.textDim} wrapMode="none" style={{ flexShrink: 1 }} />
+                    <text content={rebootSummary(info)} fg={theme.textDim} />
                   ) : infoError ? (
-                    <text content="couldn't read detail over SSH" fg={theme.textFaint} wrapMode="none" />
+                    <text content={infoError} fg={theme.textFaint} />
                   ) : (
                     <text content="reboot required" fg={theme.textDim} wrapMode="none" />
                   )}
+                </box>
+                <box style={{ height: 1 }} />
+              </>
+            )}
+            {/* SpinupWP platform upgrade — the API only exposes this as a flag,
+                no detail; the only actionable path is the web app. Two lines
+                (not a height:1 row) so the explanation can wrap instead of
+                overflowing the panel — see the flexGrow/flexShrink gotcha in
+                CLAUDE.md. */}
+            {upgradeRequired && (
+              <>
+                <box style={{ flexDirection: "column" }}>
+                  <text content="⬆ SpinupWP upgrade pending" fg={theme.warn} wrapMode="none" />
+                  <text content="Not doable from here — press w to open it in SpinupWP." fg={theme.textDim} />
                 </box>
                 <box style={{ height: 1 }} />
               </>
@@ -308,6 +333,7 @@ export function ServerActions() {
         return [
           { key: "↑↓/jk", label: "action" },
           { key: "⏎", label: "choose" },
+          ...(upgradeRequired ? [{ key: "w", label: "open in SpinupWP" }] : []),
           { key: "esc", label: "cancel" },
         ]
       case "confirm":


### PR DESCRIPTION
## Summary
- Server actions (`a`) now shows a banner when a server has a pending SpinupWP platform upgrade, explaining the API only exposes it as a flag (no detail/endpoint), with `w` to jump straight to it in the SpinupWP web app.
- Fixes the reboot-pending detail line to show the real SSH error (e.g. an auth failure) instead of a generic message when the probe fails.
- Both banners now wrap across lines instead of overflowing the panel on longer text.
- Adds the app version to the splash screen.

## Test plan
- [x] `bun run typecheck` passes
- [x] Verified visually via PTY replay in Dev Mode (upgrade banner + `w` hint) and live against the real account (web2.spinuptui.com's reboot SSH-auth-failure case, both before/after the wrap fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kgPzfcNoR5MuEyFfzxNFi