### PR TITLE
feat: `spinuptui pull files` / `pull db` CLI subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ versions; such changes are called out here.
   - **`pull files` never re-syncs over an existing copy** — a site that's
     already linked is refused with its current path, rather than clobbering
     local work.
+  - **`pull files` warns that the copied `wp-config.php` is production's**, and
+    a `pull db` that's denied by local MySQL says why. The rsync path brings
+    down the site's real `wp-config.php`, credentials and all — harmless (their
+    `DB_HOST` is localhost, so nothing local can reach production's database
+    through them) but it means local wp-cli authenticates as the *production*
+    DB user, and `pull db` fails on its very first step until they're pointed
+    at a local database.
   - The path argument is optional only when exactly one `localRoots` entry is
     configured. With several, it's required: which root a site belongs in isn't
     knowable from here, and guessing would file a standard-WP site under

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,9 @@ versions; such changes are called out here.
     credentials included, on the file-pull path. Nothing local can reach the
     production database through them (its `DB_HOST` is localhost), but local
     wp-cli authenticates as the production DB user, so the DB pull offered on
-    the same screen is denied until they're pointed at a local database.
+    the same screen is denied until they're pointed at a local database. A
+    Bedrock/Radicle clone gets the mirror-image note: `.env` holds its database
+    credentials and isn't in the repo, so a fresh checkout has none.
 
 ## [0.25.0] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ versions; such changes are called out here.
     through them) but it means local wp-cli authenticates as the *production*
     DB user, and `pull db` fails on its very first step until they're pointed
     at a local database.
+  - **`--server <name>` picks one site when a domain exists on more than one
+    server**, and the ambiguity itself now lists what matched (in both output
+    modes) instead of only saying there was more than one.
+  - **A Bedrock/Radicle clone is flagged for its missing `.env`** — that's where
+    its database credentials live and it's deliberately not in the repo, so
+    `pull db` would otherwise die on `mysqldump: unknown variable 'pass='`.
+    It's now caught up front, by name.
   - The path argument is optional only when exactly one `localRoots` entry is
     configured. With several, it's required: which root a site belongs in isn't
     knowable from here, and guessing would file a standard-WP site under

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ versions; such changes are called out here.
 ## [Unreleased]
 
 ### Added
+- **`spinuptui pull files` and `spinuptui pull db`** — the local-working-copy
+  setup and DB sync, driven non-interactively from the command line, on the
+  same engines the TUI's guided flow uses. `pull files <domain> [path]` clones a
+  site's code down and links it; `pull db <domain> --yes` imports production's
+  database into that copy. Built for an agentic workflow ("pull site X down for
+  local dev") as much as for a person: progress goes to stderr, and stdout
+  carries the machine contract — with `--json`, a single result object, exit
+  code mirroring `ok`, and failures carrying both a stable `reason` code and a
+  `remedy` naming the exact command that fixes it.
+  - **`pull db` is gated twice**, since it overwrites the local database:
+    `"localSync": true` in the config (the same opt-in the TUI enforces) *and*
+    `--yes` on the invocation. Both are checked before any network call, so a
+    typo'd domain in a script bounces off the gate rather than off a lookup.
+  - **`pull files` never re-syncs over an existing copy** — a site that's
+    already linked is refused with its current path, rather than clobbering
+    local work.
+  - The path argument is optional only when exactly one `localRoots` entry is
+    configured. With several, it's required: which root a site belongs in isn't
+    knowable from here, and guessing would file a standard-WP site under
+    Bedrock.
 - **Clone a site's full local working copy from production** — `L` on a site
   with no local copy yet now opens a choose screen: `e` is the existing manual
   "enter a path" form, and the new `c` runs a guided clone. It pulls the code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+### Added
+- **Clone a site's full local working copy from production** — `L` on a site
+  with no local copy yet now opens a choose screen: `e` is the existing manual
+  "enter a path" form, and the new `c` runs a guided clone. It pulls the code
+  down (a `git clone` for git-deployed sites, an `rsync` over SSH for everything
+  else), runs `composer install` when the checkout turns out to be
+  Bedrock/Radicle, links the result exactly as the manual form would, and then
+  hands off to the existing DB sync (`p`) and production-media (`m`) flows
+  unchanged — three already-reviewed screens chained by keypresses rather than
+  one new mega-flow. The local database and webserver config are never touched.
+  - The rsync pull always takes the site's whole files root (so a `public/`-style
+    layout brings `wp-config.php` down from one level above the webroot), and the
+    real webroot is **detected** on the server rather than trusting
+    `public_folder`.
+  - `wp-content/uploads` is excluded — production media is served through the
+    media-fallback mu-plugin (`m`) instead of copied.
+  - `object-cache.php` and `advanced-cache.php` are excluded outright: SpinupWP's
+    Redis drop-in doesn't no-op when Redis is unreachable, it 500s on a cache
+    miss, so copying them down fatals the local site.
+
 ## [0.25.0] - 2026-08-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ versions; such changes are called out here.
   - `object-cache.php` and `advanced-cache.php` are excluded outright: SpinupWP's
     Redis drop-in doesn't no-op when Redis is unreachable, it 500s on a cache
     miss, so copying them down fatals the local site.
+  - The done screen flags that the copied `wp-config.php` is **production's**,
+    credentials included, on the file-pull path. Nothing local can reach the
+    production database through them (its `DB_HOST` is localhost), but local
+    wp-cli authenticates as the production DB user, so the DB pull offered on
+    the same screen is denied until they're pointed at a local database.
 
 ## [0.25.0] - 2026-08-12
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,11 @@ spinuptui pull files <domain> [path] [--url <local url>] [--json]
                      over your work. With exactly one `localRoots` entry
                      configured the path is optional (defaults to
                      `<that root>/<domain>`); with several, it's required,
-                     since which root a site belongs in isn't knowable.
+                     since which root a site belongs in isn't knowable. Note
+                     the rsync path copies the site's real `wp-config.php` —
+                     production credentials and all — so point its DB settings
+                     at your local database before `pull db` (the command says
+                     so on success, and again if the import is denied).
 spinuptui pull db <domain> [--url <local url>] --yes [--json]
                      Import production's database into the already-linked local
                      copy, rewriting production URLs to the local URL, after

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@
 - **Installed plugins & themes** (`e`) — real `wp plugin`/`theme list` over SSH,
   with per-item version and update status. → [docs/plugins-themes.md](docs/plugins-themes.md)
 - **Open in browser** (`o`) / **SSH into a site** (`s`) — one-key shortcuts.
-- **Link local working copies** (`L`) — link a site to its local checkout, with
-  auto-discovery and git-drift indicators. → [docs/local-working-copies.md](docs/local-working-copies.md)
+- **Local working copies** (`L`) — link a site to its local checkout, or clone
+  one from production (`c`) when you don't have it yet; with auto-discovery and
+  git-drift indicators. → [docs/local-working-copies.md](docs/local-working-copies.md)
 - **DNS migration lens** (`n` / `N`) — see and edit a site's hosting records,
   repoint it to another server. → [docs/dns-access-editing.md](docs/dns-access-editing.md)
 - **Database backup & sync** (`d` / `p`, Servers / Search tabs) — download or
@@ -256,7 +257,7 @@ These can be set in `config.json` or via an environment variable:
 | `d` | Download a production DB backup into the linked copy (Servers / Search; WordPress + linked) |
 | `p` | Pull the production DB into the linked copy — overwrites local; opt-in via `localSync` (Servers / Search) |
 | `m` | Production media fallback: serve missing-locally images from production (Servers / Search; WordPress + linked) |
-| `L` | Link / edit a site's local working copy |
+| `L` | Link / edit a site's local working copy — on an unlinked site, `e` enters a path by hand and `c` clones one from production |
 | `t` / `v` | Open the linked copy in a terminal / its local URL in your browser |
 | `n` | DNS migration view for a site — its records + TTLs (`⏎` edits a TTL; `p` repoints the record; `a` shows the whole server) |
 | `N` | DNS migration view for the whole server |

--- a/README.md
+++ b/README.md
@@ -193,7 +193,8 @@ spinuptui incidents <domain> | --all [--hours N]  Print Uptime Kuma down/up
                      monitoring for (config.json's kumaMonitors) — --all
                      sweeps every such site in one Kuma connection, --hours
                      sets the lookback window (default 24)
-spinuptui pull files <domain> [path] [--url <local url>] [--json]
+spinuptui pull files <domain> [path] [--url <local url>] [--server <name>]
+                     [--json]
                      Set up a new local working copy of a site: `git clone` for
                      git-deployed sites, `rsync` over SSH otherwise (excluding
                      uploads and the caching drop-ins), `composer install` for
@@ -207,8 +208,13 @@ spinuptui pull files <domain> [path] [--url <local url>] [--json]
                      the rsync path copies the site's real `wp-config.php` —
                      production credentials and all — so point its DB settings
                      at your local database before `pull db` (the command says
-                     so on success, and again if the import is denied).
-spinuptui pull db <domain> [--url <local url>] --yes [--json]
+                     so on success, and again if the import is denied). A
+                     Bedrock/Radicle clone lands without its `.env` — which is
+                     where its DB credentials live and is deliberately not in
+                     the repo — and says so the same way. `--server <name>`
+                     picks one site when a domain exists on more than one
+                     server; the ambiguity message lists the candidates.
+spinuptui pull db <domain> [--url <local url>] [--server <name>] --yes [--json]
                      Import production's database into the already-linked local
                      copy, rewriting production URLs to the local URL, after
                      dumping the current local database as a backup. This
@@ -226,8 +232,9 @@ result to **stdout** — with `--json`, a single result object (`{ok:true, …}`
 `{ok:false, reason, message, remedy}`), and the exit code mirrors `ok`. That
 keeps stdout parseable for an agent while a person watching a ten-minute rsync
 can still see it isn't hung. Failures carry a machine-readable `reason`
-(`site_not_found`, `already_linked`, `dest_not_empty`, `ambiguous_dest`,
-`not_linked`, `local_sync_disabled`, `not_confirmed`, …) and, where there's a
+(`site_not_found`, `multiple_matches`, `already_linked`, `dest_not_empty`,
+`ambiguous_dest`, `not_linked`, `missing_env`, `local_sync_disabled`,
+`not_confirmed`, …) and, where there's a
 clear next step, a `remedy` naming the exact command to run.
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -81,9 +81,12 @@
   if it's read-only — anything that looks like a write/restart/destructive
   action is denied rather than run, so any agent using it inherits that
   guarantee without building its own guard; `spinuptui incidents <domain>` /
-  `--all` surfaces Uptime Kuma's down/up history as JSON. Built so another
-  agent/script can go from just a domain to "what's wrong and how do I get
-  in" with no manual lookup. → [CLI subcommands](#cli-subcommands)
+  `--all` surfaces Uptime Kuma's down/up history as JSON; `spinuptui pull files
+  <domain> [path]` and `spinuptui pull db <domain> --yes` set up a local working
+  copy from production without opening the TUI at all — the same engines the
+  guided flow drives. Built so another agent/script can go from just a domain to
+  "what's wrong and how do I get in", or to a working local copy, with no manual
+  lookup. → [CLI subcommands](#cli-subcommands)
 - **Completion toasts** — a non-focus-stealing toast when a background write
   (PHP upgrade, reboot, DNS resolve, …) finishes.
 - **Release notes** — an in-app "what's new" after every update, sourced
@@ -190,9 +193,38 @@ spinuptui incidents <domain> | --all [--hours N]  Print Uptime Kuma down/up
                      monitoring for (config.json's kumaMonitors) — --all
                      sweeps every such site in one Kuma connection, --hours
                      sets the lookback window (default 24)
+spinuptui pull files <domain> [path] [--url <local url>] [--json]
+                     Set up a new local working copy of a site: `git clone` for
+                     git-deployed sites, `rsync` over SSH otherwise (excluding
+                     uploads and the caching drop-ins), `composer install` for
+                     Bedrock/Radicle, then link it. Read-only on production.
+                     Refuses a path that exists and isn't empty, and refuses a
+                     site that already has a local copy rather than re-syncing
+                     over your work. With exactly one `localRoots` entry
+                     configured the path is optional (defaults to
+                     `<that root>/<domain>`); with several, it's required,
+                     since which root a site belongs in isn't knowable.
+spinuptui pull db <domain> [--url <local url>] --yes [--json]
+                     Import production's database into the already-linked local
+                     copy, rewriting production URLs to the local URL, after
+                     dumping the current local database as a backup. This
+                     **overwrites your local database**, so it's gated twice:
+                     `"localSync": true` must be set in the config (or
+                     `SPINUPWP_LOCAL_SYNC=1`) *and* `--yes` passed on the
+                     invocation. Both are checked before any network call.
+                     `--url` doubles as "set the local URL, then sync".
 spinuptui --version  Print the version
 spinuptui --help     Show help
 ```
+
+Both `pull` commands write human-readable progress to **stderr** and their
+result to **stdout** — with `--json`, a single result object (`{ok:true, …}` or
+`{ok:false, reason, message, remedy}`), and the exit code mirrors `ok`. That
+keeps stdout parseable for an agent while a person watching a ten-minute rsync
+can still see it isn't hung. Failures carry a machine-readable `reason`
+(`site_not_found`, `already_linked`, `dest_not_empty`, `ambiguous_dest`,
+`not_linked`, `local_sync_disabled`, `not_confirmed`, …) and, where there's a
+clear next step, a `remedy` naming the exact command to run.
 
 ## Configuration
 

--- a/docs/local-working-copies.md
+++ b/docs/local-working-copies.md
@@ -6,6 +6,25 @@ serve it; the site's details gain a "Local" field, and you can open the copy wit
 `t` (a terminal at the path) or `v` (its local URL). All of this is **local-only**
 — no SpinupWP writes.
 
+- **Clone one from production (`L` → `c`).** For a site you have no copy of yet,
+  `L` opens a choice: `e` to type in a path you already have, or `c` to build the
+  copy from production. The clone pulls the code down — a `git clone` for
+  git-deployed sites, an `rsync` over SSH for everything else — runs `composer
+  install` if the checkout turns out to be Bedrock/Radicle, links it, and then
+  hands off to the existing DB pull (`p`) and media fallback (`m`). It never
+  touches your local database or webserver config.
+  - **`wp-config.php` comes down too.** The pull takes the site's whole files
+    root, so a `public/`-style layout brings the config from one level above the
+    webroot — and the real webroot is *detected* on the server, never inferred
+    from the `public_folder` setting. That config is **production's**, so point
+    `DB_NAME` / `DB_USER` / `DB_PASSWORD` / `DB_HOST` at a local database before
+    pulling the DB. (A Bedrock/Radicle clone has the opposite problem: `.env`
+    isn't in the repo, so the checkout arrives without one.) The done screen
+    says which applies.
+  - **`wp-content/uploads` is skipped** — that's what the media fallback (`m`) is
+    for — as are `object-cache.php` and `advanced-cache.php`, which are wired to
+    production's Redis and fatal locally rather than degrading quietly.
+
 - **Auto-discover (`S`, Stacks tab).** Scan one or more folders and match their
   subdirectories to sites — by git remote, Bedrock `WP_HOME`, or folder name —
   then batch-link the matches.

--- a/docs/local-working-copies.md
+++ b/docs/local-working-copies.md
@@ -35,5 +35,31 @@ serve it; the site's details gain a "Local" field, and you can open the copy wit
   shows its local git drift (`⇡N unpushed` / `● uncommitted`), read from the repo
   with no network.
 
+## From the command line
+
+The same two engines run without the TUI, for a script or an agent handed only a
+domain:
+
+```sh
+spinuptui pull files <domain> [path] [--url <local url>] [--server <name>] [--json]
+spinuptui pull db <domain> [--url <local url>] [--server <name>] --yes [--json]
+```
+
+`pull files` clones the code down and links it; `pull db` imports production's
+database into that copy, rewriting URLs. Progress goes to stderr and the result
+to stdout — with `--json`, one object, exit code mirroring `ok`, and a `reason`
+plus a `remedy` naming the exact command that fixes any failure.
+
+- **`pull db` is gated twice**, since it overwrites your local database:
+  `"localSync": true` in the config *and* `--yes` on the invocation. Both are
+  checked before any network call.
+- **`pull files` won't re-sync over an existing copy** — a site that's already
+  linked is refused with its current path, rather than clobbering local work.
+- **The path is optional only with exactly one `localRoots` entry** (it becomes
+  `<that root>/<domain>`). With several configured, which one a site belongs in
+  isn't knowable, so it's required.
+- **`--server <name>`** picks one site when a domain exists on more than one
+  server; it works on `ssh` and `ssh-exec` too.
+
 Config keys: `localRoots` (folders to scan) and `localSites` (per-site path +
 local URL — tool-agnostic: Valet, Cove, LocalWP, Herd, DDEV, …).

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,7 @@ import { SpinupWPClient } from "./api/client.ts"
 import { resolveSshAccess } from "./lib/cliSsh.ts"
 import { resolveIncidents } from "./lib/cliIncidents.ts"
 import { execSshCommand } from "./lib/sshExec.ts"
+import { runPullFiles, runPullDb } from "./lib/cliPull.ts"
 
 const args = process.argv.slice(2)
 const positionals = args.filter((a) => !a.startsWith("-"))
@@ -34,8 +35,20 @@ Usage:
                        (JSON); denies anything that looks like a remote write
   spinuptui incidents <domain> | --all [--hours N]  Print Uptime Kuma
                        down/up incidents for a site or the whole fleet (JSON)
+  spinuptui pull files <domain> [path] [--url <local url>]
+                       Clone a site's code to a new local working copy and link
+                       it. Read-only on production; refuses a non-empty path.
+                       With exactly one localRoots entry configured, the path
+                       defaults to <that root>/<domain>.
+  spinuptui pull db <domain> [--url <local url>] --yes
+                       Import production's database into the linked local copy,
+                       rewriting URLs. OVERWRITES your local database: needs
+                       both --yes and "localSync": true in the config.
   spinuptui --version  Print the version
   spinuptui --help     Show this help
+
+Add --json to either pull command for a single machine-readable result object
+on stdout; progress always goes to stderr, so a long pull never looks hung.
 
 Token resolution: SPINUPWP_ACCESS_TOKEN (env / .env) first, then the config
 file. Run \`spinuptui login\` once to save a token so \`spinuptui\` works from
@@ -108,6 +121,73 @@ if (command === "incidents") {
   const cfg = loadConfig()
   const result = await resolveIncidents(cfg, { domain: domainArg, hours })
   console.log(JSON.stringify(result))
+  process.exit(result.ok ? 0 : 1)
+}
+
+if (command === "pull") {
+  const rest = args.slice(1)
+  const json = rest.includes("--json")
+  const yes = rest.includes("--yes")
+  const urlIdx = rest.indexOf("--url")
+  const url = urlIdx !== -1 ? (rest[urlIdx + 1] ?? null) : null
+  // Positionals, skipping flags and the value that belongs to --url (which is a
+  // URL, so it doesn't look like a flag and would otherwise be read as a path).
+  const pos: string[] = []
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i]!
+    if (a.startsWith("-")) {
+      if (a === "--url") i++
+      continue
+    }
+    pos.push(a)
+  }
+  const sub = pos[0]
+  const domain = pos[1]
+  const destPath = pos[2] ?? null
+
+  const usage = (message: string) => {
+    console.error(JSON.stringify({ ok: false, reason: "usage", message }))
+    process.exit(1)
+  }
+
+  if (sub !== "files" && sub !== "db") {
+    usage("Usage: spinuptui pull files <domain> [path] [--url <local url>] | spinuptui pull db <domain> [--url <local url>] --yes")
+  }
+  if (!domain) usage(`Usage: spinuptui pull ${sub} <domain>`)
+  if (urlIdx !== -1 && (!url || url.startsWith("-"))) usage("--url needs a value, e.g. --url https://example.test")
+  if (sub === "db" && destPath) usage("`pull db` imports into the already-linked copy and takes no path. Use --url to set the local URL.")
+
+  const cfg = loadConfig()
+  const client = new SpinupWPClient(cfg)
+  // Progress is a human channel on stderr in both modes: it keeps a long rsync
+  // from looking hung, and leaves stdout as the machine contract.
+  const onStage = (line: string) => process.stderr.write(`\u2192 ${line}\n`)
+
+  const result =
+    sub === "files"
+      ? await runPullFiles(domain!, { path: destPath, url }, client, cfg, onStage)
+      : await runPullDb(domain!, { url, yes }, client, cfg, onStage)
+
+  if (json) {
+    console.log(JSON.stringify(result))
+  } else if (result.ok) {
+    if (result.command === "pull files") {
+      const built = result.ranComposer ? ", composer install ran" : ""
+      console.log(`Pulled ${result.primaryDomain} to ${result.path} (${result.method}${built}) and linked it.`)
+      console.log(
+        result.localUrl
+          ? `Next: spinuptui pull db ${result.primaryDomain} --yes`
+          : `Next: spinuptui pull db ${result.primaryDomain} --url <local url> --yes`,
+      )
+    } else {
+      console.log(`Imported production's database for ${result.primaryDomain} into ${result.path}.`)
+      console.log(`Local database backed up first to ${result.localBackupPath}`)
+    }
+    if (result.warning) console.error(`Warning: ${result.warning}`)
+  } else {
+    console.error(result.message)
+    if (result.remedy) console.error(result.remedy)
+  }
   process.exit(result.ok ? 0 : 1)
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -183,7 +183,7 @@ if (command === "pull") {
       console.log(`Imported production's database for ${result.primaryDomain} into ${result.path}.`)
       console.log(`Local database backed up first to ${result.localBackupPath}`)
     }
-    if (result.warning) console.error(`Warning: ${result.warning}`)
+    for (const warning of result.warnings ?? []) console.error(`Warning: ${warning}`)
   } else {
     console.error(result.message)
     if (result.remedy) console.error(result.remedy)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,20 +35,22 @@ Usage:
                        (JSON); denies anything that looks like a remote write
   spinuptui incidents <domain> | --all [--hours N]  Print Uptime Kuma
                        down/up incidents for a site or the whole fleet (JSON)
-  spinuptui pull files <domain> [path] [--url <local url>]
+  spinuptui pull files <domain> [path] [--url <local url>] [--server <name>]
                        Clone a site's code to a new local working copy and link
                        it. Read-only on production; refuses a non-empty path.
                        With exactly one localRoots entry configured, the path
                        defaults to <that root>/<domain>.
-  spinuptui pull db <domain> [--url <local url>] --yes
+  spinuptui pull db <domain> [--url <local url>] [--server <name>] --yes
                        Import production's database into the linked local copy,
                        rewriting URLs. OVERWRITES your local database: needs
                        both --yes and "localSync": true in the config.
   spinuptui --version  Print the version
   spinuptui --help     Show this help
 
-Add --json to either pull command for a single machine-readable result object
-on stdout; progress always goes to stderr, so a long pull never looks hung.
+--server picks one site when a domain exists on more than one server (the
+ambiguity message lists them). Add --json to either pull command for a single
+machine-readable result object on stdout; progress always goes to stderr, so a
+long pull never looks hung.
 
 Token resolution: SPINUPWP_ACCESS_TOKEN (env / .env) first, then the config
 file. Run \`spinuptui login\` once to save a token so \`spinuptui\` works from
@@ -130,13 +132,15 @@ if (command === "pull") {
   const yes = rest.includes("--yes")
   const urlIdx = rest.indexOf("--url")
   const url = urlIdx !== -1 ? (rest[urlIdx + 1] ?? null) : null
+  const serverIdx = rest.indexOf("--server")
+  const server = serverIdx !== -1 ? (rest[serverIdx + 1] ?? null) : null
   // Positionals, skipping flags and the value that belongs to --url (which is a
   // URL, so it doesn't look like a flag and would otherwise be read as a path).
   const pos: string[] = []
   for (let i = 0; i < rest.length; i++) {
     const a = rest[i]!
     if (a.startsWith("-")) {
-      if (a === "--url") i++
+      if (a === "--url" || a === "--server") i++
       continue
     }
     pos.push(a)
@@ -155,6 +159,7 @@ if (command === "pull") {
   }
   if (!domain) usage(`Usage: spinuptui pull ${sub} <domain>`)
   if (urlIdx !== -1 && (!url || url.startsWith("-"))) usage("--url needs a value, e.g. --url https://example.test")
+  if (serverIdx !== -1 && (!server || server.startsWith("-"))) usage("--server needs a value, e.g. --server web1.example.com")
   if (sub === "db" && destPath) usage("`pull db` imports into the already-linked copy and takes no path. Use --url to set the local URL.")
 
   const cfg = loadConfig()
@@ -165,8 +170,8 @@ if (command === "pull") {
 
   const result =
     sub === "files"
-      ? await runPullFiles(domain!, { path: destPath, url }, client, cfg, onStage)
-      : await runPullDb(domain!, { url, yes }, client, cfg, onStage)
+      ? await runPullFiles(domain!, { path: destPath, url, server }, client, cfg, onStage)
+      : await runPullDb(domain!, { url, yes, server }, client, cfg, onStage)
 
   if (json) {
     console.log(JSON.stringify(result))
@@ -186,6 +191,7 @@ if (command === "pull") {
     for (const warning of result.warnings ?? []) console.error(`Warning: ${warning}`)
   } else {
     console.error(result.message)
+    for (const c of result.candidates ?? []) console.error(`  · ${c.server} (site ${c.siteId})`)
     if (result.remedy) console.error(result.remedy)
   }
   process.exit(result.ok ? 0 : 1)

--- a/src/lib/cliPull.ts
+++ b/src/lib/cliPull.ts
@@ -1,0 +1,333 @@
+// `spinuptui pull files` / `spinuptui pull db` — the two local-working-copy
+// engines, driven non-interactively.
+//
+// Same engines the TUI drives (lib/localSetup.ts and lib/dbSync.ts), same
+// domain resolution as `ssh`/`ssh-exec` (lib/cliSsh.ts's resolveSiteByDomain),
+// so behavior can't drift between the two front ends. Nothing here reimplements
+// a step; this file is argument resolution, gating, and result shaping.
+//
+// Output contract, matching the other subcommands: the returned object is the
+// machine-readable result (one JSON object on stdout under --json, exit code
+// mirrors `ok`). Progress goes to the caller's `onStage` — stderr, always,
+// human-readable — so a person watching a ten-minute rsync can see it isn't
+// hung and an agent still has the trail when something fails.
+//
+// `pull files` is read-only on production. `pull db` OVERWRITES the local
+// database, so it's gated twice: the `localSync` config opt-in (same gate the
+// TUI enforces) and an explicit `--yes` on the invocation. Both are checked
+// before any network call, so a typo'd domain in a script fails on the gate.
+
+import { join } from "node:path"
+import { configPath, type AppConfig } from "../config.ts"
+import type { SpinupWPClientLike } from "../api/client.ts"
+import { resolveSiteByDomain, type SshAccessCandidate, type SshAccessReason } from "./cliSsh.ts"
+import { planLocalSetup, runLocalSetup, type LocalSetupStage } from "./localSetup.ts"
+import { planDbSync, runDbSync, type DbSyncStage } from "./dbSync.ts"
+import { readLink, writeLink } from "./links.ts"
+import { expandPath } from "./local.ts"
+
+export type PullReason =
+  | SshAccessReason
+  | "no_dest"
+  | "ambiguous_dest"
+  | "already_linked"
+  | "dest_not_empty"
+  | "plan_failed"
+  | "fetch_failed"
+  | "composer_failed"
+  | "not_linked"
+  | "local_sync_disabled"
+  | "not_confirmed"
+  | "sync_failed"
+
+export type PullCommand = "pull files" | "pull db"
+
+export interface PullFailure {
+  ok: false
+  command: PullCommand
+  domain: string
+  reason: PullReason
+  message: string
+  remedy?: string
+  candidates?: SshAccessCandidate[]
+  failedStage?: string
+}
+
+export interface PullFilesSuccess {
+  ok: true
+  command: "pull files"
+  domain: string
+  primaryDomain: string
+  path: string
+  localUrl: string
+  method: "git" | "rsync"
+  ranComposer: boolean
+  linked: true
+  // Present when the copy is on disk and linked but not yet usable by `pull db`
+  // — it needs a local URL to rewrite production URLs to.
+  warning?: string
+}
+
+export interface PullDbSuccess {
+  ok: true
+  command: "pull db"
+  domain: string
+  primaryDomain: string
+  path: string
+  localUrl: string
+  downloadPath: string
+  localBackupPath: string
+  ranHook: boolean
+  warning?: string
+}
+
+export type PullFilesResult = PullFilesSuccess | PullFailure
+export type PullDbResult = PullDbSuccess | PullFailure
+
+export type StageReporter = (line: string) => void
+
+const FILES_STAGE_LABELS: Record<LocalSetupStage, string> = {
+  fetch: "Getting the code down",
+  build: "composer install",
+  done: "Done",
+  error: "Failed",
+}
+
+const DB_STAGE_LABELS: Record<DbSyncStage, string> = {
+  "local-backup": "Backing up the local database first",
+  export: "Exporting the production database",
+  download: "Downloading the dump",
+  import: "Importing into the local database",
+  replace: "Rewriting production URLs to local",
+  hook: "Running bin/sync.d/post-import.sh",
+  done: "Done",
+  error: "Failed",
+}
+
+// Shape a resolver failure (unknown domain, ambiguous domain, dead token, …)
+// into this command's result type, preserving the shared reason codes.
+function fromResolverFailure(command: PullCommand, failure: { ok: false } & Record<string, unknown>): PullFailure {
+  return {
+    ok: false,
+    command,
+    domain: String(failure.domain ?? ""),
+    reason: failure.reason as PullReason,
+    message: String(failure.message ?? ""),
+    ...(failure.remedy ? { remedy: String(failure.remedy) } : {}),
+    ...(failure.candidates ? { candidates: failure.candidates as SshAccessCandidate[] } : {}),
+  }
+}
+
+export async function runPullFiles(
+  domain: string,
+  opts: { path?: string | null; url?: string | null },
+  client: SpinupWPClientLike,
+  cfg: AppConfig,
+  onStage: StageReporter,
+): Promise<PullFilesResult> {
+  const command: PullCommand = "pull files"
+  const fail = (reason: PullReason, message: string, remedy?: string): PullFailure => ({
+    ok: false,
+    command,
+    domain,
+    reason,
+    message,
+    ...(remedy ? { remedy } : {}),
+  })
+
+  onStage(`Resolving ${domain} …`)
+  const resolved = await resolveSiteByDomain(domain, client, cfg)
+  if (!resolved.ok) return fromResolverFailure(command, resolved.result)
+  const { site, server } = resolved
+  onStage(`Site ${site.domain} on ${server.name} (${server.ip_address})`)
+
+  // A site that already has a local copy is not re-pulled: this engine only
+  // ever populates an empty directory, and re-syncing over an existing checkout
+  // would clobber local work. Refuse and say where the copy already is.
+  const existing = readLink(site.id)
+  if (existing) {
+    return fail(
+      "already_linked",
+      `${site.domain} already has a local copy at ${existing.path}.`,
+      "Pull the database into it with `spinuptui pull db`, or unlink it first (run `spinuptui`, select the site, press L then x).",
+    )
+  }
+
+  // Destination: the explicit argument, else derived as <localRoot>/<primary
+  // domain>, so an agent handed only a domain never has to invent a filesystem
+  // path. Only derived when there's exactly one root — with several configured
+  // there's no way to tell which one this site belongs in (they're commonly
+  // split by stack), and guessing would file a standard-WP site under Bedrock.
+  let dest = opts.path?.trim() ?? ""
+  if (!dest) {
+    if (cfg.localRoots.length === 0) {
+      return fail(
+        "no_dest",
+        "No destination path given, and no localRoots configured to derive one from.",
+        `Pass a path (\`spinuptui pull files ${domain} <path>\`), or set "localRoots": ["~/your/dev/dir"] in ${configPath()}.`,
+      )
+    }
+    if (cfg.localRoots.length > 1) {
+      return fail(
+        "ambiguous_dest",
+        `No destination path given, and ${cfg.localRoots.length} localRoots are configured (${cfg.localRoots.join(", ")}) — which one this site belongs in isn't knowable from here.`,
+        `Pass a path, e.g. \`spinuptui pull files ${domain} ${join(cfg.localRoots[0]!, site.domain)}\`.`,
+      )
+    }
+    dest = join(cfg.localRoots[0]!, site.domain)
+    onStage(`Destination derived from localRoots: ${dest}`)
+  }
+  const localUrl = opts.url?.trim() ?? ""
+
+  const planned = planLocalSetup(site, server, cfg.sshUser, dest, localUrl)
+  if (!planned.ok) {
+    const reason: PullReason = /isn't empty/i.test(planned.error) ? "dest_not_empty" : "plan_failed"
+    return fail(reason, planned.error)
+  }
+  const plan = planned.plan
+
+  onStage(
+    plan.isGit
+      ? `Source: git clone ${plan.repoUrl}`
+      : `Source: rsync ${plan.user}@${plan.host}:${plan.filesRoot}/ (excluding uploads and the caching drop-ins)`,
+  )
+  onStage(`Destination: ${plan.destPath}`)
+
+  let lastStage: LocalSetupStage | null = null
+  const result = await runLocalSetup(plan, (p) => {
+    if (p.stage !== lastStage && p.stage !== "done" && p.stage !== "error") {
+      lastStage = p.stage
+      onStage(`${FILES_STAGE_LABELS[p.stage]} …`)
+    }
+  })
+
+  if (result.stage === "error") {
+    const reason: PullReason = result.failedStage === "build" ? "composer_failed" : "fetch_failed"
+    return {
+      ...fail(reason, result.error ?? "The pull failed."),
+      ...(result.failedStage ? { failedStage: result.failedStage } : {}),
+    }
+  }
+
+  // Link it exactly as the TUI's guided clone does — `pull db` and the TUI's
+  // own `p`/`m` flows all key off this link.
+  await writeLink(site.id, { domain: site.domain, path: plan.destPath, localUrl })
+  onStage(`Linked ${site.domain} → ${plan.destPath}`)
+
+  return {
+    ok: true,
+    command,
+    domain,
+    primaryDomain: site.domain,
+    path: plan.destPath,
+    localUrl,
+    method: plan.isGit ? "git" : "rsync",
+    ranComposer: result.ranComposer === true,
+    linked: true,
+    ...(localUrl
+      ? {}
+      : {
+          warning: `No local URL recorded. \`spinuptui pull db ${site.domain}\` needs one to rewrite production URLs — pass --url on the next run.`,
+        }),
+  }
+}
+
+export async function runPullDb(
+  domain: string,
+  opts: { url?: string | null; yes: boolean },
+  client: SpinupWPClientLike,
+  cfg: AppConfig,
+  onStage: StageReporter,
+): Promise<PullDbResult> {
+  const command: PullCommand = "pull db"
+  const fail = (reason: PullReason, message: string, remedy?: string): PullFailure => ({
+    ok: false,
+    command,
+    domain,
+    reason,
+    message,
+    ...(remedy ? { remedy } : {}),
+  })
+
+  // Both gates first, before any network call: a wrong domain in a script
+  // should bounce off the confirmation, not off a fleet lookup.
+  if (!cfg.localSync) {
+    return fail(
+      "local_sync_disabled",
+      "Local database sync is disabled for this install.",
+      `Set "localSync": true in ${configPath()} (or export SPINUPWP_LOCAL_SYNC=1) to enable it.`,
+    )
+  }
+  if (!opts.yes) {
+    return fail(
+      "not_confirmed",
+      `This overwrites the local database for ${domain} with production's.`,
+      `Re-run with --yes once you're sure: \`spinuptui pull db ${domain} --yes\`.`,
+    )
+  }
+
+  onStage(`Resolving ${domain} …`)
+  const resolved = await resolveSiteByDomain(domain, client, cfg)
+  if (!resolved.ok) return fromResolverFailure(command, resolved.result)
+  const { site, server } = resolved
+
+  let link = readLink(site.id)
+  if (!link) {
+    return fail(
+      "not_linked",
+      `${site.domain} has no local copy linked, so there's nothing to import into.`,
+      `Run \`spinuptui pull files ${domain} <path> --url <local url>\` first.`,
+    )
+  }
+  // `--url` here doubles as "set the local URL and then sync", which is how a
+  // copy pulled without one becomes syncable without a detour through the TUI.
+  const url = opts.url?.trim()
+  if (url && url !== link.localUrl) {
+    link = { ...link, localUrl: url }
+    await writeLink(site.id, link)
+    onStage(`Local URL set to ${url}`)
+  }
+  onStage(`Local copy: ${expandPath(link.path)}`)
+
+  const planned = planDbSync(site, server, cfg.sshUser, link, new Date())
+  if (!planned.ok) {
+    return fail(
+      "plan_failed",
+      planned.error,
+      /local URL/i.test(planned.error) ? `Pass --url <local url> (e.g. \`spinuptui pull db ${domain} --url https://example.test --yes\`).` : undefined,
+    )
+  }
+  const plan = planned.plan
+
+  onStage(`Rewriting ${plan.remoteOrigin} → ${plan.localOrigin}`)
+  if (plan.prefixWarning) onStage(`Warning: ${plan.prefixWarning}`)
+  onStage(`A pre-import backup of the local database is written to ${plan.localBackupPath}`)
+
+  let lastStage: DbSyncStage | null = null
+  const result = await runDbSync(plan, site.domain, (p) => {
+    if (p.stage !== lastStage && p.stage !== "done" && p.stage !== "error") {
+      lastStage = p.stage
+      onStage(`${DB_STAGE_LABELS[p.stage]} …`)
+    }
+  })
+
+  if (result.stage === "error") {
+    return {
+      ...fail("sync_failed", result.error ?? "The sync failed."),
+      ...(result.failedStage ? { failedStage: result.failedStage } : {}),
+    }
+  }
+
+  return {
+    ok: true,
+    command,
+    domain,
+    primaryDomain: site.domain,
+    path: expandPath(link.path),
+    localUrl: plan.localOrigin,
+    downloadPath: result.downloadPath ?? plan.downloadPath,
+    localBackupPath: result.localBackupPath ?? plan.localBackupPath,
+    ranHook: result.ranHook === true,
+    ...(plan.prefixWarning ? { warning: plan.prefixWarning } : {}),
+  }
+}

--- a/src/lib/cliPull.ts
+++ b/src/lib/cliPull.ts
@@ -17,6 +17,7 @@
 // TUI enforces) and an explicit `--yes` on the invocation. Both are checked
 // before any network call, so a typo'd domain in a script fails on the gate.
 
+import { existsSync } from "node:fs"
 import { join } from "node:path"
 import { configPath, type AppConfig } from "../config.ts"
 import type { SpinupWPClientLike } from "../api/client.ts"
@@ -63,9 +64,9 @@ export interface PullFilesSuccess {
   method: "git" | "rsync"
   ranComposer: boolean
   linked: true
-  // Present when the copy is on disk and linked but not yet usable by `pull db`
-  // — it needs a local URL to rewrite production URLs to.
-  warning?: string
+  // Non-fatal caveats about the copy that just landed — most importantly the
+  // things standing between it and a working `pull db`.
+  warnings?: string[]
 }
 
 export interface PullDbSuccess {
@@ -78,7 +79,7 @@ export interface PullDbSuccess {
   downloadPath: string
   localBackupPath: string
   ranHook: boolean
-  warning?: string
+  warnings?: string[]
 }
 
 export type PullFilesResult = PullFilesSuccess | PullFailure
@@ -214,6 +215,24 @@ export async function runPullFiles(
   await writeLink(site.id, { domain: site.domain, path: plan.destPath, localUrl })
   onStage(`Linked ${site.domain} → ${plan.destPath}`)
 
+  const warnings: string[] = []
+  if (!localUrl) {
+    warnings.push(
+      `No local URL recorded. \`spinuptui pull db ${site.domain}\` needs one to rewrite production URLs — pass --url on the next run.`,
+    )
+  }
+  // The rsync path copies the site's real wp-config.php, which holds
+  // PRODUCTION's database credentials. Harmless in itself (SpinupWP's DB_HOST
+  // is localhost, so nothing local can reach the production database through
+  // it) but it means local wp-cli — and therefore `pull db` — authenticates as
+  // the production DB user against the local server and is denied. Say so here
+  // rather than letting it surface as a bare "Access denied" three steps later.
+  if (!plan.isGit && existsSync(join(plan.destPath, "wp-config.php"))) {
+    warnings.push(
+      `wp-config.php came from production and still holds its database credentials. Point DB_NAME / DB_USER / DB_PASSWORD / DB_HOST at your local database before running \`spinuptui pull db ${site.domain}\`.`,
+    )
+  }
+
   return {
     ok: true,
     command,
@@ -224,11 +243,7 @@ export async function runPullFiles(
     method: plan.isGit ? "git" : "rsync",
     ranComposer: result.ranComposer === true,
     linked: true,
-    ...(localUrl
-      ? {}
-      : {
-          warning: `No local URL recorded. \`spinuptui pull db ${site.domain}\` needs one to rewrite production URLs — pass --url on the next run.`,
-        }),
+    ...(warnings.length ? { warnings } : {}),
   }
 }
 
@@ -312,8 +327,19 @@ export async function runPullDb(
   })
 
   if (result.stage === "error") {
+    const error = result.error ?? "The sync failed."
+    // The overwhelmingly likely cause right after `pull files`: the copied
+    // wp-config.php still carries production's DB credentials, so local wp-cli
+    // authenticates as the production user against the local MySQL.
+    const deniedAs = /access denied for user '([^']+)'/i.exec(error)?.[1]
     return {
-      ...fail("sync_failed", result.error ?? "The sync failed."),
+      ...fail(
+        "sync_failed",
+        error,
+        deniedAs
+          ? `Local MySQL refused the user "${deniedAs}". If this copy came from \`pull files\`, its wp-config.php still holds production's database credentials — point DB_NAME / DB_USER / DB_PASSWORD / DB_HOST at your local database and re-run.`
+          : undefined,
+      ),
       ...(result.failedStage ? { failedStage: result.failedStage } : {}),
     }
   }
@@ -328,6 +354,6 @@ export async function runPullDb(
     downloadPath: result.downloadPath ?? plan.downloadPath,
     localBackupPath: result.localBackupPath ?? plan.localBackupPath,
     ranHook: result.ranHook === true,
-    ...(plan.prefixWarning ? { warning: plan.prefixWarning } : {}),
+    ...(plan.prefixWarning ? { warnings: [plan.prefixWarning] } : {}),
   }
 }

--- a/src/lib/cliPull.ts
+++ b/src/lib/cliPull.ts
@@ -37,6 +37,7 @@ export type PullReason =
   | "fetch_failed"
   | "composer_failed"
   | "not_linked"
+  | "missing_env"
   | "local_sync_disabled"
   | "not_confirmed"
   | "sync_failed"
@@ -108,20 +109,29 @@ const DB_STAGE_LABELS: Record<DbSyncStage, string> = {
 // Shape a resolver failure (unknown domain, ambiguous domain, dead token, …)
 // into this command's result type, preserving the shared reason codes.
 function fromResolverFailure(command: PullCommand, failure: { ok: false } & Record<string, unknown>): PullFailure {
+  const candidates = failure.candidates as SshAccessCandidate[] | undefined
+  // Unlike `ssh`/`ssh-exec`, these commands can be pointed at one of the
+  // matches, so an ambiguous domain is recoverable — name the flag that does it.
+  const remedy =
+    failure.remedy != null
+      ? String(failure.remedy)
+      : failure.reason === "multiple_matches" && candidates?.length
+        ? `Pick one with --server, e.g. \`--server ${candidates[0]!.server}\`.`
+        : undefined
   return {
     ok: false,
     command,
     domain: String(failure.domain ?? ""),
     reason: failure.reason as PullReason,
     message: String(failure.message ?? ""),
-    ...(failure.remedy ? { remedy: String(failure.remedy) } : {}),
-    ...(failure.candidates ? { candidates: failure.candidates as SshAccessCandidate[] } : {}),
+    ...(remedy ? { remedy } : {}),
+    ...(candidates ? { candidates } : {}),
   }
 }
 
 export async function runPullFiles(
   domain: string,
-  opts: { path?: string | null; url?: string | null },
+  opts: { path?: string | null; url?: string | null; server?: string | null },
   client: SpinupWPClientLike,
   cfg: AppConfig,
   onStage: StageReporter,
@@ -137,7 +147,7 @@ export async function runPullFiles(
   })
 
   onStage(`Resolving ${domain} …`)
-  const resolved = await resolveSiteByDomain(domain, client, cfg)
+  const resolved = await resolveSiteByDomain(domain, client, cfg, { server: opts.server })
   if (!resolved.ok) return fromResolverFailure(command, resolved.result)
   const { site, server } = resolved
   onStage(`Site ${site.domain} on ${server.name} (${server.ip_address})`)
@@ -227,6 +237,16 @@ export async function runPullFiles(
   // it) but it means local wp-cli — and therefore `pull db` — authenticates as
   // the production DB user against the local server and is denied. Say so here
   // rather than letting it surface as a bare "Access denied" three steps later.
+  // The mirror image on the git path: Bedrock/Radicle keep DB credentials and
+  // WP_HOME in .env, which is deliberately NOT in the repo — so a fresh clone
+  // has none, and wp-cli runs with empty DB settings (`mysqldump: unknown
+  // variable 'pass='`). composer install having run is exactly the signal that
+  // this is such a checkout.
+  if (result.ranComposer && !existsSync(join(plan.destPath, ".env"))) {
+    warnings.push(
+      `No .env in the checkout — Bedrock/Radicle keep database credentials and WP_HOME there, and it isn't in the repo. Copy .env.example to .env and fill in DB_NAME / DB_USER / DB_PASSWORD / WP_HOME before running \`spinuptui pull db ${site.domain}\`.`,
+    )
+  }
   if (!plan.isGit && existsSync(join(plan.destPath, "wp-config.php"))) {
     warnings.push(
       `${join(plan.destPath, "wp-config.php")} came from production and still holds its database credentials. Point DB_NAME / DB_USER / DB_PASSWORD / DB_HOST at your local database before running \`spinuptui pull db ${site.domain}\`.`,
@@ -249,7 +269,7 @@ export async function runPullFiles(
 
 export async function runPullDb(
   domain: string,
-  opts: { url?: string | null; yes: boolean },
+  opts: { url?: string | null; yes: boolean; server?: string | null },
   client: SpinupWPClientLike,
   cfg: AppConfig,
   onStage: StageReporter,
@@ -282,7 +302,7 @@ export async function runPullDb(
   }
 
   onStage(`Resolving ${domain} …`)
-  const resolved = await resolveSiteByDomain(domain, client, cfg)
+  const resolved = await resolveSiteByDomain(domain, client, cfg, { server: opts.server })
   if (!resolved.ok) return fromResolverFailure(command, resolved.result)
   const { site, server } = resolved
 
@@ -313,6 +333,16 @@ export async function runPullDb(
     )
   }
   const plan = planned.plan
+
+  // Fail on the real cause rather than letting empty DB settings surface three
+  // steps later as `mysqldump: unknown variable 'pass='`.
+  if ((plan.localKind === "bedrock" || plan.localKind === "radicle") && !existsSync(join(plan.localRoot, ".env"))) {
+    return fail(
+      "missing_env",
+      `No .env in ${plan.localRoot} — this is a ${plan.localKind} checkout, so its database credentials live there and it isn't in the repo.`,
+      "Copy .env.example to .env and fill in DB_NAME / DB_USER / DB_PASSWORD / WP_HOME, then re-run.",
+    )
+  }
 
   onStage(`Rewriting ${plan.remoteOrigin} → ${plan.localOrigin}`)
   if (plan.prefixWarning) onStage(`Warning: ${plan.prefixWarning}`)

--- a/src/lib/cliPull.ts
+++ b/src/lib/cliPull.ts
@@ -229,7 +229,7 @@ export async function runPullFiles(
   // rather than letting it surface as a bare "Access denied" three steps later.
   if (!plan.isGit && existsSync(join(plan.destPath, "wp-config.php"))) {
     warnings.push(
-      `wp-config.php came from production and still holds its database credentials. Point DB_NAME / DB_USER / DB_PASSWORD / DB_HOST at your local database before running \`spinuptui pull db ${site.domain}\`.`,
+      `${join(plan.destPath, "wp-config.php")} came from production and still holds its database credentials. Point DB_NAME / DB_USER / DB_PASSWORD / DB_HOST at your local database before running \`spinuptui pull db ${site.domain}\`.`,
     )
   }
 

--- a/src/lib/cliSsh.ts
+++ b/src/lib/cliSsh.ts
@@ -66,6 +66,11 @@ export async function resolveSiteByDomain(
   domain: string,
   client: SpinupWPClientLike,
   cfg: AppConfig,
+  // Narrows an otherwise ambiguous domain to one server, by name — matching
+  // either the full name or its first label ("web1" for "web1.example.com"),
+  // which is what the ambiguity message itself prints. Callers that expose no
+  // way to pass it (ssh, ssh-exec) simply omit it and keep failing as before.
+  opts?: { server?: string | null },
 ): Promise<SiteResolution> {
   const fail = (
     partial: Omit<SshAccessResult & { ok: false }, "ok" | "domain">,
@@ -95,11 +100,27 @@ export async function resolveSiteByDomain(
           return { siteId: s.id, serverId: s.server_id, server: srv.name }
         }),
       )
-      return fail({
-        reason: "multiple_matches",
-        message: `"${domain}" matches ${matches.length} sites in this account — cannot pick one automatically.`,
-        candidates,
-      })
+      const wanted = opts?.server?.trim().toLowerCase()
+      const narrowed = wanted
+        ? candidates.filter((c) => {
+            const name = c.server.toLowerCase()
+            return name === wanted || name.split(".")[0] === wanted
+          })
+        : candidates
+      if (narrowed.length !== 1) {
+        return fail({
+          reason: "multiple_matches",
+          message: wanted
+            ? `"${domain}" matches ${matches.length} sites in this account, and ${narrowed.length === 0 ? "none are" : `${narrowed.length} are`} on a server matching "${opts?.server}".`
+            : `"${domain}" matches ${matches.length} sites in this account — cannot pick one automatically.`,
+          candidates,
+        })
+      }
+      site = matches.find((m) => m.id === narrowed[0]!.siteId)!
+      server = await client.getServer(site.server_id)
+      return server.ip_address
+        ? { ok: true, site, server }
+        : fail({ reason: "server_has_no_ip", message: `Server "${server.name}" has no IP address on file.` })
     }
     site = matches[0]!
     server = await client.getServer(site.server_id)

--- a/src/lib/cliSsh.ts
+++ b/src/lib/cliSsh.ts
@@ -5,6 +5,7 @@
 // trustworthy go/no-go rather than a guess.
 
 import type { AppConfig } from "../config.ts"
+import type { Server, Site } from "../api/types.ts"
 import type { SpinupWPClientLike } from "../api/client.ts"
 import { ApiError } from "../api/client.ts"
 import { resolveSiteSshTarget, SSH_OPTS } from "./probe.ts"
@@ -53,38 +54,39 @@ export type SshTargetResolution =
   | { ok: true; info: SshTargetInfo }
   | { ok: false; result: SshAccessResult & { ok: false } }
 
-// Domain -> site -> server -> SSH target/port, with no live connectivity check.
-// Split out of resolveSshAccess so callers that are about to run a real command
-// (which is itself a connectivity test) don't pay for a redundant probe first.
-export async function resolveSshTargetInfo(
+// A resolved domain, before anything is done with it. Shared by every
+// domain-addressed CLI command (`ssh`, `ssh-exec`, `pull`) so they all fail the
+// same way — same reason codes, same messages — on an unknown or ambiguous
+// domain, a rejected token, or a server with no IP.
+export type SiteResolution =
+  | { ok: true; site: Site; server: Server }
+  | { ok: false; result: SshAccessResult & { ok: false } }
+
+export async function resolveSiteByDomain(
   domain: string,
   client: SpinupWPClientLike,
   cfg: AppConfig,
-): Promise<SshTargetResolution> {
+): Promise<SiteResolution> {
+  const fail = (
+    partial: Omit<SshAccessResult & { ok: false }, "ok" | "domain">,
+  ): SiteResolution => ({ ok: false, result: { ok: false, domain, ...partial } })
+
   if (!cfg.token) {
-    return {
-      ok: false,
-      result: { ok: false, domain, reason: "no_token", message: "No API token configured. Run `spinuptui login`." },
-    }
+    return fail({ reason: "no_token", message: "No API token configured. Run `spinuptui login`." })
   }
 
-  let site
-  let server
+  let site: Site
+  let server: Server
   try {
     const sites = await client.listSites()
     const matches = sites.filter(
       (s) => s.domain === domain || s.additional_domains?.some((a) => a.domain === domain),
     )
     if (matches.length === 0) {
-      return {
-        ok: false,
-        result: {
-          ok: false,
-          domain,
-          reason: "site_not_found",
-          message: `No site matching "${domain}" found in this SpinupWP account.`,
-        },
-      }
+      return fail({
+        reason: "site_not_found",
+        message: `No site matching "${domain}" found in this SpinupWP account.`,
+      })
     }
     if (matches.length > 1) {
       const candidates: SshAccessCandidate[] = await Promise.all(
@@ -93,48 +95,45 @@ export async function resolveSshTargetInfo(
           return { siteId: s.id, serverId: s.server_id, server: srv.name }
         }),
       )
-      return {
-        ok: false,
-        result: {
-          ok: false,
-          domain,
-          reason: "multiple_matches",
-          message: `"${domain}" matches ${matches.length} sites in this account — cannot pick one automatically.`,
-          candidates,
-        },
-      }
+      return fail({
+        reason: "multiple_matches",
+        message: `"${domain}" matches ${matches.length} sites in this account — cannot pick one automatically.`,
+        candidates,
+      })
     }
-    site = matches[0]
+    site = matches[0]!
     server = await client.getServer(site.server_id)
   } catch (err) {
     if (err instanceof ApiError && err.status === 401) {
-      return {
-        ok: false,
-        result: {
-          ok: false,
-          domain,
-          reason: "token_rejected",
-          message: "Saved API token was rejected (401) — it may be expired or revoked.",
-          remedy: "Run `spinuptui login` to save a fresh token.",
-        },
-      }
+      return fail({
+        reason: "token_rejected",
+        message: "Saved API token was rejected (401) — it may be expired or revoked.",
+        remedy: "Run `spinuptui login` to save a fresh token.",
+      })
     }
     const message = err instanceof ApiError ? err.message : `Unexpected error: ${(err as Error).message}`
-    return { ok: false, result: { ok: false, domain, reason: "api_error", message } }
+    return fail({ reason: "api_error", message })
   }
 
   if (!server.ip_address) {
-    return {
-      ok: false,
-      result: {
-        ok: false,
-        domain,
-        reason: "server_has_no_ip",
-        message: `Server "${server.name}" has no IP address on file.`,
-      },
-    }
+    return fail({ reason: "server_has_no_ip", message: `Server "${server.name}" has no IP address on file.` })
   }
 
+  return { ok: true, site, server }
+}
+
+// Domain -> site -> server -> SSH target/port, with no live connectivity check.
+// Split out of resolveSshAccess so callers that are about to run a real command
+// (which is itself a connectivity test) don't pay for a redundant probe first.
+export async function resolveSshTargetInfo(
+  domain: string,
+  client: SpinupWPClientLike,
+  cfg: AppConfig,
+): Promise<SshTargetResolution> {
+  const resolved = await resolveSiteByDomain(domain, client, cfg)
+  if (!resolved.ok) return resolved
+
+  const { site, server } = resolved
   const target = resolveSiteSshTarget(site, server, cfg.sshUser)
   const port = server.ssh_port && server.ssh_port !== 22 ? server.ssh_port : null
 

--- a/src/lib/dbBackup.ts
+++ b/src/lib/dbBackup.ts
@@ -111,12 +111,12 @@ export async function runProcess(
   timeoutMs: number,
   cwd?: string,
   env?: Record<string, string>,
-): Promise<{ code: number; stderr: string }> {
+): Promise<{ code: number; stderr: string; stdout: string }> {
   let proc: ReturnType<typeof Bun.spawn>
   try {
     proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "pipe", stdin: "ignore", cwd, env })
   } catch (err) {
-    return { code: -1, stderr: `Failed to launch ${cmd[0]}: ${(err as Error).message}` }
+    return { code: -1, stderr: `Failed to launch ${cmd[0]}: ${(err as Error).message}`, stdout: "" }
   }
   const timer = setTimeout(() => {
     try {
@@ -127,8 +127,11 @@ export async function runProcess(
   }, timeoutMs)
   const code = await proc.exited
   clearTimeout(timer)
-  const stderr = await new Response(proc.stderr as ReadableStream<Uint8Array>).text()
-  return { code, stderr }
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout as ReadableStream<Uint8Array>).text(),
+    new Response(proc.stderr as ReadableStream<Uint8Array>).text(),
+  ])
+  return { code, stderr, stdout }
 }
 
 // Pick a meaningful error line out of ssh/wp stderr, skipping the deprecation /

--- a/src/lib/links.ts
+++ b/src/lib/links.ts
@@ -1,0 +1,23 @@
+// Local working-copy links, read/written outside the React store.
+//
+// The TUI's store owns an authoritative in-memory Map and persists the whole
+// map on every change (see store.tsx's persistLinks), so it doesn't need these.
+// The CLI has no store: it reads the config once and writes a single link back,
+// merging rather than replacing so a concurrent TUI session's other links
+// survive. Both paths end up in the same config key (`localSites`).
+
+import { loadConfig, saveConfig } from "../config.ts"
+import { normalizeLink, type LocalLink } from "./local.ts"
+
+// The link recorded for a site id, if any.
+export function readLink(siteId: number): LocalLink | undefined {
+  const raw = loadConfig().localSites[String(siteId)]
+  return raw ? normalizeLink(raw) : undefined
+}
+
+// Merge one link into the stored set. Re-reads the config immediately before
+// writing so we don't clobber links made since this process started.
+export async function writeLink(siteId: number, link: LocalLink): Promise<void> {
+  const current = loadConfig().localSites
+  await saveConfig({ localSites: { ...current, [String(siteId)]: normalizeLink(link) } })
+}

--- a/src/lib/localSetup.ts
+++ b/src/lib/localSetup.ts
@@ -1,0 +1,164 @@
+// Set up a brand-new local working copy for a remote SpinupWP site — the
+// missing first step before dbSync (`p`) and mediaFallback (`m`) can run.
+//
+// Gets the CODE down (git clone for git-deployed sites, an rsync pull over SSH
+// for everything else — excluding uploads/ and the server-specific caching
+// drop-ins, object-cache.php/advanced-cache.php: they're wired to production's
+// Redis/disk cache, and object-cache.php doesn't just no-op without it, it
+// fatals) and runs `composer install` locally when the checkout turns out to
+// be Bedrock/Radicle. Deliberately stops there: it never touches the local
+// database or webserver config, and never links the site itself — the caller
+// does that (reusing `linkSite`) once this succeeds, then hands off to the
+// existing dbSync (`p`) and mediaFallback (`m`) flows unchanged.
+//
+// For a public/-style webroot, wp-config.php lives ONE level above it (see
+// CLAUDE.md's WordPress layout rules) — so the rsync path always pulls the
+// site's whole files root, not just the detected webroot, so wp-config.php
+// (and anything else living beside it) comes down too. `public_folder` is a
+// SETTING, not a fact (SpinupWP never enforces it), so the real webroot is
+// detected on the source via `detectWpDirScript` rather than trusted.
+
+import { existsSync, mkdirSync, readdirSync } from "node:fs"
+import { dirname } from "node:path"
+import type { Server, Site } from "../api/types.ts"
+import { expandPath, resolveLocalLink } from "./local.ts"
+import { SSH_OPTS, sshPort, runProcess, meaningfulError } from "./dbBackup.ts"
+import { detectWpDirScript } from "./serverClone.ts"
+
+export interface LocalSetupPlan {
+  domain: string
+  isGit: boolean
+  repoUrl: string | null // git clone source, when isGit
+  user: string // SSH user — only needed for the non-git rsync path
+  host: string
+  port: number | null
+  filesRoot: string // remote /sites/{domain}/files — rsync source root
+  publicFolder: string | null // as configured; the real webroot is still detected, not trusted
+  destPath: string // expanded local destination (must not exist, or be empty)
+  destUrl: string
+}
+
+export type LocalSetupPlanResult = { ok: true; plan: LocalSetupPlan } | { ok: false; error: string }
+
+export function planLocalSetup(
+  site: Site,
+  server: Server | undefined,
+  sshUser: string | null,
+  destPath: string,
+  destUrl: string,
+): LocalSetupPlanResult {
+  const path = destPath.trim()
+  if (!path) return { ok: false, error: "Enter a local path." }
+  const dir = expandPath(path)
+  if (existsSync(dir) && readdirSync(dir).length > 0) return { ok: false, error: "That path already exists and isn't empty." }
+
+  const isGit = !!site.git?.repo
+  const host = server?.ip_address
+  const user = site.site_user ?? sshUser
+  // Non-git sites are pulled over SSH, so they need a reachable server + user.
+  // Git sites clone straight from the repo and never touch the server.
+  if (!isGit && (!host || !user)) return { ok: false, error: "Missing site user or server IP — can't reach the site." }
+
+  return {
+    ok: true,
+    plan: {
+      domain: site.domain,
+      isGit,
+      repoUrl: site.git?.repo ?? null,
+      user: user ?? "",
+      host: host ?? "",
+      port: server?.ssh_port ?? null,
+      filesRoot: `/sites/${site.domain}/files`,
+      publicFolder: site.public_folder,
+      destPath: dir,
+      destUrl: destUrl.trim(),
+    },
+  }
+}
+
+export type LocalSetupStage = "fetch" | "build" | "done" | "error"
+
+export interface LocalSetupProgress {
+  stage: LocalSetupStage
+  domain: string
+  destPath?: string
+  error?: string
+  failedStage?: LocalSetupStage
+  ranComposer?: boolean
+}
+
+export function isLocalSetupInFlight(p: LocalSetupProgress | undefined): boolean {
+  return p != null && p.stage !== "done" && p.stage !== "error"
+}
+
+// rsync the source's whole files root down, excluding uploads wherever they
+// land (relative to the detected webroot, not assumed at the files root).
+async function fetchByRsync(plan: LocalSetupPlan): Promise<{ code: number; stderr: string }> {
+  const target = `${plan.user}@${plan.host}`
+  const probeScript = `${detectWpDirScript(plan.filesRoot, plan.publicFolder ?? undefined)}; echo "D:$D"; echo "W:$W"`
+  const probe = await runProcess(["ssh", ...SSH_OPTS, ...sshPort(plan.port), target, probeScript], 30_000)
+  if (probe.code !== 0) return { code: probe.code, stderr: probe.stderr }
+  const d = probe.stdout.match(/^D:(.*)$/m)?.[1]?.trim()
+  const w = probe.stdout.match(/^W:(.*)$/m)?.[1]?.trim()
+  if (!d) return { code: 1, stderr: "couldn't determine the site's files root on the server." }
+  if (!w) return { code: 1, stderr: "couldn't find a WordPress install under this site on the server." }
+
+  // Paths relative to the files root we're about to rsync, e.g.
+  // "public/wp-content/uploads" when the webroot sits below the files root, or
+  // bare "wp-content/uploads" when it doesn't.
+  const webrootRel = w === d ? "" : w.slice(d.length).replace(/^\/+/, "")
+  const contentRel = (name: string) => (webrootRel ? `${webrootRel}/wp-content/${name}` : `wp-content/${name}`)
+  // object-cache.php (and advanced-cache.php, same family) are server drop-ins
+  // wired to production's Redis/disk cache — they don't just no-op without it,
+  // they fatal (confirmed: SpinupWP's object-cache drop-in 500s on a cache MISS
+  // when Redis is unreachable). Local dev doesn't want production caching
+  // anyway, so these are excluded outright rather than copied and hoping.
+  const excludes = ["uploads", "object-cache.php", "advanced-cache.php"].map((name) => `--exclude=${contentRel(name)}`)
+
+  const sshCmd = ["ssh", ...SSH_OPTS, ...sshPort(plan.port)].join(" ")
+  return runProcess(["rsync", "-az", "-e", sshCmd, ...excludes, `${target}:${d}/`, `${plan.destPath}/`], 600_000)
+}
+
+export async function runLocalSetup(plan: LocalSetupPlan, onProgress: (p: LocalSetupProgress) => void): Promise<LocalSetupProgress> {
+  const domain = plan.domain
+  const fail = (error: string, failedStage: LocalSetupStage = "fetch"): LocalSetupProgress => {
+    const p: LocalSetupProgress = { stage: "error", domain, error, failedStage }
+    onProgress(p)
+    return p
+  }
+  const stageFail = (label: string, stderr: string, fallback: string, failedStage: LocalSetupStage) =>
+    fail(`${label} — ${meaningfulError(stderr, fallback)}`, failedStage)
+
+  onProgress({ stage: "fetch", domain })
+  try {
+    mkdirSync(dirname(plan.destPath), { recursive: true })
+  } catch {
+    // best-effort — the actual clone/rsync surfaces a real error if this truly can't be created
+  }
+
+  if (plan.isGit) {
+    if (!plan.repoUrl) return fail("This site has no git repo configured in SpinupWP.", "fetch")
+    const cl = await runProcess(["git", "clone", plan.repoUrl, plan.destPath], 300_000)
+    if (cl.code !== 0) return stageFail("git clone failed", cl.stderr, `exit ${cl.code}.`, "fetch")
+  } else {
+    mkdirSync(plan.destPath, { recursive: true })
+    const rs = await fetchByRsync(plan)
+    if (rs.code !== 0) return stageFail("File pull failed", rs.stderr, `exit ${rs.code}.`, "fetch")
+  }
+
+  // Bedrock/Radicle needs `composer install` to build vendor/ + web/wp before
+  // anything (wp-cli included) can find a WordPress install in the checkout.
+  // Standard WP ships its core in the tree already, so this is a no-op there.
+  const kind = resolveLocalLink({ domain, path: plan.destPath, localUrl: plan.destUrl }).kind
+  let ranComposer = false
+  if (kind === "bedrock" || kind === "radicle") {
+    onProgress({ stage: "build", domain })
+    const ci = await runProcess(["bash", "-lc", "composer install"], 300_000, plan.destPath)
+    if (ci.code !== 0) return stageFail("composer install failed", ci.stderr, "composer error.", "build")
+    ranComposer = true
+  }
+
+  const done: LocalSetupProgress = { stage: "done", domain, destPath: plan.destPath, ranComposer }
+  onProgress(done)
+  return done
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -30,6 +30,7 @@ import { NewServer } from "./views/NewServer.tsx"
 import { VanityNewSite } from "./views/VanityNewSite.tsx"
 import { CloneWizard } from "./views/CloneWizard.tsx"
 import { LocalLinkOverlay } from "./views/LocalLink.tsx"
+import { LocalSetupOverlay } from "./views/LocalSetup.tsx"
 import { Discover } from "./views/Discover.tsx"
 import { Forgotten } from "./views/Forgotten.tsx"
 import { DnsInventory } from "./views/DnsInventory.tsx"
@@ -75,6 +76,7 @@ export function App() {
     store.vanityServer !== null ||
     store.cloneServer !== null ||
     store.localLinkSite !== null ||
+    store.localSetupSite !== null ||
     store.discoverOpen ||
     store.forgottenOpen ||
     store.dnsInventoryServer !== null ||
@@ -166,6 +168,9 @@ export function App() {
     // The local-link overlay owns the keyboard while open.
     if (store.localLinkSite) return
 
+    // The new-local-copy (clone/rsync) overlay owns the keyboard while open.
+    if (store.localSetupSite) return
+
     // The discovery overlay owns the keyboard while open.
     if (store.discoverOpen) return
 
@@ -256,6 +261,7 @@ export function App() {
       {store.vanityServer && <VanityNewSite />}
       {store.cloneServer && <CloneWizard />}
       {store.localLinkSite && <LocalLinkOverlay />}
+      {store.localSetupSite && <LocalSetupOverlay />}
       {store.discoverOpen && <Discover />}
       {store.forgottenOpen && <Forgotten />}
       {store.dnsInventoryServer && <DnsInventory />}

--- a/src/ui/store.tsx
+++ b/src/ui/store.tsx
@@ -55,6 +55,7 @@ import { resolvePhpEolDates, refreshPhpEolDates, isPhpEol as isPhpEolWith, offer
 import { resolveUbuntuEolDates, refreshUbuntuEolDates, isUbuntuEol as isUbuntuEolWith, type UbuntuEolDates } from "../lib/ubuntuEol.ts"
 import { planDbBackup, runDbBackup, type DbBackupProgress, type PlanResult } from "../lib/dbBackup.ts"
 import { planDbSync, runDbSync, type DbSyncProgress, type SyncPlanResult } from "../lib/dbSync.ts"
+import { planLocalSetup, runLocalSetup, type LocalSetupProgress, type LocalSetupPlanResult } from "../lib/localSetup.ts"
 import { planMediaFallback, type MediaFallbackResult } from "../lib/mediaFallback.ts"
 
 export type Route = "dashboard" | "servers" | "stacks" | "search" | "events"
@@ -372,12 +373,14 @@ const phpJobId = (siteId: number) => `phpUpgrade:${siteId}`
 const httpsJobId = (siteId: number) => `httpsToggle:${siteId}`
 const dbSyncJobId = (siteId: number) => `dbSync:${siteId}`
 const dbBackupJobId = (siteId: number) => `dbBackup:${siteId}`
+const localSetupJobId = (siteId: number) => `localSetup:${siteId}`
 
 // SSH-orchestrated jobs (no SpinupWP event to re-attach to) can't truly resume —
 // their child processes died with the app. On restart we surface them as
 // interrupted rather than pretend, since the local DB may be half-applied.
 const INTERRUPTED_SYNC_MSG = "Interrupted by a restart — your local database may be partially imported. Re-run the sync (p)."
 const INTERRUPTED_BACKUP_MSG = "Interrupted by a restart — the download didn't finish. Re-run the backup (d)."
+const INTERRUPTED_LOCAL_SETUP_MSG = "Interrupted by a restart — the local copy may be partial. Re-run the clone."
 // Server provisioning events settle with one of these (broader than PHP/site
 // writes, whose terminal is "deployed"); finished_at also implies done.
 const SERVER_DONE = new Set(["deployed", "completed", "provisioned", "finished", "success"])
@@ -715,6 +718,16 @@ interface StoreValue extends DataState {
   startDbSync: (site: Site) => void
   clearDbSync: (siteId: number) => void
 
+  // Set up a brand-new local working copy for a remote site (clone/rsync the
+  // code down, composer install if Bedrock/Radicle) — the missing first step
+  // before a link exists at all. Never touches the DB or webserver config.
+  localSetupSite: Site | null
+  setLocalSetupSite: (s: Site | null) => void
+  localSetups: Map<number, LocalSetupProgress>
+  planLocalSetupFor: (site: Site, destPath: string, destUrl: string) => LocalSetupPlanResult
+  startLocalSetup: (site: Site, destPath: string, destUrl: string) => void
+  clearLocalSetup: (siteId: number) => void
+
   // Production media fallback overlay (mu-plugin in the linked local copy). State
   // is the plugin file's presence, resolved fresh by planMediaFallbackFor.
   mediaFallbackSite: Site | null
@@ -1003,6 +1016,8 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   const [dbBackups, setDbBackups] = useState<Map<number, DbBackupProgress>>(new Map())
   const [dbSyncSite, setDbSyncSite] = useState<Site | null>(null)
   const [dbSyncs, setDbSyncs] = useState<Map<number, DbSyncProgress>>(new Map())
+  const [localSetupSite, setLocalSetupSite] = useState<Site | null>(null)
+  const [localSetups, setLocalSetups] = useState<Map<number, LocalSetupProgress>>(new Map())
   const [localSync, setLocalSyncState] = useState<boolean>(() => cfgRef.current.localSync)
   const [enableLocalSyncSite, setEnableLocalSyncSite] = useState<Site | null>(null)
   const [mediaFallbackSite, setMediaFallbackSite] = useState<Site | null>(null)
@@ -2146,6 +2161,51 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       })
     },
     [dbSyncs, planDbSyncFor],
+  )
+
+  // ---- New local working copy (clone/rsync + composer install) ----------
+
+  const setLocalSetup = (siteId: number, progress: LocalSetupProgress) =>
+    setLocalSetups((prev) => new Map(prev).set(siteId, progress))
+
+  const clearLocalSetup = useCallback(
+    (siteId: number) =>
+      setLocalSetups((prev) => {
+        if (!prev.has(siteId)) return prev
+        const next = new Map(prev)
+        next.delete(siteId)
+        return next
+      }),
+    [],
+  )
+
+  const planLocalSetupFor = useCallback(
+    (site: Site, destPath: string, destUrl: string): LocalSetupPlanResult =>
+      planLocalSetup(site, servers.find((s) => s.id === site.server_id), cfgRef.current.sshUser, destPath, destUrl),
+    [servers],
+  )
+
+  const startLocalSetup = useCallback(
+    (site: Site, destPath: string, destUrl: string) => {
+      const existing = localSetups.get(site.id)
+      if (existing && existing.stage !== "done" && existing.stage !== "error") return
+      const res = planLocalSetupFor(site, destPath, destUrl)
+      if (!res.ok) {
+        setLocalSetup(site.id, { stage: "error", domain: site.domain, error: res.error })
+        return
+      }
+      // SSH/local-process orchestrated (no event): persist only so a restart can
+      // flag it as interrupted; drop it the moment it settles.
+      void saveJob({ id: localSetupJobId(site.id), kind: "localSetup", status: "running", startedAt: Date.now(), inputs: { siteId: site.id, domain: site.domain } })
+      void runLocalSetup(res.plan, (p) => {
+        setLocalSetup(site.id, p)
+        // Link as soon as the files are down, same shape the manual `L` form
+        // writes — dbSync (`p`) and mediaFallback (`m`) both require a link.
+        if (p.stage === "done") linkSite(site.id, { domain: site.domain, path: res.plan.destPath, localUrl: res.plan.destUrl })
+        if (p.stage === "done" || p.stage === "error") void removeJob(localSetupJobId(site.id))
+      })
+    },
+    [localSetups, planLocalSetupFor, linkSite],
   )
 
   // Compute a linked site's git drift once (cached), fire-and-forget. Stable
@@ -4151,6 +4211,10 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           if (inp.siteId != null) setSync(inp.siteId, { stage: "error", domain: inp.domain ?? "", error: INTERRUPTED_SYNC_MSG })
           void removeJob(job.id)
           break
+        case "localSetup":
+          if (inp.siteId != null) setLocalSetup(inp.siteId, { stage: "error", domain: inp.domain ?? "", error: INTERRUPTED_LOCAL_SETUP_MSG })
+          void removeJob(job.id)
+          break
         case "dbBackup":
           if (inp.siteId != null) setBackup(inp.siteId, { stage: "error", domain: inp.domain ?? "", error: INTERRUPTED_BACKUP_MSG })
           void removeJob(job.id)
@@ -4333,6 +4397,12 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     planDbSyncFor,
     startDbSync,
     clearDbSync,
+    localSetupSite,
+    setLocalSetupSite,
+    localSetups,
+    planLocalSetupFor,
+    startLocalSetup,
+    clearLocalSetup,
     drift,
     ensureDrift,
     rebootInfo,

--- a/src/ui/views/LocalLink.tsx
+++ b/src/ui/views/LocalLink.tsx
@@ -1,14 +1,19 @@
-// Local working-copy link overlay — Phase 1 (link + view, no mutation).
+// Local working-copy link overlay — Phase 1 (link + view, no mutation) plus
+// the entry point into Phase 2 (LocalSetup.tsx's guided clone).
 //
-// Opened with `L` on a selected site (Browser / Search results). Two modes:
+// Opened with `L` on a selected site (Browser / Search results). Modes:
+//   • choose — no link exists yet: pick manual entry (`e`) or a guided clone
+//     from production (`c`, hands off to LocalSetupOverlay).
 //   • view — the site is linked: shows the validated status (Bedrock / WordPress
 //     / missing) and offers open-locally actions: `t` opens a terminal at the
 //     path, `v` opens the stored local URL in the browser. `e` edits, `x` unlinks.
 //   • edit — a small form to enter the local path + local URL (manual entry).
 //
-// Per the locked spec these are LOCAL conveniences only: we open a terminal and
-// the local URL — we never launch an editor and never run composer/git here.
-// The mutating maintenance loop (composer update → push → deploy) is a later phase.
+// This file itself still only links — we open a terminal and the local URL, and
+// never launch an editor. Getting code onto disk (git clone / rsync / composer)
+// lives entirely in LocalSetup.tsx, kept separate from this file's original
+// read-only-on-disk scope. The mutating maintenance loop (composer update → push
+// → deploy) is still a later phase.
 
 import { useEffect, useState } from "react"
 import { useKeyboard } from "@opentui/react"
@@ -19,7 +24,7 @@ import { StatusBar } from "../StatusBar.tsx"
 import { useStore } from "../store.tsx"
 import { resolveLocalLink, type LocalKind } from "../../lib/local.ts"
 
-type Mode = "view" | "edit"
+type Mode = "choose" | "view" | "edit"
 type EditField = "path" | "url"
 
 function kindColor(kind: LocalKind, exists: boolean): string {
@@ -31,11 +36,11 @@ function kindColor(kind: LocalKind, exists: boolean): string {
 
 export function LocalLinkOverlay() {
   const store = useStore()
-  const { localLinkSite: site, setLocalLinkSite, localLinks, linkSite, unlinkSite, setInputMode, openLocalTerminal, openLocalUrl, linkReturnToForgotten, setLinkReturnToForgotten, setForgottenOpen } = store
+  const { localLinkSite: site, setLocalLinkSite, localLinks, linkSite, unlinkSite, setInputMode, openLocalTerminal, openLocalUrl, linkReturnToForgotten, setLinkReturnToForgotten, setForgottenOpen, setLocalSetupSite } = store
 
   const existing = site ? localLinks.get(site.id) : undefined
 
-  const [mode, setMode] = useState<Mode>(() => (existing ? "view" : "edit"))
+  const [mode, setMode] = useState<Mode>(() => (existing ? "view" : "choose"))
   const [field, setField] = useState<EditField>("path")
   const [pathInput, setPathInput] = useState(existing?.path ?? "")
   const [urlInput, setUrlInput] = useState(existing?.localUrl ?? "")
@@ -73,9 +78,28 @@ export function LocalLinkOverlay() {
   useKeyboard((key) => {
     const name = key.name ?? ""
 
+    if (mode === "choose") {
+      if (name === "escape" || name === "q") return close()
+      if (name === "e") {
+        setPathInput("")
+        setUrlInput("")
+        setField("path")
+        return setMode("edit")
+      }
+      if (name === "c" && site) {
+        // Not close() — that hands back to the "needs a local copy" report if we
+        // arrived from there, which doesn't make sense mid-clone. Just hand off.
+        setInputMode(false)
+        setLocalLinkSite(null)
+        setLocalSetupSite(site)
+      }
+      return
+    }
+
     if (mode === "edit") {
-      // Esc backs out: to the view mode if a link already exists, else closes.
-      if (name === "escape") return existing ? setMode("view") : close()
+      // Esc backs out: to the view mode if a link already exists, else to the
+      // choose screen (there's no link yet, so there's nothing to "view").
+      if (name === "escape") return existing ? setMode("view") : setMode("choose")
       // ↑/↓ switch fields (Enter advances/saves via the inputs' onSubmit).
       if (name === "up") return setField("path")
       if (name === "down") return setField("url")
@@ -138,11 +162,32 @@ export function LocalLinkOverlay() {
         <text content={existing ? "linked" : "not linked"} fg={existing ? theme.good : theme.textFaint} style={{ flexShrink: 0 }} />
       </box>
 
-      <Centered>{mode === "edit" ? renderEdit() : renderView()}</Centered>
+      <Centered>{mode === "choose" ? renderChoose() : mode === "edit" ? renderEdit() : renderView()}</Centered>
 
       <StatusBar hints={hints()} message={flash ?? undefined} messageColor={theme.brand} showGlobal={false} />
     </box>
   )
+
+  function renderChoose() {
+    return (
+      <Panel title=" No local copy yet " active>
+        <box style={{ flexDirection: "column", width: 62, paddingTop: 1, paddingBottom: 1 }}>
+          <text content="How do you want to set this up?" fg={theme.text} wrapMode="none" />
+          <box style={{ height: 1 }} />
+          <box style={{ flexDirection: "row" }}>
+            <text content="c  " fg={theme.accent} style={{ flexShrink: 0 }} />
+            <text content="Clone fullsite (DB + files) from production" fg={theme.text} wrapMode="none" />
+          </box>
+          <text content="   git clone / file pull, no uploads/ — guided" fg={theme.textFaint} wrapMode="none" />
+          <box style={{ height: 1 }} />
+          <box style={{ flexDirection: "row" }}>
+            <text content="e  " fg={theme.accent} style={{ flexShrink: 0 }} />
+            <text content="Enter a path — you already have a copy" fg={theme.text} wrapMode="none" />
+          </box>
+        </box>
+      </Panel>
+    )
+  }
 
   function renderView() {
     return (
@@ -203,6 +248,12 @@ export function LocalLinkOverlay() {
   }
 
   function hints() {
+    if (mode === "choose")
+      return [
+        { key: "c", label: "clone from production" },
+        { key: "e", label: "enter a path" },
+        { key: "esc", label: "cancel" },
+      ]
     if (mode === "edit")
       return [
         { key: "↑↓", label: "field" },

--- a/src/ui/views/LocalSetup.tsx
+++ b/src/ui/views/LocalSetup.tsx
@@ -204,6 +204,16 @@ export function LocalSetupOverlay() {
                   <text content="or the DB pull is denied as production's user." fg={theme.warn} wrapMode="none" />
                 </>
               )}
+              {/* The mirror image on the git path: Bedrock/Radicle keep DB
+                  credentials and WP_HOME in .env, which is deliberately not in
+                  the repo — so a fresh clone has none and wp-cli runs with
+                  empty settings. composer install having run is the signal. */}
+              {progress?.ranComposer ? (
+                <>
+                  <text content=".env isn't in the repo, so this checkout has none — copy" fg={theme.warn} wrapMode="none" />
+                  <text content=".env.example to .env and set DB_* + WP_HOME before pulling." fg={theme.warn} wrapMode="none" />
+                </>
+              ) : null}
               <text content="Press ⏎ / p to pull production's database now, once that's ready." fg={theme.purple} wrapMode="none" />
               <text content="Esc to finish here" fg={theme.textFaint} wrapMode="none" />
             </>

--- a/src/ui/views/LocalSetup.tsx
+++ b/src/ui/views/LocalSetup.tsx
@@ -191,6 +191,19 @@ export function LocalSetupOverlay() {
               {progress?.ranComposer ? <text content="composer install ran" fg={theme.textFaint} wrapMode="none" /> : null}
               <box style={{ height: 1 }} />
               <text content="Next: create a local database and point your local tool at it." fg={theme.textFaint} wrapMode="none" />
+              {/* The file pull copies the site's real wp-config.php, production
+                  DB credentials and all. Nothing local can reach production's
+                  database through them (its DB_HOST is localhost), but local
+                  wp-cli authenticates as the production user, so the DB pull
+                  below is denied until they're localized. Say so here rather
+                  than letting it surface as a bare "Access denied" later. */}
+              {isGit ? null : (
+                <>
+                  <text content="wp-config.php came down with production's DB credentials —" fg={theme.warn} wrapMode="none" />
+                  <text content="update DB_NAME / DB_USER / DB_PASSWORD / DB_HOST to match," fg={theme.warn} wrapMode="none" />
+                  <text content="or the DB pull is denied as production's user." fg={theme.warn} wrapMode="none" />
+                </>
+              )}
               <text content="Press ⏎ / p to pull production's database now, once that's ready." fg={theme.purple} wrapMode="none" />
               <text content="Esc to finish here" fg={theme.textFaint} wrapMode="none" />
             </>

--- a/src/ui/views/LocalSetup.tsx
+++ b/src/ui/views/LocalSetup.tsx
@@ -1,0 +1,233 @@
+// Clone a brand-new local working copy from production — the guided
+// alternative to `L`'s manual "enter a path" form, offered when a site has no
+// local link yet. Opened from LocalLink.tsx's choose screen.
+//
+// Gets the code down (git clone, or an rsync pull over SSH excluding uploads/
+// for non-git sites), runs `composer install` for Bedrock/Radicle, then links
+// the result exactly like the manual form would. It deliberately stops there —
+// the local database and webserver config are NOT touched here. On success it
+// hands off to the existing dbSync (`p`) flow unchanged (which itself gates on
+// `localSync` being enabled), then that flow's own done screen already nudges
+// into mediaFallback (`m`). Three existing, already-reviewed screens chained
+// by keypresses, not one new mega state machine.
+
+import { useState } from "react"
+import { useKeyboard } from "@opentui/react"
+import { theme } from "../../lib/theme.ts"
+import { truncate, middleTruncate } from "../../lib/format.ts"
+import { Panel, Centered, DestPath, Steps, type StepRow } from "../components.tsx"
+import { StatusBar } from "../StatusBar.tsx"
+import { useStore } from "../store.tsx"
+import type { LocalSetupStage } from "../../lib/localSetup.ts"
+
+const SETUP_STEPS: { stage: LocalSetupStage; label: string }[] = [
+  { stage: "fetch", label: "Get the code (clone / pull)" },
+  { stage: "build", label: "composer install" },
+]
+
+export function LocalSetupOverlay() {
+  const { localSetupSite: site, setLocalSetupSite, serverById, planLocalSetupFor, localSetups, startLocalSetup, clearLocalSetup, localSync, setEnableLocalSyncSite, setDbSyncSite } = useStore()
+
+  const progress = site ? localSetups.get(site.id) : undefined
+  const [path, setPath] = useState("")
+  const [url, setUrl] = useState("")
+  const [field, setField] = useState<"path" | "url">("path")
+  const [formError, setFormError] = useState<string | null>(null)
+
+  const dp: "form" | "running" | "done" | "error" =
+    !progress ? "form" : progress.stage === "done" ? "done" : progress.stage === "error" ? "error" : "running"
+
+  const close = () => {
+    if (site && (progress?.stage === "done" || progress?.stage === "error")) clearLocalSetup(site.id)
+    setLocalSetupSite(null)
+  }
+
+  const submit = () => {
+    if (!site) return
+    const res = planLocalSetupFor(site, path, url)
+    if (!res.ok) {
+      setFormError(res.error)
+      return
+    }
+    setFormError(null)
+    startLocalSetup(site, path, url)
+  }
+
+  const pullDb = () => {
+    if (!site) return
+    close()
+    if (!localSync) setEnableLocalSyncSite(site)
+    else setDbSyncSite(site)
+  }
+
+  useKeyboard((key) => {
+    const name = key.name ?? ""
+    if (name === "escape" || name === "q") return close()
+
+    if (dp === "form") {
+      if (name === "up") return setField("path")
+      if (name === "down") return setField("url")
+      return
+    }
+    if (dp === "error") {
+      if (name === "r" && site) {
+        clearLocalSetup(site.id)
+        setFormError(null)
+      }
+      return
+    }
+    if (dp === "done") {
+      if (name === "return" || name === "p") return pullDb()
+      return
+    }
+  })
+
+  if (!site) return null
+  const server = serverById(site.server_id)
+  const isGit = !!site.git?.repo
+
+  return (
+    <box style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", flexDirection: "column", backgroundColor: theme.bg, zIndex: 210 }}>
+      <box style={{ flexDirection: "row", height: 1, backgroundColor: theme.bgAlt, paddingLeft: 1, paddingRight: 1, alignItems: "center" }}>
+        <text content="⇩ Clone fullsite (DB + files) from production  " fg={theme.brand} style={{ flexShrink: 0 }} />
+        <text content={truncate(site.domain, 38)} fg={theme.text} wrapMode="none" style={{ flexShrink: 1 }} />
+      </box>
+
+      <Centered>{renderBody()}</Centered>
+
+      <StatusBar hints={hints()} showGlobal={false} />
+    </box>
+  )
+
+  function renderBody() {
+    if (dp === "form") {
+      return (
+        <Panel title=" Clone from production " active>
+          <box style={{ flexDirection: "column", width: 68, paddingTop: 1, paddingBottom: 1 }}>
+            <box style={{ flexDirection: "row" }}>
+              <text content="from " fg={theme.textFaint} />
+              <text content={truncate(site!.domain, 30)} fg={theme.accent} wrapMode="none" />
+              <text content=" on " fg={theme.textDim} />
+              <text content={truncate(server?.name ?? "—", 22)} fg={theme.textDim} wrapMode="none" />
+            </box>
+            <text content={isGit ? "source: git clone (this site's repo)" : "source: file pull over SSH (excludes uploads/)"} fg={theme.textFaint} wrapMode="none" />
+            <box style={{ height: 1 }} />
+            <text content="Local path for the new working copy" fg={field === "path" ? theme.accent : theme.textDim} />
+            <input
+              focused={field === "path"}
+              value={path}
+              placeholder={`~/code/${site!.domain}`}
+              onInput={setPath}
+              onSubmit={() => setField("url")}
+              style={{ backgroundColor: theme.bgAlt, focusedBackgroundColor: theme.bgAlt, textColor: theme.text }}
+            />
+            <box style={{ height: 1 }} />
+            <text content="Local URL (optional) — Valet, Cove, LocalWP, Herd, DDEV…" fg={field === "url" ? theme.accent : theme.textDim} />
+            <input
+              focused={field === "url"}
+              value={url}
+              placeholder="https://example.test"
+              onInput={setUrl}
+              onSubmit={submit}
+              style={{ backgroundColor: theme.bgAlt, focusedBackgroundColor: theme.bgAlt, textColor: theme.text }}
+            />
+            {formError ? (
+              <>
+                <box style={{ height: 1 }} />
+                <text content={`✕ ${formError}`} fg={theme.bad} wrapMode="none" />
+              </>
+            ) : null}
+            <box style={{ height: 1 }} />
+            <text content="This only pulls code — your local DB/webserver aren't touched." fg={theme.textFaint} wrapMode="none" />
+            <text content="↑↓ switch field · Enter on the URL starts · Esc cancels" fg={theme.textFaint} wrapMode="none" />
+          </box>
+        </Panel>
+      )
+    }
+
+    // "build" (composer install) only applies to Bedrock/Radicle — unknown
+    // until the fetch stage finishes, so it stays out of the list entirely
+    // (like DbSync's optional hook row) until we actually know, rather than
+    // rendering a row that never ran as if it had.
+    const buildApplies =
+      progress?.stage === "build" ||
+      (progress?.stage === "done" && !!progress.ranComposer) ||
+      (progress?.stage === "error" && progress.failedStage === "build")
+    const steps = SETUP_STEPS.filter((s) => s.stage !== "build" || buildApplies)
+    const order = steps.map((s) => s.stage)
+    const curIdx = order.indexOf((progress?.stage ?? "fetch") as LocalSetupStage)
+    const failedIdx = progress?.failedStage ? order.indexOf(progress.failedStage) : order.length - 1
+    const rows: StepRow[] = steps.map(({ label }, i) => {
+      const state: StepRow["state"] =
+        dp === "done"
+          ? "done"
+          : dp === "error"
+            ? i < failedIdx
+              ? "done"
+              : i === failedIdx
+                ? "failed"
+                : "pending"
+            : i < curIdx
+              ? "done"
+              : i === curIdx
+                ? "active"
+                : "pending"
+      return { label, state }
+    })
+
+    return (
+      <Panel title=" Cloning from production " active>
+        <box style={{ flexDirection: "column", width: 64, paddingTop: 1, paddingBottom: 1 }}>
+          <Steps rows={rows} />
+          <box style={{ height: 1 }} />
+          {dp === "done" ? (
+            <>
+              <box style={{ flexDirection: "row" }}>
+                <text content="✓ " fg={theme.good} />
+                <text content="Files are down and linked." fg={theme.text} wrapMode="none" />
+              </box>
+              <box style={{ height: 1 }} />
+              <DestPath path={middleTruncate(progress?.destPath ?? "", 62)} fileColor={theme.good} width={62} />
+              {progress?.ranComposer ? <text content="composer install ran" fg={theme.textFaint} wrapMode="none" /> : null}
+              <box style={{ height: 1 }} />
+              <text content="Next: create a local database and point your local tool at it." fg={theme.textFaint} wrapMode="none" />
+              <text content="Press ⏎ / p to pull production's database now, once that's ready." fg={theme.purple} wrapMode="none" />
+              <text content="Esc to finish here" fg={theme.textFaint} wrapMode="none" />
+            </>
+          ) : dp === "error" ? (
+            <>
+              <text content={`✕ ${progress?.error ?? "Something went wrong."}`} fg={theme.bad} />
+              <box style={{ height: 1 }} />
+              <text content="Press r to try again · Esc to close" fg={theme.textFaint} wrapMode="none" />
+            </>
+          ) : (
+            <text content="You can press Esc — it keeps running in the background." fg={theme.textFaint} wrapMode="none" />
+          )}
+        </box>
+      </Panel>
+    )
+  }
+
+  function hints() {
+    switch (dp) {
+      case "form":
+        return [
+          { key: "↑↓", label: "field" },
+          { key: "⏎", label: "start" },
+          { key: "esc", label: "cancel" },
+        ]
+      case "error":
+        return [
+          { key: "r", label: "retry" },
+          { key: "esc", label: "close" },
+        ]
+      case "done":
+        return [
+          { key: "⏎/p", label: "pull DB" },
+          { key: "esc", label: "close" },
+        ]
+      default:
+        return [{ key: "esc", label: "close" }]
+    }
+  }
+}


### PR DESCRIPTION
> **Stacked on #54** — it drives that PR's `lib/localSetup.ts`. GitHub retargets this to `main` once #54 merges; review everything after that PR's commits.

Drives the two local-working-copy engines the TUI already uses (`lib/localSetup.ts`, `lib/dbSync.ts`) from the command line, so a site can be pulled down for local dev from a script or an agent without opening the TUI.

```
spinuptui pull files <domain> [path] [--url <local url>] [--server <name>] [--json]
spinuptui pull db <domain> [--url <local url>] [--server <name>] --yes [--json]
```

### Output contract
Follows `ssh-exec`'s shape rather than inventing one: **stdout is the machine channel** (with `--json`, exactly one result object; exit code mirrors `ok`), **stderr is human progress**, in both modes — so stdout stays trivially parseable for an agent while a person watching a ten-minute rsync can see it isn't hung. Failures carry a stable `reason` plus a `remedy` naming the exact command that fixes them:

```
$ spinuptui pull files bedrock.spinuptui.com ~/dev/bedrock.spinuptui.com
→ Resolving bedrock.spinuptui.com …
"bedrock.spinuptui.com" matches 2 sites in this account — cannot pick one automatically.
  · web1.spinuptui.com (site 252037)
  · web2.spinuptui.com (site 253297)
Pick one with --server, e.g. `--server web1.spinuptui.com`.
```

### Safety
- **`pull db` is gated twice** — `"localSync": true` in config (the same opt-in the TUI enforces) **and** `--yes`. Both are checked *before any network call*, so a typo'd domain in a script bounces off the gate rather than off a fleet lookup.
- **`pull files` refuses a site that already has a local copy** instead of re-syncing over local work, and refuses a non-empty destination.
- **The default path is only derived when exactly one `localRoots` entry exists.** With several configured (they're commonly split by stack) it's required — guessing would file a standard-WP site under Bedrock.

### The local-credentials problem, both halves of it
A pulled copy is never immediately syncable, for opposite reasons per stack, and both used to surface as cryptic `mysqldump` errors several steps later:

- **File pull** brings the site's real `wp-config.php` down, **production credentials and all**. Harmless in itself — SpinupWP's `DB_HOST` is localhost, so nothing local can reach production's database through them — but local wp-cli then authenticates as the *production* DB user and is denied.
- **Git clone** brings **no `.env`** at all, since Bedrock/Radicle keep credentials there and it's deliberately not in the repo. wp-cli runs with empty DB settings and dies on `mysqldump: unknown variable 'pass='`.

Both are now stated on the `pull files` that creates the copy (naming the exact file), and caught again on `pull db` — the missing `.env` up front as `reason: "missing_env"`, a denied login with a `remedy` explaining the likely cause. #54 carries the matching notes on the TUI's clone screen.

### Refactors
- `cliSsh.ts`'s domain→site/server lookup is extracted as `resolveSiteByDomain`, so `ssh`, `ssh-exec` and `pull` fail identically on an unknown/ambiguous domain, a rejected token, or an IP-less server. It gained optional `--server` narrowing, which `ssh`/`ssh-exec` don't pass — their output is unchanged.
- New `lib/links.ts` merges a single link into `config.localSites` (re-reading immediately before write, so a concurrent TUI session's links survive). The store keeps persisting its own authoritative map.

### Testing
`bun run typecheck` green. **Both paths live-tested end to end against real sites**, each followed by a successful `pull db` and verified in MySQL.

**`pub.spinuptui.com`** — Standard WP, non-git → the rsync path:

```
→ Source: rsync …:/sites/pub.spinuptui.com/files/ (excluding uploads and the caching drop-ins)
→ Getting the code down …
→ Linked pub.spinuptui.com → /Users/…/pub.spinuptui.com
Warning: /Users/…/wp-config.php came from production and still holds its database credentials. …
```

120 MB in ~10s. On disk: root-webroot layout preserved with `wp-config.php` alongside core, and the remote's `wp-content/uploads/` **and** `object-cache.php` both absent locally while everything else came down.

**`bedrock.spinuptui.com`** — Bedrock, git-deployed → the clone path:

```
→ Source: git clone git@github.com:…
→ Getting the code down …   → composer install …
Pulled … (git, composer install ran) and linked it.
Warning: No .env in the checkout — Bedrock/Radicle keep database credentials and WP_HOME there …
```

`composer install` built `web/wp` correctly. This site is also the one that exists on two servers, which is how the disambiguation gap surfaced.

**`pull db` after each**: local pre-import backup written, production dump downloaded, imported, URLs rewritten. Verified in MySQL — the site's real table prefix handled, `home`/`siteurl` on the local URL, and **zero** rows left containing the production domain.

Also verified: every usage error, both `pull db` gates, `site_not_found`, `multiple_matches` (with and without `--server`, including an unmatched value), `already_linked`, `ambiguous_dest`, `dest_not_empty`, `not_linked`, `missing_env`, and both output modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SG3orBudWnfTif1maqAeH3
