### PR TITLE
fix: remove the stray .sql a failed local DB backup leaves behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ versions; such changes are called out here.
 
 ## [Unreleased]
 
+### Fixed
+- **A failed local-database backup no longer leaves a fake backup behind.** The
+  DB pull (`p`, and the same engine everywhere else) starts by dumping the
+  local database as a safety net; `wp db export` creates its output file before
+  it knows the dump will succeed, and the follow-up `gzip` never runs when it
+  doesn't — leaving a bare `.sql` in `sql/`, named exactly like a real backup.
+  Empty when the failure is instant (bad credentials), **partial** when the
+  dump dies midway, which is the case that matters: it reads as a safety net
+  and isn't one. Nothing was lost by removing it — the pull aborts at that step,
+  before the local database is touched at all.
+
 ## [0.25.0] - 2026-08-12
 
 ### Added

--- a/src/lib/dbSync.ts
+++ b/src/lib/dbSync.ts
@@ -12,7 +12,7 @@
 // SYNC_REMOTE_HOST / SYNC_LOCAL_HOST env contract as the sync-prod-to-local
 // script, so per-project tweaks (Elementor URL swaps, plugin toggles) carry over.
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from "node:fs"
+import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync, rmSync } from "node:fs"
 import { join, dirname } from "node:path"
 import type { Server, Site } from "../api/types.ts"
 import { expandPath, findProjectRoot, resolveLocalLink, type LocalKind, type LocalLink } from "./local.ts"
@@ -212,6 +212,20 @@ export async function runDbSync(plan: DbSyncPlan, domain: string, onProgress: (p
   const localSql = plan.localBackupPath.replace(/\.gz$/, "")
   const lb = await wp(`wp db export "${localSql}" >/dev/null && gzip -f "${localSql}"`, 300_000)
   if (lb.code !== 0) {
+    // `wp db export` creates its output file before it knows the dump will
+    // succeed, and the `&& gzip` never runs when it doesn't — leaving a bare
+    // .sql behind (empty on an instant failure, PARTIAL if the dump dies
+    // midway) named exactly like a real backup. Nothing was restorable from it
+    // anyway: this step aborts before the local database is touched. Remove it
+    // rather than leave a file that reads as a safety net, the same way the
+    // download branch below cleans up the remote dump it orphaned. A
+    // successful run leaves only the .gz, and the name carries a
+    // to-the-minute timestamp, so this can only ever be this run's artifact.
+    try {
+      rmSync(localSql, { force: true })
+    } catch {
+      /* best-effort — a leftover file must not mask the real failure below */
+    }
     // wp-cli's own "not a WordPress install" error is a common first-pull snag on a
     // fresh checkout — a Bedrock or Radicle project needs `composer install` to
     // build vendor/ + web/wp (or public/wp) before wp-cli (or wp-cli.yml) can find


### PR DESCRIPTION
Found while live-testing the CLI pull (#56), but it's in shipped code — it affects the TUI's `p` exactly as much.

### What happens
The DB pull opens by dumping the local database as a safety net:

```
wp db export "<path>.sql" >/dev/null && gzip -f "<path>.sql"
```

`wp db export` creates its output file *before* it knows the dump will succeed, and the `&& gzip` never runs when it doesn't. So a failed backup leaves a bare `.sql` in `sql/`, named exactly like a real backup — while a successful run leaves only the `.gz`.

Empty when the failure is instant (bad local credentials, which is the common first-pull snag). **Partial when the dump dies midway** — disk full, connection dropped — and that's the case that matters: it reads as a safety net and isn't one.

### The fix
Remove it on the failure branch. Nothing is lost: the pull aborts at that step, *before* the local database is touched, so there was never anything to restore. This mirrors the download branch 20 lines below, which already `rm -f`s the remote dump it orphans — the local side just never got the same treatment.

Collision-safe: a successful run never leaves a bare `.sql`, and the filename carries a to-the-minute timestamp, so the path can only name this run's own artifact.

### Testing
Live A/B against a real site with deliberately wrong local DB credentials:

```
unfixed → sql/ contains local_2026-08-26_0948.sql   ← the fake backup
fixed   → sql/ contains only the real .gz artifacts
```

The underlying error (`Access denied for user …`) is surfaced identically either way. `bun run typecheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SG3orBudWnfTif1maqAeH3