### PR TITLE
feat: `--server` disambiguation for `ssh` and `ssh-exec`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ versions; such changes are called out here.
     configured. With several, it's required: which root a site belongs in isn't
     knowable from here, and guessing would file a standard-WP site under
     Bedrock.
+- **`--server <name>` on `ssh` and `ssh-exec` too**, not just the `pull`
+  commands. A domain that exists on more than one server — a clone-wizard
+  destination, a staging twin — could previously be reported as ambiguous by
+  these commands but never resolved, leaving it simply unreachable from the
+  CLI. The ambiguity now also lists the candidates and names the flag that
+  picks one, everywhere it's raised.
 - **Clone a site's full local working copy from production** — `L` on a site
   with no local copy yet now opens a choose screen: `e` is the existing manual
   "enter a path" form, and the new `c` runs a guided clone. It pulls the code

--- a/README.md
+++ b/README.md
@@ -173,11 +173,13 @@ to the version in the header (and in the `?` About panel).
 spinuptui            Launch the dashboard
 spinuptui login      Set or update your saved API token
 spinuptui where      Show the config path and which source the token came from
-spinuptui ssh <domain>  Print SSH access info for a site as JSON (resolves the
+spinuptui ssh <domain> [--server <name>]  Print SSH access info for a site
+                     as JSON (resolves the
                      site's server, builds its SSH target, and runs a live
                      connectivity probe — for external tooling, e.g. an
                      incident-diagnostics agent handed only a domain)
-spinuptui ssh-exec <domain> -- <command>  Resolve the domain's SSH target and
+spinuptui ssh-exec <domain> [--server <name>] -- <command>  Resolve the
+                     domain's SSH target and
                      run <command> on it, but only if the command is
                      read-only — anything matching a write/restart/destructive
                      pattern (plugin/theme changes, DB writes, service
@@ -226,6 +228,13 @@ spinuptui pull db <domain> [--url <local url>] [--server <name>] --yes [--json]
 spinuptui --version  Print the version
 spinuptui --help     Show help
 ```
+
+`--server <name>` works on every domain-addressed subcommand (`ssh`,
+`ssh-exec`, `pull files`, `pull db`). A domain can legitimately exist on more
+than one server — a clone-wizard destination, a staging twin — and without it
+those commands could only report the ambiguity, not resolve it. It matches the
+full server name or its first label (`web1` for `web1.example.com`), and the
+ambiguity message lists the candidates to pick from.
 
 Both `pull` commands write human-readable progress to **stderr** and their
 result to **stdout** — with `--json`, a single result object (`{ok:true, …}` or

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,6 +22,38 @@ const args = process.argv.slice(2)
 const positionals = args.filter((a) => !a.startsWith("-"))
 const command = positionals[0]
 
+// Flags that take a following value. Listed so that value can be skipped when
+// collecting positionals — otherwise `--server web1 <domain>` reads "web1" as
+// the domain, and a URL (which doesn't look like a flag) reads as a path.
+const VALUE_FLAGS = new Set(["--url", "--server"])
+
+function parseFlags(list: string[]): { positionals: string[]; flags: Map<string, string> } {
+  const out: string[] = []
+  const flags = new Map<string, string>()
+  for (let i = 0; i < list.length; i++) {
+    const a = list[i]!
+    if (a.startsWith("-")) {
+      if (VALUE_FLAGS.has(a)) {
+        flags.set(a, list[i + 1] ?? "")
+        i++
+      } else {
+        flags.set(a, "")
+      }
+      continue
+    }
+    out.push(a)
+  }
+  return { positionals: out, flags }
+}
+
+// A value-taking flag with nothing usable after it is a mistake worth naming,
+// not a silently-empty value.
+function badFlagValue(flags: Map<string, string>, name: string): boolean {
+  if (!flags.has(name)) return false
+  const v = flags.get(name)!
+  return !v || v.startsWith("-")
+}
+
 if (args.includes("-h") || args.includes("--help") || command === "help") {
   const cfg = loadConfig()
   console.log(`SpinupTUI v${pkg.version} — terminal dashboard for your SpinupWP account
@@ -30,9 +62,11 @@ Usage:
   spinuptui            Launch the dashboard
   spinuptui login      Set or update your saved API token
   spinuptui where      Print the config file path and token source
-  spinuptui ssh <domain>  Print SSH access info for a site (JSON)
-  spinuptui ssh-exec <domain> -- <command>  Run a read-only command over SSH
-                       (JSON); denies anything that looks like a remote write
+  spinuptui ssh <domain> [--server <name>]  Print SSH access info for a site
+                       (JSON)
+  spinuptui ssh-exec <domain> [--server <name>] -- <command>  Run a read-only
+                       command over SSH (JSON); denies anything that looks
+                       like a remote write
   spinuptui incidents <domain> | --all [--hours N]  Print Uptime Kuma
                        down/up incidents for a site or the whole fleet (JSON)
   spinuptui pull files <domain> [path] [--url <local url>] [--server <name>]
@@ -48,7 +82,8 @@ Usage:
   spinuptui --help     Show this help
 
 --server picks one site when a domain exists on more than one server (the
-ambiguity message lists them). Add --json to either pull command for a single
+ambiguity message lists them); it works on ssh, ssh-exec and both pull
+commands. Add --json to either pull command for a single
 machine-readable result object on stdout; progress always goes to stderr, so a
 long pull never looks hung.
 
@@ -74,31 +109,43 @@ if (command === "where") {
 }
 
 if (command === "ssh") {
-  const domain = positionals[1]
-  if (!domain) {
-    console.error(JSON.stringify({ ok: false, reason: "usage", message: "Usage: spinuptui ssh <domain>" }))
+  const parsed = parseFlags(args.slice(1))
+  const domain = parsed.positionals[0]
+  const server = parsed.flags.get("--server") ?? null
+  if (!domain || badFlagValue(parsed.flags, "--server")) {
+    console.error(
+      JSON.stringify({ ok: false, reason: "usage", message: "Usage: spinuptui ssh <domain> [--server <name>]" }),
+    )
     process.exit(1)
   }
   const cfg = loadConfig()
   const client = new SpinupWPClient(cfg)
-  const result = await resolveSshAccess(domain, client, cfg)
+  const result = await resolveSshAccess(domain, client, cfg, { server })
   console.log(JSON.stringify(result))
   process.exit(result.ok ? 0 : 1)
 }
 
 if (command === "ssh-exec") {
   const dashIdx = args.indexOf("--")
-  const domain = positionals[1]
+  // Only the arguments BEFORE `--` are ours; everything after is the remote
+  // command, which may legitimately contain things that look like our flags.
+  const parsed = parseFlags(dashIdx === -1 ? args.slice(1) : args.slice(1, dashIdx))
+  const domain = parsed.positionals[0]
+  const server = parsed.flags.get("--server") ?? null
   const remoteCmd = dashIdx !== -1 ? args.slice(dashIdx + 1).join(" ") : ""
-  if (!domain || dashIdx === -1 || !remoteCmd.trim()) {
+  if (!domain || dashIdx === -1 || !remoteCmd.trim() || badFlagValue(parsed.flags, "--server")) {
     console.error(
-      JSON.stringify({ ok: false, reason: "usage", message: "Usage: spinuptui ssh-exec <domain> -- <command>" }),
+      JSON.stringify({
+        ok: false,
+        reason: "usage",
+        message: "Usage: spinuptui ssh-exec <domain> [--server <name>] -- <command>",
+      }),
     )
     process.exit(1)
   }
   const cfg = loadConfig()
   const client = new SpinupWPClient(cfg)
-  const result = await execSshCommand(domain, remoteCmd, client, cfg)
+  const result = await execSshCommand(domain, remoteCmd, client, cfg, { server })
   console.log(JSON.stringify(result))
   process.exit(result.ok ? 0 : 1)
 }
@@ -127,24 +174,11 @@ if (command === "incidents") {
 }
 
 if (command === "pull") {
-  const rest = args.slice(1)
-  const json = rest.includes("--json")
-  const yes = rest.includes("--yes")
-  const urlIdx = rest.indexOf("--url")
-  const url = urlIdx !== -1 ? (rest[urlIdx + 1] ?? null) : null
-  const serverIdx = rest.indexOf("--server")
-  const server = serverIdx !== -1 ? (rest[serverIdx + 1] ?? null) : null
-  // Positionals, skipping flags and the value that belongs to --url (which is a
-  // URL, so it doesn't look like a flag and would otherwise be read as a path).
-  const pos: string[] = []
-  for (let i = 0; i < rest.length; i++) {
-    const a = rest[i]!
-    if (a.startsWith("-")) {
-      if (a === "--url" || a === "--server") i++
-      continue
-    }
-    pos.push(a)
-  }
+  const { positionals: pos, flags } = parseFlags(args.slice(1))
+  const json = flags.has("--json")
+  const yes = flags.has("--yes")
+  const url = flags.get("--url") ?? null
+  const server = flags.get("--server") ?? null
   const sub = pos[0]
   const domain = pos[1]
   const destPath = pos[2] ?? null
@@ -158,8 +192,8 @@ if (command === "pull") {
     usage("Usage: spinuptui pull files <domain> [path] [--url <local url>] | spinuptui pull db <domain> [--url <local url>] --yes")
   }
   if (!domain) usage(`Usage: spinuptui pull ${sub} <domain>`)
-  if (urlIdx !== -1 && (!url || url.startsWith("-"))) usage("--url needs a value, e.g. --url https://example.test")
-  if (serverIdx !== -1 && (!server || server.startsWith("-"))) usage("--server needs a value, e.g. --server web1.example.com")
+  if (badFlagValue(flags, "--url")) usage("--url needs a value, e.g. --url https://example.test")
+  if (badFlagValue(flags, "--server")) usage("--server needs a value, e.g. --server web1.example.com")
   if (sub === "db" && destPath) usage("`pull db` imports into the already-linked copy and takes no path. Use --url to set the local URL.")
 
   const cfg = loadConfig()

--- a/src/lib/cliPull.ts
+++ b/src/lib/cliPull.ts
@@ -110,14 +110,7 @@ const DB_STAGE_LABELS: Record<DbSyncStage, string> = {
 // into this command's result type, preserving the shared reason codes.
 function fromResolverFailure(command: PullCommand, failure: { ok: false } & Record<string, unknown>): PullFailure {
   const candidates = failure.candidates as SshAccessCandidate[] | undefined
-  // Unlike `ssh`/`ssh-exec`, these commands can be pointed at one of the
-  // matches, so an ambiguous domain is recoverable — name the flag that does it.
-  const remedy =
-    failure.remedy != null
-      ? String(failure.remedy)
-      : failure.reason === "multiple_matches" && candidates?.length
-        ? `Pick one with --server, e.g. \`--server ${candidates[0]!.server}\`.`
-        : undefined
+  const remedy = failure.remedy != null ? String(failure.remedy) : undefined
   return {
     ok: false,
     command,

--- a/src/lib/cliSsh.ts
+++ b/src/lib/cliSsh.ts
@@ -113,6 +113,9 @@ export async function resolveSiteByDomain(
           message: wanted
             ? `"${domain}" matches ${matches.length} sites in this account, and ${narrowed.length === 0 ? "none are" : `${narrowed.length} are`} on a server matching "${opts?.server}".`
             : `"${domain}" matches ${matches.length} sites in this account — cannot pick one automatically.`,
+          // Every command that resolves a domain takes --server, so this is
+          // always actionable — say so here rather than in each of them.
+          remedy: `Pick one with --server, e.g. \`--server ${candidates[0]!.server}\`.`,
           candidates,
         })
       }
@@ -150,8 +153,9 @@ export async function resolveSshTargetInfo(
   domain: string,
   client: SpinupWPClientLike,
   cfg: AppConfig,
+  opts?: { server?: string | null },
 ): Promise<SshTargetResolution> {
-  const resolved = await resolveSiteByDomain(domain, client, cfg)
+  const resolved = await resolveSiteByDomain(domain, client, cfg, opts)
   if (!resolved.ok) return resolved
 
   const { site, server } = resolved
@@ -168,8 +172,9 @@ export async function resolveSshAccess(
   domain: string,
   client: SpinupWPClientLike,
   cfg: AppConfig,
+  opts?: { server?: string | null },
 ): Promise<SshAccessResult> {
-  const resolution = await resolveSshTargetInfo(domain, client, cfg)
+  const resolution = await resolveSshTargetInfo(domain, client, cfg, opts)
   if (!resolution.ok) return resolution.result
   const { primaryDomain, sshTarget: target, port, server: serverName } = resolution.info
   const portOpt = port ? ["-p", String(port)] : []

--- a/src/lib/sshExec.ts
+++ b/src/lib/sshExec.ts
@@ -44,8 +44,9 @@ export async function execSshCommand(
   command: string,
   client: SpinupWPClientLike,
   cfg: AppConfig,
+  opts?: { server?: string | null },
 ): Promise<SshExecResult> {
-  const resolution = await resolveSshTargetInfo(domain, client, cfg)
+  const resolution = await resolveSshTargetInfo(domain, client, cfg, opts)
   if (!resolution.ok) {
     logSshExecAttempt({ domain, command, decision: "error", reason: resolution.result.reason, message: resolution.result.message })
     return { ...resolution.result, command }


### PR DESCRIPTION
> **Stacked on #56** — it extends the `--server` narrowing that PR added to the shared resolver. GitHub retargets this once #56 merges; review only the last commit.

A domain can legitimately exist on more than one server in a SpinupWP account — a clone-wizard destination, a staging twin. `pull` gained a way to pick one in #56; `ssh` and `ssh-exec` could only *report* the ambiguity, which left such a site simply unreachable from the CLI:

```
$ spinuptui ssh-exec bedrock.spinuptui.com -- "wp option get home"
{"ok":false,"reason":"multiple_matches","message":"… matches 2 sites …"}   ← dead end
```

Both now take `--server <name>`, threaded through the resolver they already share. It matches the full server name or its first label (`web1` for `web1.spinuptui.com`).

```
$ spinuptui ssh bedrock.spinuptui.com --server web1
{"ok":true,…,"sshTarget":"bedrock@203.0.113.10","server":"web1.spinuptui.com"}
```

### Where the remedy lives
The `multiple_matches` remedy moves **into `resolveSiteByDomain`** now that every domain-addressed command supports the flag, instead of being synthesized by the one caller that did. So the ambiguity lists its candidates and names the flag that resolves it, everywhere it's raised.

### Flag parsing
Factored into `parseFlags` / `badFlagValue` rather than a third hand-rolled copy. That fixes a real ordering bug in passing: `--server web1 <domain>` used to read `"web1"` as the domain, because positionals were collected without knowing which flags take a value. `--url` had the same latent problem.

For `ssh-exec`, only the arguments **before `--`** are parsed, so a remote command containing `--server` is passed through untouched.

### Testing
`bun run typecheck` green. Verified live against a domain that really is on two servers:

- ambiguity now carries `remedy` + `candidates` on both commands
- `--server web1` and `--server web1.spinuptui.com` both resolve
- the flag before *or* after the domain works — the old bug
- each server resolves to its own distinct IP
- `ssh-exec … --server web1 -- "echo --server web9 --url x"` returns the string intact
- the read-only guardrail still denies `wp plugin install`
- regression sweep over every `pull` usage error and failure path after the parser refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SG3orBudWnfTif1maqAeH3