### PR TITLE
feat: Search uses the shared Control drawer; fix K/V on server results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,9 @@ versions; such changes are called out here.
     credentials included, on the file-pull path. Nothing local can reach the
     production database through them (its `DB_HOST` is localhost), but local
     wp-cli authenticates as the production DB user, so the DB pull offered on
-    the same screen is denied until they're pointed at a local database.
+    the same screen is denied until they're pointed at a local database. A
+    Bedrock/Radicle clone gets the mirror-image note: `.env` holds its database
+    credentials and isn't in the repo, so a fresh checkout has none.
 
 ## [0.25.0] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+### Added
+- **Clone a site's full local working copy from production** — `L` on a site
+  with no local copy yet now opens a choose screen: `e` is the existing manual
+  "enter a path" form, and the new `c` runs a guided clone. It pulls the code
+  down (a `git clone` for git-deployed sites, an `rsync` over SSH for everything
+  else), runs `composer install` when the checkout turns out to be
+  Bedrock/Radicle, links the result exactly as the manual form would, and then
+  hands off to the existing DB sync (`p`) and production-media (`m`) flows
+  unchanged — three already-reviewed screens chained by keypresses rather than
+  one new mega-flow. The local database and webserver config are never touched.
+  - The rsync pull always takes the site's whole files root (so a `public/`-style
+    layout brings `wp-config.php` down from one level above the webroot), and the
+    real webroot is **detected** on the server rather than trusting
+    `public_folder`.
+  - `wp-content/uploads` is excluded — production media is served through the
+    media-fallback mu-plugin (`m`) instead of copied.
+  - `object-cache.php` and `advanced-cache.php` are excluded outright: SpinupWP's
+    Redis drop-in doesn't no-op when Redis is unreachable, it 500s on a cache
+    miss, so copying them down fatals the local site.
+
 ## [0.25.0] - 2026-08-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ versions; such changes are called out here.
   - `object-cache.php` and `advanced-cache.php` are excluded outright: SpinupWP's
     Redis drop-in doesn't no-op when Redis is unreachable, it 500s on a cache
     miss, so copying them down fatals the local site.
+  - The done screen flags that the copied `wp-config.php` is **production's**,
+    credentials included, on the file-pull path. Nothing local can reach the
+    production database through them (its `DB_HOST` is localhost), but local
+    wp-cli authenticates as the production DB user, so the DB pull offered on
+    the same screen is denied until they're pointed at a local database.
 
 ## [0.25.0] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,21 @@ versions; such changes are called out here.
     Bedrock/Radicle clone gets the mirror-image note: `.env` holds its database
     credentials and isn't in the repo, so a fresh checkout has none.
 
+### Changed
+- **Search now shows a full-width Site/Server Control drawer**, matching the
+  Servers tab, instead of swapping the right-hand panel between Details and
+  Actions. The Details pane stays put while you browse, and the drawer below
+  always reflects the currently selected result — reusing the exact same
+  control-list component the Servers tab uses, so the two views can't drift
+  out of sync again.
+
+### Fixed
+- **`K` (Grant SSH key) and `V` (create/resume vanity site) now work on server
+  results in Search**, not just site results. Both were already advertised in
+  the legend but silently did nothing on a server before this — `K` falls back
+  to the server's first key-eligible site as the anchor, matching the Servers
+  tab's behavior.
+
 ## [0.25.0] - 2026-08-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@
 - **Installed plugins & themes** (`e`) — real `wp plugin`/`theme list` over SSH,
   with per-item version and update status. → [docs/plugins-themes.md](docs/plugins-themes.md)
 - **Open in browser** (`o`) / **SSH into a site** (`s`) — one-key shortcuts.
-- **Link local working copies** (`L`) — link a site to its local checkout, with
-  auto-discovery and git-drift indicators. → [docs/local-working-copies.md](docs/local-working-copies.md)
+- **Local working copies** (`L`) — link a site to its local checkout, or clone
+  one from production (`c`) when you don't have it yet; with auto-discovery and
+  git-drift indicators. → [docs/local-working-copies.md](docs/local-working-copies.md)
 - **DNS migration lens** (`n` / `N`) — see and edit a site's hosting records,
   repoint it to another server. → [docs/dns-access-editing.md](docs/dns-access-editing.md)
 - **Database backup & sync** (`d` / `p`, Servers / Search tabs) — download or
@@ -256,7 +257,7 @@ These can be set in `config.json` or via an environment variable:
 | `d` | Download a production DB backup into the linked copy (Servers / Search; WordPress + linked) |
 | `p` | Pull the production DB into the linked copy — overwrites local; opt-in via `localSync` (Servers / Search) |
 | `m` | Production media fallback: serve missing-locally images from production (Servers / Search; WordPress + linked) |
-| `L` | Link / edit a site's local working copy |
+| `L` | Link / edit a site's local working copy — on an unlinked site, `e` enters a path by hand and `c` clones one from production |
 | `t` / `v` | Open the linked copy in a terminal / its local URL in your browser |
 | `n` | DNS migration view for a site — its records + TTLs (`⏎` edits a TTL; `p` repoints the record; `a` shows the whole server) |
 | `N` | DNS migration view for the whole server |

--- a/docs/local-working-copies.md
+++ b/docs/local-working-copies.md
@@ -6,6 +6,25 @@ serve it; the site's details gain a "Local" field, and you can open the copy wit
 `t` (a terminal at the path) or `v` (its local URL). All of this is **local-only**
 — no SpinupWP writes.
 
+- **Clone one from production (`L` → `c`).** For a site you have no copy of yet,
+  `L` opens a choice: `e` to type in a path you already have, or `c` to build the
+  copy from production. The clone pulls the code down — a `git clone` for
+  git-deployed sites, an `rsync` over SSH for everything else — runs `composer
+  install` if the checkout turns out to be Bedrock/Radicle, links it, and then
+  hands off to the existing DB pull (`p`) and media fallback (`m`). It never
+  touches your local database or webserver config.
+  - **`wp-config.php` comes down too.** The pull takes the site's whole files
+    root, so a `public/`-style layout brings the config from one level above the
+    webroot — and the real webroot is *detected* on the server, never inferred
+    from the `public_folder` setting. That config is **production's**, so point
+    `DB_NAME` / `DB_USER` / `DB_PASSWORD` / `DB_HOST` at a local database before
+    pulling the DB. (A Bedrock/Radicle clone has the opposite problem: `.env`
+    isn't in the repo, so the checkout arrives without one.) The done screen
+    says which applies.
+  - **`wp-content/uploads` is skipped** — that's what the media fallback (`m`) is
+    for — as are `object-cache.php` and `advanced-cache.php`, which are wired to
+    production's Redis and fatal locally rather than degrading quietly.
+
 - **Auto-discover (`S`, Stacks tab).** Scan one or more folders and match their
   subdirectories to sites — by git remote, Bedrock `WP_HOME`, or folder name —
   then batch-link the matches.

--- a/src/lib/dbBackup.ts
+++ b/src/lib/dbBackup.ts
@@ -111,12 +111,12 @@ export async function runProcess(
   timeoutMs: number,
   cwd?: string,
   env?: Record<string, string>,
-): Promise<{ code: number; stderr: string }> {
+): Promise<{ code: number; stderr: string; stdout: string }> {
   let proc: ReturnType<typeof Bun.spawn>
   try {
     proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "pipe", stdin: "ignore", cwd, env })
   } catch (err) {
-    return { code: -1, stderr: `Failed to launch ${cmd[0]}: ${(err as Error).message}` }
+    return { code: -1, stderr: `Failed to launch ${cmd[0]}: ${(err as Error).message}`, stdout: "" }
   }
   const timer = setTimeout(() => {
     try {
@@ -127,8 +127,11 @@ export async function runProcess(
   }, timeoutMs)
   const code = await proc.exited
   clearTimeout(timer)
-  const stderr = await new Response(proc.stderr as ReadableStream<Uint8Array>).text()
-  return { code, stderr }
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout as ReadableStream<Uint8Array>).text(),
+    new Response(proc.stderr as ReadableStream<Uint8Array>).text(),
+  ])
+  return { code, stderr, stdout }
 }
 
 // Pick a meaningful error line out of ssh/wp stderr, skipping the deprecation /

--- a/src/lib/localSetup.ts
+++ b/src/lib/localSetup.ts
@@ -1,0 +1,164 @@
+// Set up a brand-new local working copy for a remote SpinupWP site — the
+// missing first step before dbSync (`p`) and mediaFallback (`m`) can run.
+//
+// Gets the CODE down (git clone for git-deployed sites, an rsync pull over SSH
+// for everything else — excluding uploads/ and the server-specific caching
+// drop-ins, object-cache.php/advanced-cache.php: they're wired to production's
+// Redis/disk cache, and object-cache.php doesn't just no-op without it, it
+// fatals) and runs `composer install` locally when the checkout turns out to
+// be Bedrock/Radicle. Deliberately stops there: it never touches the local
+// database or webserver config, and never links the site itself — the caller
+// does that (reusing `linkSite`) once this succeeds, then hands off to the
+// existing dbSync (`p`) and mediaFallback (`m`) flows unchanged.
+//
+// For a public/-style webroot, wp-config.php lives ONE level above it (see
+// CLAUDE.md's WordPress layout rules) — so the rsync path always pulls the
+// site's whole files root, not just the detected webroot, so wp-config.php
+// (and anything else living beside it) comes down too. `public_folder` is a
+// SETTING, not a fact (SpinupWP never enforces it), so the real webroot is
+// detected on the source via `detectWpDirScript` rather than trusted.
+
+import { existsSync, mkdirSync, readdirSync } from "node:fs"
+import { dirname } from "node:path"
+import type { Server, Site } from "../api/types.ts"
+import { expandPath, resolveLocalLink } from "./local.ts"
+import { SSH_OPTS, sshPort, runProcess, meaningfulError } from "./dbBackup.ts"
+import { detectWpDirScript } from "./serverClone.ts"
+
+export interface LocalSetupPlan {
+  domain: string
+  isGit: boolean
+  repoUrl: string | null // git clone source, when isGit
+  user: string // SSH user — only needed for the non-git rsync path
+  host: string
+  port: number | null
+  filesRoot: string // remote /sites/{domain}/files — rsync source root
+  publicFolder: string | null // as configured; the real webroot is still detected, not trusted
+  destPath: string // expanded local destination (must not exist, or be empty)
+  destUrl: string
+}
+
+export type LocalSetupPlanResult = { ok: true; plan: LocalSetupPlan } | { ok: false; error: string }
+
+export function planLocalSetup(
+  site: Site,
+  server: Server | undefined,
+  sshUser: string | null,
+  destPath: string,
+  destUrl: string,
+): LocalSetupPlanResult {
+  const path = destPath.trim()
+  if (!path) return { ok: false, error: "Enter a local path." }
+  const dir = expandPath(path)
+  if (existsSync(dir) && readdirSync(dir).length > 0) return { ok: false, error: "That path already exists and isn't empty." }
+
+  const isGit = !!site.git?.repo
+  const host = server?.ip_address
+  const user = site.site_user ?? sshUser
+  // Non-git sites are pulled over SSH, so they need a reachable server + user.
+  // Git sites clone straight from the repo and never touch the server.
+  if (!isGit && (!host || !user)) return { ok: false, error: "Missing site user or server IP — can't reach the site." }
+
+  return {
+    ok: true,
+    plan: {
+      domain: site.domain,
+      isGit,
+      repoUrl: site.git?.repo ?? null,
+      user: user ?? "",
+      host: host ?? "",
+      port: server?.ssh_port ?? null,
+      filesRoot: `/sites/${site.domain}/files`,
+      publicFolder: site.public_folder,
+      destPath: dir,
+      destUrl: destUrl.trim(),
+    },
+  }
+}
+
+export type LocalSetupStage = "fetch" | "build" | "done" | "error"
+
+export interface LocalSetupProgress {
+  stage: LocalSetupStage
+  domain: string
+  destPath?: string
+  error?: string
+  failedStage?: LocalSetupStage
+  ranComposer?: boolean
+}
+
+export function isLocalSetupInFlight(p: LocalSetupProgress | undefined): boolean {
+  return p != null && p.stage !== "done" && p.stage !== "error"
+}
+
+// rsync the source's whole files root down, excluding uploads wherever they
+// land (relative to the detected webroot, not assumed at the files root).
+async function fetchByRsync(plan: LocalSetupPlan): Promise<{ code: number; stderr: string }> {
+  const target = `${plan.user}@${plan.host}`
+  const probeScript = `${detectWpDirScript(plan.filesRoot, plan.publicFolder ?? undefined)}; echo "D:$D"; echo "W:$W"`
+  const probe = await runProcess(["ssh", ...SSH_OPTS, ...sshPort(plan.port), target, probeScript], 30_000)
+  if (probe.code !== 0) return { code: probe.code, stderr: probe.stderr }
+  const d = probe.stdout.match(/^D:(.*)$/m)?.[1]?.trim()
+  const w = probe.stdout.match(/^W:(.*)$/m)?.[1]?.trim()
+  if (!d) return { code: 1, stderr: "couldn't determine the site's files root on the server." }
+  if (!w) return { code: 1, stderr: "couldn't find a WordPress install under this site on the server." }
+
+  // Paths relative to the files root we're about to rsync, e.g.
+  // "public/wp-content/uploads" when the webroot sits below the files root, or
+  // bare "wp-content/uploads" when it doesn't.
+  const webrootRel = w === d ? "" : w.slice(d.length).replace(/^\/+/, "")
+  const contentRel = (name: string) => (webrootRel ? `${webrootRel}/wp-content/${name}` : `wp-content/${name}`)
+  // object-cache.php (and advanced-cache.php, same family) are server drop-ins
+  // wired to production's Redis/disk cache — they don't just no-op without it,
+  // they fatal (confirmed: SpinupWP's object-cache drop-in 500s on a cache MISS
+  // when Redis is unreachable). Local dev doesn't want production caching
+  // anyway, so these are excluded outright rather than copied and hoping.
+  const excludes = ["uploads", "object-cache.php", "advanced-cache.php"].map((name) => `--exclude=${contentRel(name)}`)
+
+  const sshCmd = ["ssh", ...SSH_OPTS, ...sshPort(plan.port)].join(" ")
+  return runProcess(["rsync", "-az", "-e", sshCmd, ...excludes, `${target}:${d}/`, `${plan.destPath}/`], 600_000)
+}
+
+export async function runLocalSetup(plan: LocalSetupPlan, onProgress: (p: LocalSetupProgress) => void): Promise<LocalSetupProgress> {
+  const domain = plan.domain
+  const fail = (error: string, failedStage: LocalSetupStage = "fetch"): LocalSetupProgress => {
+    const p: LocalSetupProgress = { stage: "error", domain, error, failedStage }
+    onProgress(p)
+    return p
+  }
+  const stageFail = (label: string, stderr: string, fallback: string, failedStage: LocalSetupStage) =>
+    fail(`${label} — ${meaningfulError(stderr, fallback)}`, failedStage)
+
+  onProgress({ stage: "fetch", domain })
+  try {
+    mkdirSync(dirname(plan.destPath), { recursive: true })
+  } catch {
+    // best-effort — the actual clone/rsync surfaces a real error if this truly can't be created
+  }
+
+  if (plan.isGit) {
+    if (!plan.repoUrl) return fail("This site has no git repo configured in SpinupWP.", "fetch")
+    const cl = await runProcess(["git", "clone", plan.repoUrl, plan.destPath], 300_000)
+    if (cl.code !== 0) return stageFail("git clone failed", cl.stderr, `exit ${cl.code}.`, "fetch")
+  } else {
+    mkdirSync(plan.destPath, { recursive: true })
+    const rs = await fetchByRsync(plan)
+    if (rs.code !== 0) return stageFail("File pull failed", rs.stderr, `exit ${rs.code}.`, "fetch")
+  }
+
+  // Bedrock/Radicle needs `composer install` to build vendor/ + web/wp before
+  // anything (wp-cli included) can find a WordPress install in the checkout.
+  // Standard WP ships its core in the tree already, so this is a no-op there.
+  const kind = resolveLocalLink({ domain, path: plan.destPath, localUrl: plan.destUrl }).kind
+  let ranComposer = false
+  if (kind === "bedrock" || kind === "radicle") {
+    onProgress({ stage: "build", domain })
+    const ci = await runProcess(["bash", "-lc", "composer install"], 300_000, plan.destPath)
+    if (ci.code !== 0) return stageFail("composer install failed", ci.stderr, "composer error.", "build")
+    ranComposer = true
+  }
+
+  const done: LocalSetupProgress = { stage: "done", domain, destPath: plan.destPath, ranComposer }
+  onProgress(done)
+  return done
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -30,6 +30,7 @@ import { NewServer } from "./views/NewServer.tsx"
 import { VanityNewSite } from "./views/VanityNewSite.tsx"
 import { CloneWizard } from "./views/CloneWizard.tsx"
 import { LocalLinkOverlay } from "./views/LocalLink.tsx"
+import { LocalSetupOverlay } from "./views/LocalSetup.tsx"
 import { Discover } from "./views/Discover.tsx"
 import { Forgotten } from "./views/Forgotten.tsx"
 import { DnsInventory } from "./views/DnsInventory.tsx"
@@ -75,6 +76,7 @@ export function App() {
     store.vanityServer !== null ||
     store.cloneServer !== null ||
     store.localLinkSite !== null ||
+    store.localSetupSite !== null ||
     store.discoverOpen ||
     store.forgottenOpen ||
     store.dnsInventoryServer !== null ||
@@ -166,6 +168,9 @@ export function App() {
     // The local-link overlay owns the keyboard while open.
     if (store.localLinkSite) return
 
+    // The new-local-copy (clone/rsync) overlay owns the keyboard while open.
+    if (store.localSetupSite) return
+
     // The discovery overlay owns the keyboard while open.
     if (store.discoverOpen) return
 
@@ -256,6 +261,7 @@ export function App() {
       {store.vanityServer && <VanityNewSite />}
       {store.cloneServer && <CloneWizard />}
       {store.localLinkSite && <LocalLinkOverlay />}
+      {store.localSetupSite && <LocalSetupOverlay />}
       {store.discoverOpen && <Discover />}
       {store.forgottenOpen && <Forgotten />}
       {store.dnsInventoryServer && <DnsInventory />}

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -55,6 +55,7 @@ import { resolvePhpEolDates, refreshPhpEolDates, isPhpEol as isPhpEolWith, offer
 import { resolveUbuntuEolDates, refreshUbuntuEolDates, isUbuntuEol as isUbuntuEolWith, type UbuntuEolDates } from "../lib/ubuntuEol.ts"
 import { planDbBackup, runDbBackup, type DbBackupProgress, type PlanResult } from "../lib/dbBackup.ts"
 import { planDbSync, runDbSync, type DbSyncProgress, type SyncPlanResult } from "../lib/dbSync.ts"
+import { planLocalSetup, runLocalSetup, type LocalSetupProgress, type LocalSetupPlanResult } from "../lib/localSetup.ts"
 import { planMediaFallback, type MediaFallbackResult } from "../lib/mediaFallback.ts"
 
 export type Route = "dashboard" | "servers" | "stacks" | "search" | "events"
@@ -372,12 +373,14 @@ const phpJobId = (siteId: number) => `phpUpgrade:${siteId}`
 const httpsJobId = (siteId: number) => `httpsToggle:${siteId}`
 const dbSyncJobId = (siteId: number) => `dbSync:${siteId}`
 const dbBackupJobId = (siteId: number) => `dbBackup:${siteId}`
+const localSetupJobId = (siteId: number) => `localSetup:${siteId}`
 
 // SSH-orchestrated jobs (no SpinupWP event to re-attach to) can't truly resume —
 // their child processes died with the app. On restart we surface them as
 // interrupted rather than pretend, since the local DB may be half-applied.
 const INTERRUPTED_SYNC_MSG = "Interrupted by a restart — your local database may be partially imported. Re-run the sync (p)."
 const INTERRUPTED_BACKUP_MSG = "Interrupted by a restart — the download didn't finish. Re-run the backup (d)."
+const INTERRUPTED_LOCAL_SETUP_MSG = "Interrupted by a restart — the local copy may be partial. Re-run the clone."
 // Server provisioning events settle with one of these (broader than PHP/site
 // writes, whose terminal is "deployed"); finished_at also implies done.
 const SERVER_DONE = new Set(["deployed", "completed", "provisioned", "finished", "success"])
@@ -715,6 +718,16 @@ interface StoreValue extends DataState {
   startDbSync: (site: Site) => void
   clearDbSync: (siteId: number) => void
 
+  // Set up a brand-new local working copy for a remote site (clone/rsync the
+  // code down, composer install if Bedrock/Radicle) — the missing first step
+  // before a link exists at all. Never touches the DB or webserver config.
+  localSetupSite: Site | null
+  setLocalSetupSite: (s: Site | null) => void
+  localSetups: Map<number, LocalSetupProgress>
+  planLocalSetupFor: (site: Site, destPath: string, destUrl: string) => LocalSetupPlanResult
+  startLocalSetup: (site: Site, destPath: string, destUrl: string) => void
+  clearLocalSetup: (siteId: number) => void
+
   // Production media fallback overlay (mu-plugin in the linked local copy). State
   // is the plugin file's presence, resolved fresh by planMediaFallbackFor.
   mediaFallbackSite: Site | null
@@ -1003,6 +1016,8 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const [dbBackups, setDbBackups] = useState<Map<number, DbBackupProgress>>(new Map())
   const [dbSyncSite, setDbSyncSite] = useState<Site | null>(null)
   const [dbSyncs, setDbSyncs] = useState<Map<number, DbSyncProgress>>(new Map())
+  const [localSetupSite, setLocalSetupSite] = useState<Site | null>(null)
+  const [localSetups, setLocalSetups] = useState<Map<number, LocalSetupProgress>>(new Map())
   const [localSync, setLocalSyncState] = useState<boolean>(() => cfgRef.current.localSync)
   const [enableLocalSyncSite, setEnableLocalSyncSite] = useState<Site | null>(null)
   const [mediaFallbackSite, setMediaFallbackSite] = useState<Site | null>(null)
@@ -2146,6 +2161,51 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       })
     },
     [dbSyncs, planDbSyncFor],
+  )
+
+  // ---- New local working copy (clone/rsync + composer install) ----------
+
+  const setLocalSetup = (siteId: number, progress: LocalSetupProgress) =>
+    setLocalSetups((prev) => new Map(prev).set(siteId, progress))
+
+  const clearLocalSetup = useCallback(
+    (siteId: number) =>
+      setLocalSetups((prev) => {
+        if (!prev.has(siteId)) return prev
+        const next = new Map(prev)
+        next.delete(siteId)
+        return next
+      }),
+    [],
+  )
+
+  const planLocalSetupFor = useCallback(
+    (site: Site, destPath: string, destUrl: string): LocalSetupPlanResult =>
+      planLocalSetup(site, servers.find((s) => s.id === site.server_id), cfgRef.current.sshUser, destPath, destUrl),
+    [servers],
+  )
+
+  const startLocalSetup = useCallback(
+    (site: Site, destPath: string, destUrl: string) => {
+      const existing = localSetups.get(site.id)
+      if (existing && existing.stage !== "done" && existing.stage !== "error") return
+      const res = planLocalSetupFor(site, destPath, destUrl)
+      if (!res.ok) {
+        setLocalSetup(site.id, { stage: "error", domain: site.domain, error: res.error })
+        return
+      }
+      // SSH/local-process orchestrated (no event): persist only so a restart can
+      // flag it as interrupted; drop it the moment it settles.
+      void saveJob({ id: localSetupJobId(site.id), kind: "localSetup", status: "running", startedAt: Date.now(), inputs: { siteId: site.id, domain: site.domain } })
+      void runLocalSetup(res.plan, (p) => {
+        setLocalSetup(site.id, p)
+        // Link as soon as the files are down, same shape the manual `L` form
+        // writes — dbSync (`p`) and mediaFallback (`m`) both require a link.
+        if (p.stage === "done") linkSite(site.id, { domain: site.domain, path: res.plan.destPath, localUrl: res.plan.destUrl })
+        if (p.stage === "done" || p.stage === "error") void removeJob(localSetupJobId(site.id))
+      })
+    },
+    [localSetups, planLocalSetupFor, linkSite],
   )
 
   // Compute a linked site's git drift once (cached), fire-and-forget. Stable
@@ -4151,6 +4211,10 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           if (inp.siteId != null) setSync(inp.siteId, { stage: "error", domain: inp.domain ?? "", error: INTERRUPTED_SYNC_MSG })
           void removeJob(job.id)
           break
+        case "localSetup":
+          if (inp.siteId != null) setLocalSetup(inp.siteId, { stage: "error", domain: inp.domain ?? "", error: INTERRUPTED_LOCAL_SETUP_MSG })
+          void removeJob(job.id)
+          break
         case "dbBackup":
           if (inp.siteId != null) setBackup(inp.siteId, { stage: "error", domain: inp.domain ?? "", error: INTERRUPTED_BACKUP_MSG })
           void removeJob(job.id)
@@ -4333,6 +4397,12 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     planDbSyncFor,
     startDbSync,
     clearDbSync,
+    localSetupSite,
+    setLocalSetupSite,
+    localSetups,
+    planLocalSetupFor,
+    startLocalSetup,
+    clearLocalSetup,
     drift,
     ensureDrift,
     rebootInfo,

--- a/src/ui/views/LocalLink.tsx
+++ b/src/ui/views/LocalLink.tsx
@@ -1,14 +1,19 @@
-// Local working-copy link overlay — Phase 1 (link + view, no mutation).
+// Local working-copy link overlay — Phase 1 (link + view, no mutation) plus
+// the entry point into Phase 2 (LocalSetup.tsx's guided clone).
 //
-// Opened with `L` on a selected site (Browser / Search results). Two modes:
+// Opened with `L` on a selected site (Browser / Search results). Modes:
+//   • choose — no link exists yet: pick manual entry (`e`) or a guided clone
+//     from production (`c`, hands off to LocalSetupOverlay).
 //   • view — the site is linked: shows the validated status (Bedrock / WordPress
 //     / missing) and offers open-locally actions: `t` opens a terminal at the
 //     path, `v` opens the stored local URL in the browser. `e` edits, `x` unlinks.
 //   • edit — a small form to enter the local path + local URL (manual entry).
 //
-// Per the locked spec these are LOCAL conveniences only: we open a terminal and
-// the local URL — we never launch an editor and never run composer/git here.
-// The mutating maintenance loop (composer update → push → deploy) is a later phase.
+// This file itself still only links — we open a terminal and the local URL, and
+// never launch an editor. Getting code onto disk (git clone / rsync / composer)
+// lives entirely in LocalSetup.tsx, kept separate from this file's original
+// read-only-on-disk scope. The mutating maintenance loop (composer update → push
+// → deploy) is still a later phase.
 
 import { useEffect, useState } from "react"
 import { useKeyboard } from "@opentui/react"
@@ -19,7 +24,7 @@ import { StatusBar } from "../StatusBar.tsx"
 import { useStore } from "../store.tsx"
 import { resolveLocalLink, type LocalKind } from "../../lib/local.ts"
 
-type Mode = "view" | "edit"
+type Mode = "choose" | "view" | "edit"
 type EditField = "path" | "url"
 
 function kindColor(kind: LocalKind, exists: boolean): string {
@@ -31,11 +36,11 @@ function kindColor(kind: LocalKind, exists: boolean): string {
 
 export function LocalLinkOverlay() {
   const store = useStore()
-  const { localLinkSite: site, setLocalLinkSite, localLinks, linkSite, unlinkSite, setInputMode, openLocalTerminal, openLocalUrl, linkReturnToForgotten, setLinkReturnToForgotten, setForgottenOpen } = store
+  const { localLinkSite: site, setLocalLinkSite, localLinks, linkSite, unlinkSite, setInputMode, openLocalTerminal, openLocalUrl, linkReturnToForgotten, setLinkReturnToForgotten, setForgottenOpen, setLocalSetupSite } = store
 
   const existing = site ? localLinks.get(site.id) : undefined
 
-  const [mode, setMode] = useState<Mode>(() => (existing ? "view" : "edit"))
+  const [mode, setMode] = useState<Mode>(() => (existing ? "view" : "choose"))
   const [field, setField] = useState<EditField>("path")
   const [pathInput, setPathInput] = useState(existing?.path ?? "")
   const [urlInput, setUrlInput] = useState(existing?.localUrl ?? "")
@@ -73,9 +78,28 @@ export function LocalLinkOverlay() {
   useKeyboard((key) => {
     const name = key.name ?? ""
 
+    if (mode === "choose") {
+      if (name === "escape" || name === "q") return close()
+      if (name === "e") {
+        setPathInput("")
+        setUrlInput("")
+        setField("path")
+        return setMode("edit")
+      }
+      if (name === "c" && site) {
+        // Not close() — that hands back to the "needs a local copy" report if we
+        // arrived from there, which doesn't make sense mid-clone. Just hand off.
+        setInputMode(false)
+        setLocalLinkSite(null)
+        setLocalSetupSite(site)
+      }
+      return
+    }
+
     if (mode === "edit") {
-      // Esc backs out: to the view mode if a link already exists, else closes.
-      if (name === "escape") return existing ? setMode("view") : close()
+      // Esc backs out: to the view mode if a link already exists, else to the
+      // choose screen (there's no link yet, so there's nothing to "view").
+      if (name === "escape") return existing ? setMode("view") : setMode("choose")
       // ↑/↓ switch fields (Enter advances/saves via the inputs' onSubmit).
       if (name === "up") return setField("path")
       if (name === "down") return setField("url")
@@ -138,11 +162,32 @@ export function LocalLinkOverlay() {
         <text content={existing ? "linked" : "not linked"} fg={existing ? theme.good : theme.textFaint} style={{ flexShrink: 0 }} />
       </box>
 
-      <Centered>{mode === "edit" ? renderEdit() : renderView()}</Centered>
+      <Centered>{mode === "choose" ? renderChoose() : mode === "edit" ? renderEdit() : renderView()}</Centered>
 
       <StatusBar hints={hints()} message={flash ?? undefined} messageColor={theme.brand} showGlobal={false} />
     </box>
   )
+
+  function renderChoose() {
+    return (
+      <Panel title=" No local copy yet " active>
+        <box style={{ flexDirection: "column", width: 62, paddingTop: 1, paddingBottom: 1 }}>
+          <text content="How do you want to set this up?" fg={theme.text} wrapMode="none" />
+          <box style={{ height: 1 }} />
+          <box style={{ flexDirection: "row" }}>
+            <text content="c  " fg={theme.accent} style={{ flexShrink: 0 }} />
+            <text content="Clone fullsite (DB + files) from production" fg={theme.text} wrapMode="none" />
+          </box>
+          <text content="   git clone / file pull, no uploads/ — guided" fg={theme.textFaint} wrapMode="none" />
+          <box style={{ height: 1 }} />
+          <box style={{ flexDirection: "row" }}>
+            <text content="e  " fg={theme.accent} style={{ flexShrink: 0 }} />
+            <text content="Enter a path — you already have a copy" fg={theme.text} wrapMode="none" />
+          </box>
+        </box>
+      </Panel>
+    )
+  }
 
   function renderView() {
     return (
@@ -203,6 +248,12 @@ export function LocalLinkOverlay() {
   }
 
   function hints() {
+    if (mode === "choose")
+      return [
+        { key: "c", label: "clone from production" },
+        { key: "e", label: "enter a path" },
+        { key: "esc", label: "cancel" },
+      ]
     if (mode === "edit")
       return [
         { key: "↑↓", label: "field" },

--- a/src/ui/views/LocalSetup.tsx
+++ b/src/ui/views/LocalSetup.tsx
@@ -204,6 +204,16 @@ export function LocalSetupOverlay() {
                   <text content="or the DB pull is denied as production's user." fg={theme.warn} wrapMode="none" />
                 </>
               )}
+              {/* The mirror image on the git path: Bedrock/Radicle keep DB
+                  credentials and WP_HOME in .env, which is deliberately not in
+                  the repo — so a fresh clone has none and wp-cli runs with
+                  empty settings. composer install having run is the signal. */}
+              {progress?.ranComposer ? (
+                <>
+                  <text content=".env isn't in the repo, so this checkout has none — copy" fg={theme.warn} wrapMode="none" />
+                  <text content=".env.example to .env and set DB_* + WP_HOME before pulling." fg={theme.warn} wrapMode="none" />
+                </>
+              ) : null}
               <text content="Press ⏎ / p to pull production's database now, once that's ready." fg={theme.purple} wrapMode="none" />
               <text content="Esc to finish here" fg={theme.textFaint} wrapMode="none" />
             </>

--- a/src/ui/views/LocalSetup.tsx
+++ b/src/ui/views/LocalSetup.tsx
@@ -191,6 +191,19 @@ export function LocalSetupOverlay() {
               {progress?.ranComposer ? <text content="composer install ran" fg={theme.textFaint} wrapMode="none" /> : null}
               <box style={{ height: 1 }} />
               <text content="Next: create a local database and point your local tool at it." fg={theme.textFaint} wrapMode="none" />
+              {/* The file pull copies the site's real wp-config.php, production
+                  DB credentials and all. Nothing local can reach production's
+                  database through them (its DB_HOST is localhost), but local
+                  wp-cli authenticates as the production user, so the DB pull
+                  below is denied until they're localized. Say so here rather
+                  than letting it surface as a bare "Access denied" later. */}
+              {isGit ? null : (
+                <>
+                  <text content="wp-config.php came down with production's DB credentials —" fg={theme.warn} wrapMode="none" />
+                  <text content="update DB_NAME / DB_USER / DB_PASSWORD / DB_HOST to match," fg={theme.warn} wrapMode="none" />
+                  <text content="or the DB pull is denied as production's user." fg={theme.warn} wrapMode="none" />
+                </>
+              )}
               <text content="Press ⏎ / p to pull production's database now, once that's ready." fg={theme.purple} wrapMode="none" />
               <text content="Esc to finish here" fg={theme.textFaint} wrapMode="none" />
             </>

--- a/src/ui/views/LocalSetup.tsx
+++ b/src/ui/views/LocalSetup.tsx
@@ -1,0 +1,233 @@
+// Clone a brand-new local working copy from production — the guided
+// alternative to `L`'s manual "enter a path" form, offered when a site has no
+// local link yet. Opened from LocalLink.tsx's choose screen.
+//
+// Gets the code down (git clone, or an rsync pull over SSH excluding uploads/
+// for non-git sites), runs `composer install` for Bedrock/Radicle, then links
+// the result exactly like the manual form would. It deliberately stops there —
+// the local database and webserver config are NOT touched here. On success it
+// hands off to the existing dbSync (`p`) flow unchanged (which itself gates on
+// `localSync` being enabled), then that flow's own done screen already nudges
+// into mediaFallback (`m`). Three existing, already-reviewed screens chained
+// by keypresses, not one new mega state machine.
+
+import { useState } from "react"
+import { useKeyboard } from "@opentui/react"
+import { theme } from "../../lib/theme.ts"
+import { truncate, middleTruncate } from "../../lib/format.ts"
+import { Panel, Centered, DestPath, Steps, type StepRow } from "../components.tsx"
+import { StatusBar } from "../StatusBar.tsx"
+import { useStore } from "../store.tsx"
+import type { LocalSetupStage } from "../../lib/localSetup.ts"
+
+const SETUP_STEPS: { stage: LocalSetupStage; label: string }[] = [
+  { stage: "fetch", label: "Get the code (clone / pull)" },
+  { stage: "build", label: "composer install" },
+]
+
+export function LocalSetupOverlay() {
+  const { localSetupSite: site, setLocalSetupSite, serverById, planLocalSetupFor, localSetups, startLocalSetup, clearLocalSetup, localSync, setEnableLocalSyncSite, setDbSyncSite } = useStore()
+
+  const progress = site ? localSetups.get(site.id) : undefined
+  const [path, setPath] = useState("")
+  const [url, setUrl] = useState("")
+  const [field, setField] = useState<"path" | "url">("path")
+  const [formError, setFormError] = useState<string | null>(null)
+
+  const dp: "form" | "running" | "done" | "error" =
+    !progress ? "form" : progress.stage === "done" ? "done" : progress.stage === "error" ? "error" : "running"
+
+  const close = () => {
+    if (site && (progress?.stage === "done" || progress?.stage === "error")) clearLocalSetup(site.id)
+    setLocalSetupSite(null)
+  }
+
+  const submit = () => {
+    if (!site) return
+    const res = planLocalSetupFor(site, path, url)
+    if (!res.ok) {
+      setFormError(res.error)
+      return
+    }
+    setFormError(null)
+    startLocalSetup(site, path, url)
+  }
+
+  const pullDb = () => {
+    if (!site) return
+    close()
+    if (!localSync) setEnableLocalSyncSite(site)
+    else setDbSyncSite(site)
+  }
+
+  useKeyboard((key) => {
+    const name = key.name ?? ""
+    if (name === "escape" || name === "q") return close()
+
+    if (dp === "form") {
+      if (name === "up") return setField("path")
+      if (name === "down") return setField("url")
+      return
+    }
+    if (dp === "error") {
+      if (name === "r" && site) {
+        clearLocalSetup(site.id)
+        setFormError(null)
+      }
+      return
+    }
+    if (dp === "done") {
+      if (name === "return" || name === "p") return pullDb()
+      return
+    }
+  })
+
+  if (!site) return null
+  const server = serverById(site.server_id)
+  const isGit = !!site.git?.repo
+
+  return (
+    <box style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", flexDirection: "column", backgroundColor: theme.bg, zIndex: 210 }}>
+      <box style={{ flexDirection: "row", height: 1, backgroundColor: theme.bgAlt, paddingLeft: 1, paddingRight: 1, alignItems: "center" }}>
+        <text content="⇩ Clone fullsite (DB + files) from production  " fg={theme.brand} style={{ flexShrink: 0 }} />
+        <text content={truncate(site.domain, 38)} fg={theme.text} wrapMode="none" style={{ flexShrink: 1 }} />
+      </box>
+
+      <Centered>{renderBody()}</Centered>
+
+      <StatusBar hints={hints()} showGlobal={false} />
+    </box>
+  )
+
+  function renderBody() {
+    if (dp === "form") {
+      return (
+        <Panel title=" Clone from production " active>
+          <box style={{ flexDirection: "column", width: 68, paddingTop: 1, paddingBottom: 1 }}>
+            <box style={{ flexDirection: "row" }}>
+              <text content="from " fg={theme.textFaint} />
+              <text content={truncate(site!.domain, 30)} fg={theme.accent} wrapMode="none" />
+              <text content=" on " fg={theme.textDim} />
+              <text content={truncate(server?.name ?? "—", 22)} fg={theme.textDim} wrapMode="none" />
+            </box>
+            <text content={isGit ? "source: git clone (this site's repo)" : "source: file pull over SSH (excludes uploads/)"} fg={theme.textFaint} wrapMode="none" />
+            <box style={{ height: 1 }} />
+            <text content="Local path for the new working copy" fg={field === "path" ? theme.accent : theme.textDim} />
+            <input
+              focused={field === "path"}
+              value={path}
+              placeholder={`~/code/${site!.domain}`}
+              onInput={setPath}
+              onSubmit={() => setField("url")}
+              style={{ backgroundColor: theme.bgAlt, focusedBackgroundColor: theme.bgAlt, textColor: theme.text }}
+            />
+            <box style={{ height: 1 }} />
+            <text content="Local URL (optional) — Valet, Cove, LocalWP, Herd, DDEV…" fg={field === "url" ? theme.accent : theme.textDim} />
+            <input
+              focused={field === "url"}
+              value={url}
+              placeholder="https://example.test"
+              onInput={setUrl}
+              onSubmit={submit}
+              style={{ backgroundColor: theme.bgAlt, focusedBackgroundColor: theme.bgAlt, textColor: theme.text }}
+            />
+            {formError ? (
+              <>
+                <box style={{ height: 1 }} />
+                <text content={`✕ ${formError}`} fg={theme.bad} wrapMode="none" />
+              </>
+            ) : null}
+            <box style={{ height: 1 }} />
+            <text content="This only pulls code — your local DB/webserver aren't touched." fg={theme.textFaint} wrapMode="none" />
+            <text content="↑↓ switch field · Enter on the URL starts · Esc cancels" fg={theme.textFaint} wrapMode="none" />
+          </box>
+        </Panel>
+      )
+    }
+
+    // "build" (composer install) only applies to Bedrock/Radicle — unknown
+    // until the fetch stage finishes, so it stays out of the list entirely
+    // (like DbSync's optional hook row) until we actually know, rather than
+    // rendering a row that never ran as if it had.
+    const buildApplies =
+      progress?.stage === "build" ||
+      (progress?.stage === "done" && !!progress.ranComposer) ||
+      (progress?.stage === "error" && progress.failedStage === "build")
+    const steps = SETUP_STEPS.filter((s) => s.stage !== "build" || buildApplies)
+    const order = steps.map((s) => s.stage)
+    const curIdx = order.indexOf((progress?.stage ?? "fetch") as LocalSetupStage)
+    const failedIdx = progress?.failedStage ? order.indexOf(progress.failedStage) : order.length - 1
+    const rows: StepRow[] = steps.map(({ label }, i) => {
+      const state: StepRow["state"] =
+        dp === "done"
+          ? "done"
+          : dp === "error"
+            ? i < failedIdx
+              ? "done"
+              : i === failedIdx
+                ? "failed"
+                : "pending"
+            : i < curIdx
+              ? "done"
+              : i === curIdx
+                ? "active"
+                : "pending"
+      return { label, state }
+    })
+
+    return (
+      <Panel title=" Cloning from production " active>
+        <box style={{ flexDirection: "column", width: 64, paddingTop: 1, paddingBottom: 1 }}>
+          <Steps rows={rows} />
+          <box style={{ height: 1 }} />
+          {dp === "done" ? (
+            <>
+              <box style={{ flexDirection: "row" }}>
+                <text content="✓ " fg={theme.good} />
+                <text content="Files are down and linked." fg={theme.text} wrapMode="none" />
+              </box>
+              <box style={{ height: 1 }} />
+              <DestPath path={middleTruncate(progress?.destPath ?? "", 62)} fileColor={theme.good} width={62} />
+              {progress?.ranComposer ? <text content="composer install ran" fg={theme.textFaint} wrapMode="none" /> : null}
+              <box style={{ height: 1 }} />
+              <text content="Next: create a local database and point your local tool at it." fg={theme.textFaint} wrapMode="none" />
+              <text content="Press ⏎ / p to pull production's database now, once that's ready." fg={theme.purple} wrapMode="none" />
+              <text content="Esc to finish here" fg={theme.textFaint} wrapMode="none" />
+            </>
+          ) : dp === "error" ? (
+            <>
+              <text content={`✕ ${progress?.error ?? "Something went wrong."}`} fg={theme.bad} />
+              <box style={{ height: 1 }} />
+              <text content="Press r to try again · Esc to close" fg={theme.textFaint} wrapMode="none" />
+            </>
+          ) : (
+            <text content="You can press Esc — it keeps running in the background." fg={theme.textFaint} wrapMode="none" />
+          )}
+        </box>
+      </Panel>
+    )
+  }
+
+  function hints() {
+    switch (dp) {
+      case "form":
+        return [
+          { key: "↑↓", label: "field" },
+          { key: "⏎", label: "start" },
+          { key: "esc", label: "cancel" },
+        ]
+      case "error":
+        return [
+          { key: "r", label: "retry" },
+          { key: "esc", label: "close" },
+        ]
+      case "done":
+        return [
+          { key: "⏎/p", label: "pull DB" },
+          { key: "esc", label: "close" },
+        ]
+      default:
+        return [{ key: "esc", label: "close" }]
+    }
+  }
+}

--- a/src/ui/views/Search.tsx
+++ b/src/ui/views/Search.tsx
@@ -9,11 +9,11 @@ import { useKeyboard } from "@opentui/react"
 import { theme, statusColor, statusDot } from "../../lib/theme.ts"
 import { classifyStack, stackColor, stackTag } from "../../lib/stack.ts"
 import { truncate } from "../../lib/format.ts"
-import { Panel, Field, StatusBadge, SiteMetaCell, Spinner, ControlPanel, siteGroups } from "../components.tsx"
+import { Panel, SiteMetaCell, Spinner } from "../components.tsx"
 import { isDbBackupInFlight } from "../../lib/dbBackup.ts"
 import { isDbSyncInFlight } from "../../lib/dbSync.ts"
 import { List, moveSelection } from "../List.tsx"
-import { ServerDetail, SiteDetail, SERVER_CONTROL } from "../Details.tsx"
+import { ServerDetail, SiteDetail, ControlStrip, CONTROL_STRIP_HEIGHT } from "../Details.tsx"
 import { StatusBar } from "../StatusBar.tsx"
 import { openUrl } from "../../lib/open.ts"
 import { serverWebUrl, siteWebUrl } from "../../lib/spinupweb.ts"
@@ -35,11 +35,12 @@ function score(haystack: string, q: string): number | null {
 
 export function Search({ rows }: { rows: number }) {
   const store = useStore()
-  const { servers, sites, serverById, setInputMode, setRoute, route, overlayOpen, setHealthServer, setPhpUpgradeSite, setHttpsToggleSite, setPurgeCacheSite, setServerActionsServer, accountSlug, localLinks, setLocalLinkSite, openLocalTerminal, openLocalUrl, sshSite, setDnsInventoryServer, setDbBackupSite, dbBackups, setDbSyncSite, dbSyncs, localSync, setMediaFallbackSite, beginClone, setSudoConnectServer, setKumaSite, kumaConfigured, startKumaSetup, startVanityReseed, setWpInventorySite, setGrantKeySite, runProbe, setEnableLocalSyncSite } = store
+  const { servers, sites, serverById, sitesForServer, setInputMode, setRoute, route, overlayOpen, setHealthServer, setPhpUpgradeSite, setHttpsToggleSite, setPurgeCacheSite, setServerActionsServer, accountSlug, localLinks, setLocalLinkSite, openLocalTerminal, openLocalUrl, sshSite, setDnsInventoryServer, setDbBackupSite, dbBackups, setDbSyncSite, dbSyncs, localSync, setMediaFallbackSite, beginClone, setSudoConnectServer, setKumaSite, kumaConfigured, startKumaSetup, startVanityReseed, setWpInventorySite, setGrantKeySite, runProbe, setEnableLocalSyncSite, setVanityServer, vanityJob } = store
   const [query, setQuery] = useState("")
   const [selected, setSelected] = useState(0)
   // "query" = typing/filtering (input focused); "actions" = input blurred so the
-  // selected result's single-key actions (o/w/u/h) fire. Tab/→ enters, ←/Esc exits.
+  // selected result's single-key actions fire — listed in the Site/Server
+  // Control drawer below, same as the Servers tab. Tab/→ enters, ←/Esc exits.
   const [focus, setFocus] = useState<"query" | "actions">("query")
   const [flash, setFlash] = useState<string | null>(null)
   const flashMsg = (m: string) => {
@@ -160,11 +161,15 @@ export function Search({ rows }: { rows: number }) {
       case "L":
         if (current?.kind === "site") setLocalLinkSite(current.site)
         return
-      case "K":
-        // Grant Spinup's machine key to the selected site over SSH — matches
-        // Browser's K binding, which was already in the shared legend here.
-        if (current?.kind === "site") setGrantKeySite(current.site)
+      case "K": {
+        // Grant Spinup's machine key over SSH — matches Browser's K binding,
+        // which is site-anchored but works on a server result too (falls back
+        // to the server's first key-eligible site, mirroring Browser.tsx).
+        const anchor =
+          current?.kind === "site" ? current.site : current?.kind === "server" ? sitesForServer(current.server.id).find((s) => s.site_user) : undefined
+        if (anchor) setGrantKeySite(anchor)
         return
+      }
       case "s":
         if (current?.kind === "site") flashMsg(sshSite(current.site.id))
         return
@@ -262,6 +267,17 @@ export function Search({ rows }: { rows: number }) {
       case "N":
         if (current?.kind === "server") setDnsInventoryServer(current.server)
         return
+      case "V": {
+        // Create the vanity site at the server's own hostname, or resume an
+        // unfinished build — same gating as Browser's V.
+        if (current?.kind === "server") {
+          const s = current.server
+          const resumable = vanityJob && vanityJob.step !== "done" && vanityJob.serverId === s.id
+          const hasVanity = sitesForServer(s.id).some((site) => site.domain.toLowerCase() === s.name.toLowerCase())
+          if (resumable || !hasVanity) setVanityServer(s)
+        }
+        return
+      }
     }
   })
 
@@ -273,22 +289,14 @@ export function Search({ rows }: { rows: number }) {
           { key: "Tab/→", label: "actions" },
           { key: "esc", label: "dashboard" },
         ]
-      : current?.kind === "server"
-        ? [
-            { key: "↑↓", label: "select" },
-            { key: "w", label: "SpinupWP" },
-            { key: "a", label: "actions" },
-            { key: "h", label: "health" },
-            { key: "←/esc", label: "back" },
-          ]
-        : [
-            // The Actions panel (Details pane) already lists every per-site key —
-            // this footer is nav-only now, so the two can't drift out of sync.
-            { key: "↑↓", label: "select" },
-            { key: "←/esc", label: "back" },
-          ]
+      : [
+          // The Control drawer below already lists every key for the selected
+          // result — this footer stays nav-only so the two can't drift out of sync.
+          { key: "↑↓", label: "select" },
+          { key: "←/esc", label: "back" },
+        ]
 
-  const listRows = Math.max(3, rows - 8) // input box (3) + status bar (1) + chrome
+  const listRows = Math.max(3, rows - 9 - CONTROL_STRIP_HEIGHT) // input box (3) + status bar (1) + chrome + control drawer
 
   return (
     <box style={{ flexGrow: 1, flexDirection: "column" }}>
@@ -374,14 +382,9 @@ export function Search({ rows }: { rows: number }) {
           />
         </Panel>
 
-        <Panel title={focus === "actions" ? " Actions " : " Details "} active={focus === "actions"} width={64}>
+        <Panel title=" Details " width={64}>
           {!current ? (
             <text content="No selection" fg={theme.textFaint} />
-          ) : focus === "actions" ? (
-            <ActionsCard
-              result={current}
-              serverName={current.kind === "site" ? (serverById(current.site.server_id)?.name ?? "—") : current.server.name}
-            />
           ) : current.kind === "server" ? (
             <ServerDetail server={current.server} siteCount={store.sitesForServer(current.server.id).length} />
           ) : (
@@ -390,44 +393,13 @@ export function Search({ rows }: { rows: number }) {
         </Panel>
       </box>
 
-      <StatusBar hints={hints} message={flash ?? undefined} showGlobal={false} />
-    </box>
-  )
-}
+      <ControlStrip
+        site={current?.kind === "site" ? current.site : null}
+        server={current?.kind === "server" ? current.server : null}
+        serverName={current?.kind === "site" ? (serverById(current.site.server_id)?.name ?? "—") : current?.kind === "server" ? current.server.name : "—"}
+      />
 
-function ActionsCard({ result, serverName }: { result: Result; serverName: string }) {
-  const isSite = result.kind === "site"
-  const name = isSite ? result.site.domain : result.server.name
-  const status = isSite ? result.site.status : result.server.connection_status
-  // Server results reuse the SAME Server Control suite as the Browser detail pane.
-  const groups = isSite ? siteGroups(result.site.is_wordpress, isVanityPair(result.site.domain, serverName)) : SERVER_CONTROL
-  return (
-    <box style={{ flexDirection: "column" }}>
-      <box style={{ flexDirection: "row" }}>
-        <text content={truncate(name, 30)} fg={theme.text} attributes={1} wrapMode="none" />
-        <box style={{ flexGrow: 1 }} />
-        <StatusBadge status={status} />
-      </box>
-      {isSite ? (
-        <>
-          <text content={(result.site.https?.enabled ? "https://" : "http://") + result.site.domain} fg={theme.accent} wrapMode="none" />
-          <box style={{ height: 1 }} />
-          <Field label="Server" value={truncate(serverName, 28)} labelWidth={8} />
-          <Field label="PHP" value={result.site.php_version ?? "—"} labelWidth={8} />
-          <Field label="Stack" value={classifyStack(result.site)} valueColor={stackColor(classifyStack(result.site))} labelWidth={8} />
-        </>
-      ) : (
-        <>
-          <text content={result.server.ip_address ?? "—"} fg={theme.accent} wrapMode="none" />
-          <box style={{ height: 1 }} />
-          <Field label="Provider" value={result.server.provider_name ?? "—"} labelWidth={9} />
-          <Field label="Region" value={result.server.region ?? "—"} labelWidth={9} />
-        </>
-      )}
-      <box style={{ height: 1 }} />
-      <ControlPanel heading={isSite ? "Site Control" : "Server Control"} groups={groups} />
-      <box style={{ height: 1 }} />
-      <text content="↑↓ select · ←/Esc back to search" fg={theme.textFaint} wrapMode="none" />
+      <StatusBar hints={hints} message={flash ?? undefined} showGlobal={false} />
     </box>
   )
 }


### PR DESCRIPTION
> **Stacked on #54** — based on `feat/local-setup` so the `CHANGELOG.md` edits don't collide. GitHub will retarget this to `main` automatically once #54 merges; review only the second commit.

### Changed
Search swapped its right-hand panel between **Details** and **Actions** depending on focus. It now keeps the Details pane in place and renders a **full-width Control drawer below**, exactly like the Servers tab — reusing the same `ControlStrip` component, so the two views can't drift out of sync again.

### Fixed
`K` (grant SSH key) and `V` (create/resume vanity site) **on server results** — both were advertised in the legend but silently did nothing. `K` falls back to the server's first key-eligible site as the anchor, matching the Servers tab's behavior.

### Testing
`bun run typecheck` green. Needs a visual pass in Search on both a site result and a server result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SG3orBudWnfTif1maqAeH3