### PR TITLE
feat: `spinuptui pull files` / `pull db` CLI subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ versions; such changes are called out here.
   - **`pull files` never re-syncs over an existing copy** — a site that's
     already linked is refused with its current path, rather than clobbering
     local work.
+  - **`pull files` warns that the copied `wp-config.php` is production's**, and
+    a `pull db` that's denied by local MySQL says why. The rsync path brings
+    down the site's real `wp-config.php`, credentials and all — harmless (their
+    `DB_HOST` is localhost, so nothing local can reach production's database
+    through them) but it means local wp-cli authenticates as the *production*
+    DB user, and `pull db` fails on its very first step until they're pointed
+    at a local database.
   - The path argument is optional only when exactly one `localRoots` entry is
     configured. With several, it's required: which root a site belongs in isn't
     knowable from here, and guessing would file a standard-WP site under

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ versions; such changes are called out here.
     through them) but it means local wp-cli authenticates as the *production*
     DB user, and `pull db` fails on its very first step until they're pointed
     at a local database.
+  - **`--server <name>` picks one site when a domain exists on more than one
+    server**, and the ambiguity itself now lists what matched (in both output
+    modes) instead of only saying there was more than one.
+  - **A Bedrock/Radicle clone is flagged for its missing `.env`** — that's where
+    its database credentials live and it's deliberately not in the repo, so
+    `pull db` would otherwise die on `mysqldump: unknown variable 'pass='`.
+    It's now caught up front, by name.
   - The path argument is optional only when exactly one `localRoots` entry is
     configured. With several, it's required: which root a site belongs in isn't
     knowable from here, and guessing would file a standard-WP site under

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ versions; such changes are called out here.
 ## [Unreleased]
 
 ### Added
+- **`spinuptui pull files` and `spinuptui pull db`** — the local-working-copy
+  setup and DB sync, driven non-interactively from the command line, on the
+  same engines the TUI's guided flow uses. `pull files <domain> [path]` clones a
+  site's code down and links it; `pull db <domain> --yes` imports production's
+  database into that copy. Built for an agentic workflow ("pull site X down for
+  local dev") as much as for a person: progress goes to stderr, and stdout
+  carries the machine contract — with `--json`, a single result object, exit
+  code mirroring `ok`, and failures carrying both a stable `reason` code and a
+  `remedy` naming the exact command that fixes it.
+  - **`pull db` is gated twice**, since it overwrites the local database:
+    `"localSync": true` in the config (the same opt-in the TUI enforces) *and*
+    `--yes` on the invocation. Both are checked before any network call, so a
+    typo'd domain in a script bounces off the gate rather than off a lookup.
+  - **`pull files` never re-syncs over an existing copy** — a site that's
+    already linked is refused with its current path, rather than clobbering
+    local work.
+  - The path argument is optional only when exactly one `localRoots` entry is
+    configured. With several, it's required: which root a site belongs in isn't
+    knowable from here, and guessing would file a standard-WP site under
+    Bedrock.
 - **Clone a site's full local working copy from production** — `L` on a site
   with no local copy yet now opens a choose screen: `e` is the existing manual
   "enter a path" form, and the new `c` runs a guided clone. It pulls the code

--- a/README.md
+++ b/README.md
@@ -203,7 +203,11 @@ spinuptui pull files <domain> [path] [--url <local url>] [--json]
                      over your work. With exactly one `localRoots` entry
                      configured the path is optional (defaults to
                      `<that root>/<domain>`); with several, it's required,
-                     since which root a site belongs in isn't knowable.
+                     since which root a site belongs in isn't knowable. Note
+                     the rsync path copies the site's real `wp-config.php` —
+                     production credentials and all — so point its DB settings
+                     at your local database before `pull db` (the command says
+                     so on success, and again if the import is denied).
 spinuptui pull db <domain> [--url <local url>] --yes [--json]
                      Import production's database into the already-linked local
                      copy, rewriting production URLs to the local URL, after

--- a/README.md
+++ b/README.md
@@ -193,7 +193,8 @@ spinuptui incidents <domain> | --all [--hours N]  Print Uptime Kuma down/up
                      monitoring for (config.json's kumaMonitors) — --all
                      sweeps every such site in one Kuma connection, --hours
                      sets the lookback window (default 24)
-spinuptui pull files <domain> [path] [--url <local url>] [--json]
+spinuptui pull files <domain> [path] [--url <local url>] [--server <name>]
+                     [--json]
                      Set up a new local working copy of a site: `git clone` for
                      git-deployed sites, `rsync` over SSH otherwise (excluding
                      uploads and the caching drop-ins), `composer install` for
@@ -207,8 +208,13 @@ spinuptui pull files <domain> [path] [--url <local url>] [--json]
                      the rsync path copies the site's real `wp-config.php` —
                      production credentials and all — so point its DB settings
                      at your local database before `pull db` (the command says
-                     so on success, and again if the import is denied).
-spinuptui pull db <domain> [--url <local url>] --yes [--json]
+                     so on success, and again if the import is denied). A
+                     Bedrock/Radicle clone lands without its `.env` — which is
+                     where its DB credentials live and is deliberately not in
+                     the repo — and says so the same way. `--server <name>`
+                     picks one site when a domain exists on more than one
+                     server; the ambiguity message lists the candidates.
+spinuptui pull db <domain> [--url <local url>] [--server <name>] --yes [--json]
                      Import production's database into the already-linked local
                      copy, rewriting production URLs to the local URL, after
                      dumping the current local database as a backup. This
@@ -226,8 +232,9 @@ result to **stdout** — with `--json`, a single result object (`{ok:true, …}`
 `{ok:false, reason, message, remedy}`), and the exit code mirrors `ok`. That
 keeps stdout parseable for an agent while a person watching a ten-minute rsync
 can still see it isn't hung. Failures carry a machine-readable `reason`
-(`site_not_found`, `already_linked`, `dest_not_empty`, `ambiguous_dest`,
-`not_linked`, `local_sync_disabled`, `not_confirmed`, …) and, where there's a
+(`site_not_found`, `multiple_matches`, `already_linked`, `dest_not_empty`,
+`ambiguous_dest`, `not_linked`, `missing_env`, `local_sync_disabled`,
+`not_confirmed`, …) and, where there's a
 clear next step, a `remedy` naming the exact command to run.
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -81,9 +81,12 @@
   if it's read-only — anything that looks like a write/restart/destructive
   action is denied rather than run, so any agent using it inherits that
   guarantee without building its own guard; `spinuptui incidents <domain>` /
-  `--all` surfaces Uptime Kuma's down/up history as JSON. Built so another
-  agent/script can go from just a domain to "what's wrong and how do I get
-  in" with no manual lookup. → [CLI subcommands](#cli-subcommands)
+  `--all` surfaces Uptime Kuma's down/up history as JSON; `spinuptui pull files
+  <domain> [path]` and `spinuptui pull db <domain> --yes` set up a local working
+  copy from production without opening the TUI at all — the same engines the
+  guided flow drives. Built so another agent/script can go from just a domain to
+  "what's wrong and how do I get in", or to a working local copy, with no manual
+  lookup. → [CLI subcommands](#cli-subcommands)
 - **Completion toasts** — a non-focus-stealing toast when a background write
   (PHP upgrade, reboot, DNS resolve, …) finishes.
 - **Release notes** — an in-app "what's new" after every update, sourced
@@ -190,9 +193,38 @@ spinuptui incidents <domain> | --all [--hours N]  Print Uptime Kuma down/up
                      monitoring for (config.json's kumaMonitors) — --all
                      sweeps every such site in one Kuma connection, --hours
                      sets the lookback window (default 24)
+spinuptui pull files <domain> [path] [--url <local url>] [--json]
+                     Set up a new local working copy of a site: `git clone` for
+                     git-deployed sites, `rsync` over SSH otherwise (excluding
+                     uploads and the caching drop-ins), `composer install` for
+                     Bedrock/Radicle, then link it. Read-only on production.
+                     Refuses a path that exists and isn't empty, and refuses a
+                     site that already has a local copy rather than re-syncing
+                     over your work. With exactly one `localRoots` entry
+                     configured the path is optional (defaults to
+                     `<that root>/<domain>`); with several, it's required,
+                     since which root a site belongs in isn't knowable.
+spinuptui pull db <domain> [--url <local url>] --yes [--json]
+                     Import production's database into the already-linked local
+                     copy, rewriting production URLs to the local URL, after
+                     dumping the current local database as a backup. This
+                     **overwrites your local database**, so it's gated twice:
+                     `"localSync": true` must be set in the config (or
+                     `SPINUPWP_LOCAL_SYNC=1`) *and* `--yes` passed on the
+                     invocation. Both are checked before any network call.
+                     `--url` doubles as "set the local URL, then sync".
 spinuptui --version  Print the version
 spinuptui --help     Show help
 ```
+
+Both `pull` commands write human-readable progress to **stderr** and their
+result to **stdout** — with `--json`, a single result object (`{ok:true, …}` or
+`{ok:false, reason, message, remedy}`), and the exit code mirrors `ok`. That
+keeps stdout parseable for an agent while a person watching a ten-minute rsync
+can still see it isn't hung. Failures carry a machine-readable `reason`
+(`site_not_found`, `already_linked`, `dest_not_empty`, `ambiguous_dest`,
+`not_linked`, `local_sync_disabled`, `not_confirmed`, …) and, where there's a
+clear next step, a `remedy` naming the exact command to run.
 
 ## Configuration
 

--- a/docs/local-working-copies.md
+++ b/docs/local-working-copies.md
@@ -35,5 +35,31 @@ serve it; the site's details gain a "Local" field, and you can open the copy wit
   shows its local git drift (`⇡N unpushed` / `● uncommitted`), read from the repo
   with no network.
 
+## From the command line
+
+The same two engines run without the TUI, for a script or an agent handed only a
+domain:
+
+```sh
+spinuptui pull files <domain> [path] [--url <local url>] [--server <name>] [--json]
+spinuptui pull db <domain> [--url <local url>] [--server <name>] --yes [--json]
+```
+
+`pull files` clones the code down and links it; `pull db` imports production's
+database into that copy, rewriting URLs. Progress goes to stderr and the result
+to stdout — with `--json`, one object, exit code mirroring `ok`, and a `reason`
+plus a `remedy` naming the exact command that fixes any failure.
+
+- **`pull db` is gated twice**, since it overwrites your local database:
+  `"localSync": true` in the config *and* `--yes` on the invocation. Both are
+  checked before any network call.
+- **`pull files` won't re-sync over an existing copy** — a site that's already
+  linked is refused with its current path, rather than clobbering local work.
+- **The path is optional only with exactly one `localRoots` entry** (it becomes
+  `<that root>/<domain>`). With several configured, which one a site belongs in
+  isn't knowable, so it's required.
+- **`--server <name>`** picks one site when a domain exists on more than one
+  server; it works on `ssh` and `ssh-exec` too.
+
 Config keys: `localRoots` (folders to scan) and `localSites` (per-site path +
 local URL — tool-agnostic: Valet, Cove, LocalWP, Herd, DDEV, …).

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,7 @@ import { SpinupWPClient } from "./api/client.ts"
 import { resolveSshAccess } from "./lib/cliSsh.ts"
 import { resolveIncidents } from "./lib/cliIncidents.ts"
 import { execSshCommand } from "./lib/sshExec.ts"
+import { runPullFiles, runPullDb } from "./lib/cliPull.ts"
 
 const args = process.argv.slice(2)
 const positionals = args.filter((a) => !a.startsWith("-"))
@@ -34,8 +35,20 @@ Usage:
                        (JSON); denies anything that looks like a remote write
   spinuptui incidents <domain> | --all [--hours N]  Print Uptime Kuma
                        down/up incidents for a site or the whole fleet (JSON)
+  spinuptui pull files <domain> [path] [--url <local url>]
+                       Clone a site's code to a new local working copy and link
+                       it. Read-only on production; refuses a non-empty path.
+                       With exactly one localRoots entry configured, the path
+                       defaults to <that root>/<domain>.
+  spinuptui pull db <domain> [--url <local url>] --yes
+                       Import production's database into the linked local copy,
+                       rewriting URLs. OVERWRITES your local database: needs
+                       both --yes and "localSync": true in the config.
   spinuptui --version  Print the version
   spinuptui --help     Show this help
+
+Add --json to either pull command for a single machine-readable result object
+on stdout; progress always goes to stderr, so a long pull never looks hung.
 
 Token resolution: SPINUPWP_ACCESS_TOKEN (env / .env) first, then the config
 file. Run \`spinuptui login\` once to save a token so \`spinuptui\` works from
@@ -108,6 +121,73 @@ if (command === "incidents") {
   const cfg = loadConfig()
   const result = await resolveIncidents(cfg, { domain: domainArg, hours })
   console.log(JSON.stringify(result))
+  process.exit(result.ok ? 0 : 1)
+}
+
+if (command === "pull") {
+  const rest = args.slice(1)
+  const json = rest.includes("--json")
+  const yes = rest.includes("--yes")
+  const urlIdx = rest.indexOf("--url")
+  const url = urlIdx !== -1 ? (rest[urlIdx + 1] ?? null) : null
+  // Positionals, skipping flags and the value that belongs to --url (which is a
+  // URL, so it doesn't look like a flag and would otherwise be read as a path).
+  const pos: string[] = []
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i]!
+    if (a.startsWith("-")) {
+      if (a === "--url") i++
+      continue
+    }
+    pos.push(a)
+  }
+  const sub = pos[0]
+  const domain = pos[1]
+  const destPath = pos[2] ?? null
+
+  const usage = (message: string) => {
+    console.error(JSON.stringify({ ok: false, reason: "usage", message }))
+    process.exit(1)
+  }
+
+  if (sub !== "files" && sub !== "db") {
+    usage("Usage: spinuptui pull files <domain> [path] [--url <local url>] | spinuptui pull db <domain> [--url <local url>] --yes")
+  }
+  if (!domain) usage(`Usage: spinuptui pull ${sub} <domain>`)
+  if (urlIdx !== -1 && (!url || url.startsWith("-"))) usage("--url needs a value, e.g. --url https://example.test")
+  if (sub === "db" && destPath) usage("`pull db` imports into the already-linked copy and takes no path. Use --url to set the local URL.")
+
+  const cfg = loadConfig()
+  const client = new SpinupWPClient(cfg)
+  // Progress is a human channel on stderr in both modes: it keeps a long rsync
+  // from looking hung, and leaves stdout as the machine contract.
+  const onStage = (line: string) => process.stderr.write(`\u2192 ${line}\n`)
+
+  const result =
+    sub === "files"
+      ? await runPullFiles(domain!, { path: destPath, url }, client, cfg, onStage)
+      : await runPullDb(domain!, { url, yes }, client, cfg, onStage)
+
+  if (json) {
+    console.log(JSON.stringify(result))
+  } else if (result.ok) {
+    if (result.command === "pull files") {
+      const built = result.ranComposer ? ", composer install ran" : ""
+      console.log(`Pulled ${result.primaryDomain} to ${result.path} (${result.method}${built}) and linked it.`)
+      console.log(
+        result.localUrl
+          ? `Next: spinuptui pull db ${result.primaryDomain} --yes`
+          : `Next: spinuptui pull db ${result.primaryDomain} --url <local url> --yes`,
+      )
+    } else {
+      console.log(`Imported production's database for ${result.primaryDomain} into ${result.path}.`)
+      console.log(`Local database backed up first to ${result.localBackupPath}`)
+    }
+    if (result.warning) console.error(`Warning: ${result.warning}`)
+  } else {
+    console.error(result.message)
+    if (result.remedy) console.error(result.remedy)
+  }
   process.exit(result.ok ? 0 : 1)
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -183,7 +183,7 @@ if (command === "pull") {
       console.log(`Imported production's database for ${result.primaryDomain} into ${result.path}.`)
       console.log(`Local database backed up first to ${result.localBackupPath}`)
     }
-    if (result.warning) console.error(`Warning: ${result.warning}`)
+    for (const warning of result.warnings ?? []) console.error(`Warning: ${warning}`)
   } else {
     console.error(result.message)
     if (result.remedy) console.error(result.remedy)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,20 +35,22 @@ Usage:
                        (JSON); denies anything that looks like a remote write
   spinuptui incidents <domain> | --all [--hours N]  Print Uptime Kuma
                        down/up incidents for a site or the whole fleet (JSON)
-  spinuptui pull files <domain> [path] [--url <local url>]
+  spinuptui pull files <domain> [path] [--url <local url>] [--server <name>]
                        Clone a site's code to a new local working copy and link
                        it. Read-only on production; refuses a non-empty path.
                        With exactly one localRoots entry configured, the path
                        defaults to <that root>/<domain>.
-  spinuptui pull db <domain> [--url <local url>] --yes
+  spinuptui pull db <domain> [--url <local url>] [--server <name>] --yes
                        Import production's database into the linked local copy,
                        rewriting URLs. OVERWRITES your local database: needs
                        both --yes and "localSync": true in the config.
   spinuptui --version  Print the version
   spinuptui --help     Show this help
 
-Add --json to either pull command for a single machine-readable result object
-on stdout; progress always goes to stderr, so a long pull never looks hung.
+--server picks one site when a domain exists on more than one server (the
+ambiguity message lists them). Add --json to either pull command for a single
+machine-readable result object on stdout; progress always goes to stderr, so a
+long pull never looks hung.
 
 Token resolution: SPINUPWP_ACCESS_TOKEN (env / .env) first, then the config
 file. Run \`spinuptui login\` once to save a token so \`spinuptui\` works from
@@ -130,13 +132,15 @@ if (command === "pull") {
   const yes = rest.includes("--yes")
   const urlIdx = rest.indexOf("--url")
   const url = urlIdx !== -1 ? (rest[urlIdx + 1] ?? null) : null
+  const serverIdx = rest.indexOf("--server")
+  const server = serverIdx !== -1 ? (rest[serverIdx + 1] ?? null) : null
   // Positionals, skipping flags and the value that belongs to --url (which is a
   // URL, so it doesn't look like a flag and would otherwise be read as a path).
   const pos: string[] = []
   for (let i = 0; i < rest.length; i++) {
     const a = rest[i]!
     if (a.startsWith("-")) {
-      if (a === "--url") i++
+      if (a === "--url" || a === "--server") i++
       continue
     }
     pos.push(a)
@@ -155,6 +159,7 @@ if (command === "pull") {
   }
   if (!domain) usage(`Usage: spinuptui pull ${sub} <domain>`)
   if (urlIdx !== -1 && (!url || url.startsWith("-"))) usage("--url needs a value, e.g. --url https://example.test")
+  if (serverIdx !== -1 && (!server || server.startsWith("-"))) usage("--server needs a value, e.g. --server web1.example.com")
   if (sub === "db" && destPath) usage("`pull db` imports into the already-linked copy and takes no path. Use --url to set the local URL.")
 
   const cfg = loadConfig()
@@ -165,8 +170,8 @@ if (command === "pull") {
 
   const result =
     sub === "files"
-      ? await runPullFiles(domain!, { path: destPath, url }, client, cfg, onStage)
-      : await runPullDb(domain!, { url, yes }, client, cfg, onStage)
+      ? await runPullFiles(domain!, { path: destPath, url, server }, client, cfg, onStage)
+      : await runPullDb(domain!, { url, yes, server }, client, cfg, onStage)
 
   if (json) {
     console.log(JSON.stringify(result))
@@ -186,6 +191,7 @@ if (command === "pull") {
     for (const warning of result.warnings ?? []) console.error(`Warning: ${warning}`)
   } else {
     console.error(result.message)
+    for (const c of result.candidates ?? []) console.error(`  · ${c.server} (site ${c.siteId})`)
     if (result.remedy) console.error(result.remedy)
   }
   process.exit(result.ok ? 0 : 1)

--- a/src/lib/cliPull.ts
+++ b/src/lib/cliPull.ts
@@ -1,0 +1,333 @@
+// `spinuptui pull files` / `spinuptui pull db` — the two local-working-copy
+// engines, driven non-interactively.
+//
+// Same engines the TUI drives (lib/localSetup.ts and lib/dbSync.ts), same
+// domain resolution as `ssh`/`ssh-exec` (lib/cliSsh.ts's resolveSiteByDomain),
+// so behavior can't drift between the two front ends. Nothing here reimplements
+// a step; this file is argument resolution, gating, and result shaping.
+//
+// Output contract, matching the other subcommands: the returned object is the
+// machine-readable result (one JSON object on stdout under --json, exit code
+// mirrors `ok`). Progress goes to the caller's `onStage` — stderr, always,
+// human-readable — so a person watching a ten-minute rsync can see it isn't
+// hung and an agent still has the trail when something fails.
+//
+// `pull files` is read-only on production. `pull db` OVERWRITES the local
+// database, so it's gated twice: the `localSync` config opt-in (same gate the
+// TUI enforces) and an explicit `--yes` on the invocation. Both are checked
+// before any network call, so a typo'd domain in a script fails on the gate.
+
+import { join } from "node:path"
+import { configPath, type AppConfig } from "../config.ts"
+import type { SpinupWPClientLike } from "../api/client.ts"
+import { resolveSiteByDomain, type SshAccessCandidate, type SshAccessReason } from "./cliSsh.ts"
+import { planLocalSetup, runLocalSetup, type LocalSetupStage } from "./localSetup.ts"
+import { planDbSync, runDbSync, type DbSyncStage } from "./dbSync.ts"
+import { readLink, writeLink } from "./links.ts"
+import { expandPath } from "./local.ts"
+
+export type PullReason =
+  | SshAccessReason
+  | "no_dest"
+  | "ambiguous_dest"
+  | "already_linked"
+  | "dest_not_empty"
+  | "plan_failed"
+  | "fetch_failed"
+  | "composer_failed"
+  | "not_linked"
+  | "local_sync_disabled"
+  | "not_confirmed"
+  | "sync_failed"
+
+export type PullCommand = "pull files" | "pull db"
+
+export interface PullFailure {
+  ok: false
+  command: PullCommand
+  domain: string
+  reason: PullReason
+  message: string
+  remedy?: string
+  candidates?: SshAccessCandidate[]
+  failedStage?: string
+}
+
+export interface PullFilesSuccess {
+  ok: true
+  command: "pull files"
+  domain: string
+  primaryDomain: string
+  path: string
+  localUrl: string
+  method: "git" | "rsync"
+  ranComposer: boolean
+  linked: true
+  // Present when the copy is on disk and linked but not yet usable by `pull db`
+  // — it needs a local URL to rewrite production URLs to.
+  warning?: string
+}
+
+export interface PullDbSuccess {
+  ok: true
+  command: "pull db"
+  domain: string
+  primaryDomain: string
+  path: string
+  localUrl: string
+  downloadPath: string
+  localBackupPath: string
+  ranHook: boolean
+  warning?: string
+}
+
+export type PullFilesResult = PullFilesSuccess | PullFailure
+export type PullDbResult = PullDbSuccess | PullFailure
+
+export type StageReporter = (line: string) => void
+
+const FILES_STAGE_LABELS: Record<LocalSetupStage, string> = {
+  fetch: "Getting the code down",
+  build: "composer install",
+  done: "Done",
+  error: "Failed",
+}
+
+const DB_STAGE_LABELS: Record<DbSyncStage, string> = {
+  "local-backup": "Backing up the local database first",
+  export: "Exporting the production database",
+  download: "Downloading the dump",
+  import: "Importing into the local database",
+  replace: "Rewriting production URLs to local",
+  hook: "Running bin/sync.d/post-import.sh",
+  done: "Done",
+  error: "Failed",
+}
+
+// Shape a resolver failure (unknown domain, ambiguous domain, dead token, …)
+// into this command's result type, preserving the shared reason codes.
+function fromResolverFailure(command: PullCommand, failure: { ok: false } & Record<string, unknown>): PullFailure {
+  return {
+    ok: false,
+    command,
+    domain: String(failure.domain ?? ""),
+    reason: failure.reason as PullReason,
+    message: String(failure.message ?? ""),
+    ...(failure.remedy ? { remedy: String(failure.remedy) } : {}),
+    ...(failure.candidates ? { candidates: failure.candidates as SshAccessCandidate[] } : {}),
+  }
+}
+
+export async function runPullFiles(
+  domain: string,
+  opts: { path?: string | null; url?: string | null },
+  client: SpinupWPClientLike,
+  cfg: AppConfig,
+  onStage: StageReporter,
+): Promise<PullFilesResult> {
+  const command: PullCommand = "pull files"
+  const fail = (reason: PullReason, message: string, remedy?: string): PullFailure => ({
+    ok: false,
+    command,
+    domain,
+    reason,
+    message,
+    ...(remedy ? { remedy } : {}),
+  })
+
+  onStage(`Resolving ${domain} …`)
+  const resolved = await resolveSiteByDomain(domain, client, cfg)
+  if (!resolved.ok) return fromResolverFailure(command, resolved.result)
+  const { site, server } = resolved
+  onStage(`Site ${site.domain} on ${server.name} (${server.ip_address})`)
+
+  // A site that already has a local copy is not re-pulled: this engine only
+  // ever populates an empty directory, and re-syncing over an existing checkout
+  // would clobber local work. Refuse and say where the copy already is.
+  const existing = readLink(site.id)
+  if (existing) {
+    return fail(
+      "already_linked",
+      `${site.domain} already has a local copy at ${existing.path}.`,
+      "Pull the database into it with `spinuptui pull db`, or unlink it first (run `spinuptui`, select the site, press L then x).",
+    )
+  }
+
+  // Destination: the explicit argument, else derived as <localRoot>/<primary
+  // domain>, so an agent handed only a domain never has to invent a filesystem
+  // path. Only derived when there's exactly one root — with several configured
+  // there's no way to tell which one this site belongs in (they're commonly
+  // split by stack), and guessing would file a standard-WP site under Bedrock.
+  let dest = opts.path?.trim() ?? ""
+  if (!dest) {
+    if (cfg.localRoots.length === 0) {
+      return fail(
+        "no_dest",
+        "No destination path given, and no localRoots configured to derive one from.",
+        `Pass a path (\`spinuptui pull files ${domain} <path>\`), or set "localRoots": ["~/your/dev/dir"] in ${configPath()}.`,
+      )
+    }
+    if (cfg.localRoots.length > 1) {
+      return fail(
+        "ambiguous_dest",
+        `No destination path given, and ${cfg.localRoots.length} localRoots are configured (${cfg.localRoots.join(", ")}) — which one this site belongs in isn't knowable from here.`,
+        `Pass a path, e.g. \`spinuptui pull files ${domain} ${join(cfg.localRoots[0]!, site.domain)}\`.`,
+      )
+    }
+    dest = join(cfg.localRoots[0]!, site.domain)
+    onStage(`Destination derived from localRoots: ${dest}`)
+  }
+  const localUrl = opts.url?.trim() ?? ""
+
+  const planned = planLocalSetup(site, server, cfg.sshUser, dest, localUrl)
+  if (!planned.ok) {
+    const reason: PullReason = /isn't empty/i.test(planned.error) ? "dest_not_empty" : "plan_failed"
+    return fail(reason, planned.error)
+  }
+  const plan = planned.plan
+
+  onStage(
+    plan.isGit
+      ? `Source: git clone ${plan.repoUrl}`
+      : `Source: rsync ${plan.user}@${plan.host}:${plan.filesRoot}/ (excluding uploads and the caching drop-ins)`,
+  )
+  onStage(`Destination: ${plan.destPath}`)
+
+  let lastStage: LocalSetupStage | null = null
+  const result = await runLocalSetup(plan, (p) => {
+    if (p.stage !== lastStage && p.stage !== "done" && p.stage !== "error") {
+      lastStage = p.stage
+      onStage(`${FILES_STAGE_LABELS[p.stage]} …`)
+    }
+  })
+
+  if (result.stage === "error") {
+    const reason: PullReason = result.failedStage === "build" ? "composer_failed" : "fetch_failed"
+    return {
+      ...fail(reason, result.error ?? "The pull failed."),
+      ...(result.failedStage ? { failedStage: result.failedStage } : {}),
+    }
+  }
+
+  // Link it exactly as the TUI's guided clone does — `pull db` and the TUI's
+  // own `p`/`m` flows all key off this link.
+  await writeLink(site.id, { domain: site.domain, path: plan.destPath, localUrl })
+  onStage(`Linked ${site.domain} → ${plan.destPath}`)
+
+  return {
+    ok: true,
+    command,
+    domain,
+    primaryDomain: site.domain,
+    path: plan.destPath,
+    localUrl,
+    method: plan.isGit ? "git" : "rsync",
+    ranComposer: result.ranComposer === true,
+    linked: true,
+    ...(localUrl
+      ? {}
+      : {
+          warning: `No local URL recorded. \`spinuptui pull db ${site.domain}\` needs one to rewrite production URLs — pass --url on the next run.`,
+        }),
+  }
+}
+
+export async function runPullDb(
+  domain: string,
+  opts: { url?: string | null; yes: boolean },
+  client: SpinupWPClientLike,
+  cfg: AppConfig,
+  onStage: StageReporter,
+): Promise<PullDbResult> {
+  const command: PullCommand = "pull db"
+  const fail = (reason: PullReason, message: string, remedy?: string): PullFailure => ({
+    ok: false,
+    command,
+    domain,
+    reason,
+    message,
+    ...(remedy ? { remedy } : {}),
+  })
+
+  // Both gates first, before any network call: a wrong domain in a script
+  // should bounce off the confirmation, not off a fleet lookup.
+  if (!cfg.localSync) {
+    return fail(
+      "local_sync_disabled",
+      "Local database sync is disabled for this install.",
+      `Set "localSync": true in ${configPath()} (or export SPINUPWP_LOCAL_SYNC=1) to enable it.`,
+    )
+  }
+  if (!opts.yes) {
+    return fail(
+      "not_confirmed",
+      `This overwrites the local database for ${domain} with production's.`,
+      `Re-run with --yes once you're sure: \`spinuptui pull db ${domain} --yes\`.`,
+    )
+  }
+
+  onStage(`Resolving ${domain} …`)
+  const resolved = await resolveSiteByDomain(domain, client, cfg)
+  if (!resolved.ok) return fromResolverFailure(command, resolved.result)
+  const { site, server } = resolved
+
+  let link = readLink(site.id)
+  if (!link) {
+    return fail(
+      "not_linked",
+      `${site.domain} has no local copy linked, so there's nothing to import into.`,
+      `Run \`spinuptui pull files ${domain} <path> --url <local url>\` first.`,
+    )
+  }
+  // `--url` here doubles as "set the local URL and then sync", which is how a
+  // copy pulled without one becomes syncable without a detour through the TUI.
+  const url = opts.url?.trim()
+  if (url && url !== link.localUrl) {
+    link = { ...link, localUrl: url }
+    await writeLink(site.id, link)
+    onStage(`Local URL set to ${url}`)
+  }
+  onStage(`Local copy: ${expandPath(link.path)}`)
+
+  const planned = planDbSync(site, server, cfg.sshUser, link, new Date())
+  if (!planned.ok) {
+    return fail(
+      "plan_failed",
+      planned.error,
+      /local URL/i.test(planned.error) ? `Pass --url <local url> (e.g. \`spinuptui pull db ${domain} --url https://example.test --yes\`).` : undefined,
+    )
+  }
+  const plan = planned.plan
+
+  onStage(`Rewriting ${plan.remoteOrigin} → ${plan.localOrigin}`)
+  if (plan.prefixWarning) onStage(`Warning: ${plan.prefixWarning}`)
+  onStage(`A pre-import backup of the local database is written to ${plan.localBackupPath}`)
+
+  let lastStage: DbSyncStage | null = null
+  const result = await runDbSync(plan, site.domain, (p) => {
+    if (p.stage !== lastStage && p.stage !== "done" && p.stage !== "error") {
+      lastStage = p.stage
+      onStage(`${DB_STAGE_LABELS[p.stage]} …`)
+    }
+  })
+
+  if (result.stage === "error") {
+    return {
+      ...fail("sync_failed", result.error ?? "The sync failed."),
+      ...(result.failedStage ? { failedStage: result.failedStage } : {}),
+    }
+  }
+
+  return {
+    ok: true,
+    command,
+    domain,
+    primaryDomain: site.domain,
+    path: expandPath(link.path),
+    localUrl: plan.localOrigin,
+    downloadPath: result.downloadPath ?? plan.downloadPath,
+    localBackupPath: result.localBackupPath ?? plan.localBackupPath,
+    ranHook: result.ranHook === true,
+    ...(plan.prefixWarning ? { warning: plan.prefixWarning } : {}),
+  }
+}

--- a/src/lib/cliPull.ts
+++ b/src/lib/cliPull.ts
@@ -17,6 +17,7 @@
 // TUI enforces) and an explicit `--yes` on the invocation. Both are checked
 // before any network call, so a typo'd domain in a script fails on the gate.
 
+import { existsSync } from "node:fs"
 import { join } from "node:path"
 import { configPath, type AppConfig } from "../config.ts"
 import type { SpinupWPClientLike } from "../api/client.ts"
@@ -63,9 +64,9 @@ export interface PullFilesSuccess {
   method: "git" | "rsync"
   ranComposer: boolean
   linked: true
-  // Present when the copy is on disk and linked but not yet usable by `pull db`
-  // — it needs a local URL to rewrite production URLs to.
-  warning?: string
+  // Non-fatal caveats about the copy that just landed — most importantly the
+  // things standing between it and a working `pull db`.
+  warnings?: string[]
 }
 
 export interface PullDbSuccess {
@@ -78,7 +79,7 @@ export interface PullDbSuccess {
   downloadPath: string
   localBackupPath: string
   ranHook: boolean
-  warning?: string
+  warnings?: string[]
 }
 
 export type PullFilesResult = PullFilesSuccess | PullFailure
@@ -214,6 +215,24 @@ export async function runPullFiles(
   await writeLink(site.id, { domain: site.domain, path: plan.destPath, localUrl })
   onStage(`Linked ${site.domain} → ${plan.destPath}`)
 
+  const warnings: string[] = []
+  if (!localUrl) {
+    warnings.push(
+      `No local URL recorded. \`spinuptui pull db ${site.domain}\` needs one to rewrite production URLs — pass --url on the next run.`,
+    )
+  }
+  // The rsync path copies the site's real wp-config.php, which holds
+  // PRODUCTION's database credentials. Harmless in itself (SpinupWP's DB_HOST
+  // is localhost, so nothing local can reach the production database through
+  // it) but it means local wp-cli — and therefore `pull db` — authenticates as
+  // the production DB user against the local server and is denied. Say so here
+  // rather than letting it surface as a bare "Access denied" three steps later.
+  if (!plan.isGit && existsSync(join(plan.destPath, "wp-config.php"))) {
+    warnings.push(
+      `wp-config.php came from production and still holds its database credentials. Point DB_NAME / DB_USER / DB_PASSWORD / DB_HOST at your local database before running \`spinuptui pull db ${site.domain}\`.`,
+    )
+  }
+
   return {
     ok: true,
     command,
@@ -224,11 +243,7 @@ export async function runPullFiles(
     method: plan.isGit ? "git" : "rsync",
     ranComposer: result.ranComposer === true,
     linked: true,
-    ...(localUrl
-      ? {}
-      : {
-          warning: `No local URL recorded. \`spinuptui pull db ${site.domain}\` needs one to rewrite production URLs — pass --url on the next run.`,
-        }),
+    ...(warnings.length ? { warnings } : {}),
   }
 }
 
@@ -312,8 +327,19 @@ export async function runPullDb(
   })
 
   if (result.stage === "error") {
+    const error = result.error ?? "The sync failed."
+    // The overwhelmingly likely cause right after `pull files`: the copied
+    // wp-config.php still carries production's DB credentials, so local wp-cli
+    // authenticates as the production user against the local MySQL.
+    const deniedAs = /access denied for user '([^']+)'/i.exec(error)?.[1]
     return {
-      ...fail("sync_failed", result.error ?? "The sync failed."),
+      ...fail(
+        "sync_failed",
+        error,
+        deniedAs
+          ? `Local MySQL refused the user "${deniedAs}". If this copy came from \`pull files\`, its wp-config.php still holds production's database credentials — point DB_NAME / DB_USER / DB_PASSWORD / DB_HOST at your local database and re-run.`
+          : undefined,
+      ),
       ...(result.failedStage ? { failedStage: result.failedStage } : {}),
     }
   }
@@ -328,6 +354,6 @@ export async function runPullDb(
     downloadPath: result.downloadPath ?? plan.downloadPath,
     localBackupPath: result.localBackupPath ?? plan.localBackupPath,
     ranHook: result.ranHook === true,
-    ...(plan.prefixWarning ? { warning: plan.prefixWarning } : {}),
+    ...(plan.prefixWarning ? { warnings: [plan.prefixWarning] } : {}),
   }
 }

--- a/src/lib/cliPull.ts
+++ b/src/lib/cliPull.ts
@@ -37,6 +37,7 @@ export type PullReason =
   | "fetch_failed"
   | "composer_failed"
   | "not_linked"
+  | "missing_env"
   | "local_sync_disabled"
   | "not_confirmed"
   | "sync_failed"
@@ -108,20 +109,29 @@ const DB_STAGE_LABELS: Record<DbSyncStage, string> = {
 // Shape a resolver failure (unknown domain, ambiguous domain, dead token, …)
 // into this command's result type, preserving the shared reason codes.
 function fromResolverFailure(command: PullCommand, failure: { ok: false } & Record<string, unknown>): PullFailure {
+  const candidates = failure.candidates as SshAccessCandidate[] | undefined
+  // Unlike `ssh`/`ssh-exec`, these commands can be pointed at one of the
+  // matches, so an ambiguous domain is recoverable — name the flag that does it.
+  const remedy =
+    failure.remedy != null
+      ? String(failure.remedy)
+      : failure.reason === "multiple_matches" && candidates?.length
+        ? `Pick one with --server, e.g. \`--server ${candidates[0]!.server}\`.`
+        : undefined
   return {
     ok: false,
     command,
     domain: String(failure.domain ?? ""),
     reason: failure.reason as PullReason,
     message: String(failure.message ?? ""),
-    ...(failure.remedy ? { remedy: String(failure.remedy) } : {}),
-    ...(failure.candidates ? { candidates: failure.candidates as SshAccessCandidate[] } : {}),
+    ...(remedy ? { remedy } : {}),
+    ...(candidates ? { candidates } : {}),
   }
 }
 
 export async function runPullFiles(
   domain: string,
-  opts: { path?: string | null; url?: string | null },
+  opts: { path?: string | null; url?: string | null; server?: string | null },
   client: SpinupWPClientLike,
   cfg: AppConfig,
   onStage: StageReporter,
@@ -137,7 +147,7 @@ export async function runPullFiles(
   })
 
   onStage(`Resolving ${domain} …`)
-  const resolved = await resolveSiteByDomain(domain, client, cfg)
+  const resolved = await resolveSiteByDomain(domain, client, cfg, { server: opts.server })
   if (!resolved.ok) return fromResolverFailure(command, resolved.result)
   const { site, server } = resolved
   onStage(`Site ${site.domain} on ${server.name} (${server.ip_address})`)
@@ -227,6 +237,16 @@ export async function runPullFiles(
   // it) but it means local wp-cli — and therefore `pull db` — authenticates as
   // the production DB user against the local server and is denied. Say so here
   // rather than letting it surface as a bare "Access denied" three steps later.
+  // The mirror image on the git path: Bedrock/Radicle keep DB credentials and
+  // WP_HOME in .env, which is deliberately NOT in the repo — so a fresh clone
+  // has none, and wp-cli runs with empty DB settings (`mysqldump: unknown
+  // variable 'pass='`). composer install having run is exactly the signal that
+  // this is such a checkout.
+  if (result.ranComposer && !existsSync(join(plan.destPath, ".env"))) {
+    warnings.push(
+      `No .env in the checkout — Bedrock/Radicle keep database credentials and WP_HOME there, and it isn't in the repo. Copy .env.example to .env and fill in DB_NAME / DB_USER / DB_PASSWORD / WP_HOME before running \`spinuptui pull db ${site.domain}\`.`,
+    )
+  }
   if (!plan.isGit && existsSync(join(plan.destPath, "wp-config.php"))) {
     warnings.push(
       `${join(plan.destPath, "wp-config.php")} came from production and still holds its database credentials. Point DB_NAME / DB_USER / DB_PASSWORD / DB_HOST at your local database before running \`spinuptui pull db ${site.domain}\`.`,
@@ -249,7 +269,7 @@ export async function runPullFiles(
 
 export async function runPullDb(
   domain: string,
-  opts: { url?: string | null; yes: boolean },
+  opts: { url?: string | null; yes: boolean; server?: string | null },
   client: SpinupWPClientLike,
   cfg: AppConfig,
   onStage: StageReporter,
@@ -282,7 +302,7 @@ export async function runPullDb(
   }
 
   onStage(`Resolving ${domain} …`)
-  const resolved = await resolveSiteByDomain(domain, client, cfg)
+  const resolved = await resolveSiteByDomain(domain, client, cfg, { server: opts.server })
   if (!resolved.ok) return fromResolverFailure(command, resolved.result)
   const { site, server } = resolved
 
@@ -313,6 +333,16 @@ export async function runPullDb(
     )
   }
   const plan = planned.plan
+
+  // Fail on the real cause rather than letting empty DB settings surface three
+  // steps later as `mysqldump: unknown variable 'pass='`.
+  if ((plan.localKind === "bedrock" || plan.localKind === "radicle") && !existsSync(join(plan.localRoot, ".env"))) {
+    return fail(
+      "missing_env",
+      `No .env in ${plan.localRoot} — this is a ${plan.localKind} checkout, so its database credentials live there and it isn't in the repo.`,
+      "Copy .env.example to .env and fill in DB_NAME / DB_USER / DB_PASSWORD / WP_HOME, then re-run.",
+    )
+  }
 
   onStage(`Rewriting ${plan.remoteOrigin} → ${plan.localOrigin}`)
   if (plan.prefixWarning) onStage(`Warning: ${plan.prefixWarning}`)

--- a/src/lib/cliPull.ts
+++ b/src/lib/cliPull.ts
@@ -229,7 +229,7 @@ export async function runPullFiles(
   // rather than letting it surface as a bare "Access denied" three steps later.
   if (!plan.isGit && existsSync(join(plan.destPath, "wp-config.php"))) {
     warnings.push(
-      `wp-config.php came from production and still holds its database credentials. Point DB_NAME / DB_USER / DB_PASSWORD / DB_HOST at your local database before running \`spinuptui pull db ${site.domain}\`.`,
+      `${join(plan.destPath, "wp-config.php")} came from production and still holds its database credentials. Point DB_NAME / DB_USER / DB_PASSWORD / DB_HOST at your local database before running \`spinuptui pull db ${site.domain}\`.`,
     )
   }
 

--- a/src/lib/cliSsh.ts
+++ b/src/lib/cliSsh.ts
@@ -66,6 +66,11 @@ export async function resolveSiteByDomain(
   domain: string,
   client: SpinupWPClientLike,
   cfg: AppConfig,
+  // Narrows an otherwise ambiguous domain to one server, by name — matching
+  // either the full name or its first label ("web1" for "web1.example.com"),
+  // which is what the ambiguity message itself prints. Callers that expose no
+  // way to pass it (ssh, ssh-exec) simply omit it and keep failing as before.
+  opts?: { server?: string | null },
 ): Promise<SiteResolution> {
   const fail = (
     partial: Omit<SshAccessResult & { ok: false }, "ok" | "domain">,
@@ -95,11 +100,27 @@ export async function resolveSiteByDomain(
           return { siteId: s.id, serverId: s.server_id, server: srv.name }
         }),
       )
-      return fail({
-        reason: "multiple_matches",
-        message: `"${domain}" matches ${matches.length} sites in this account — cannot pick one automatically.`,
-        candidates,
-      })
+      const wanted = opts?.server?.trim().toLowerCase()
+      const narrowed = wanted
+        ? candidates.filter((c) => {
+            const name = c.server.toLowerCase()
+            return name === wanted || name.split(".")[0] === wanted
+          })
+        : candidates
+      if (narrowed.length !== 1) {
+        return fail({
+          reason: "multiple_matches",
+          message: wanted
+            ? `"${domain}" matches ${matches.length} sites in this account, and ${narrowed.length === 0 ? "none are" : `${narrowed.length} are`} on a server matching "${opts?.server}".`
+            : `"${domain}" matches ${matches.length} sites in this account — cannot pick one automatically.`,
+          candidates,
+        })
+      }
+      site = matches.find((m) => m.id === narrowed[0]!.siteId)!
+      server = await client.getServer(site.server_id)
+      return server.ip_address
+        ? { ok: true, site, server }
+        : fail({ reason: "server_has_no_ip", message: `Server "${server.name}" has no IP address on file.` })
     }
     site = matches[0]!
     server = await client.getServer(site.server_id)

--- a/src/lib/cliSsh.ts
+++ b/src/lib/cliSsh.ts
@@ -5,6 +5,7 @@
 // trustworthy go/no-go rather than a guess.
 
 import type { AppConfig } from "../config.ts"
+import type { Server, Site } from "../api/types.ts"
 import type { SpinupWPClientLike } from "../api/client.ts"
 import { ApiError } from "../api/client.ts"
 import { resolveSiteSshTarget, SSH_OPTS } from "./probe.ts"
@@ -53,38 +54,39 @@ export type SshTargetResolution =
   | { ok: true; info: SshTargetInfo }
   | { ok: false; result: SshAccessResult & { ok: false } }
 
-// Domain -> site -> server -> SSH target/port, with no live connectivity check.
-// Split out of resolveSshAccess so callers that are about to run a real command
-// (which is itself a connectivity test) don't pay for a redundant probe first.
-export async function resolveSshTargetInfo(
+// A resolved domain, before anything is done with it. Shared by every
+// domain-addressed CLI command (`ssh`, `ssh-exec`, `pull`) so they all fail the
+// same way — same reason codes, same messages — on an unknown or ambiguous
+// domain, a rejected token, or a server with no IP.
+export type SiteResolution =
+  | { ok: true; site: Site; server: Server }
+  | { ok: false; result: SshAccessResult & { ok: false } }
+
+export async function resolveSiteByDomain(
   domain: string,
   client: SpinupWPClientLike,
   cfg: AppConfig,
-): Promise<SshTargetResolution> {
+): Promise<SiteResolution> {
+  const fail = (
+    partial: Omit<SshAccessResult & { ok: false }, "ok" | "domain">,
+  ): SiteResolution => ({ ok: false, result: { ok: false, domain, ...partial } })
+
   if (!cfg.token) {
-    return {
-      ok: false,
-      result: { ok: false, domain, reason: "no_token", message: "No API token configured. Run `spinuptui login`." },
-    }
+    return fail({ reason: "no_token", message: "No API token configured. Run `spinuptui login`." })
   }
 
-  let site
-  let server
+  let site: Site
+  let server: Server
   try {
     const sites = await client.listSites()
     const matches = sites.filter(
       (s) => s.domain === domain || s.additional_domains?.some((a) => a.domain === domain),
     )
     if (matches.length === 0) {
-      return {
-        ok: false,
-        result: {
-          ok: false,
-          domain,
-          reason: "site_not_found",
-          message: `No site matching "${domain}" found in this SpinupWP account.`,
-        },
-      }
+      return fail({
+        reason: "site_not_found",
+        message: `No site matching "${domain}" found in this SpinupWP account.`,
+      })
     }
     if (matches.length > 1) {
       const candidates: SshAccessCandidate[] = await Promise.all(
@@ -93,48 +95,45 @@ export async function resolveSshTargetInfo(
           return { siteId: s.id, serverId: s.server_id, server: srv.name }
         }),
       )
-      return {
-        ok: false,
-        result: {
-          ok: false,
-          domain,
-          reason: "multiple_matches",
-          message: `"${domain}" matches ${matches.length} sites in this account — cannot pick one automatically.`,
-          candidates,
-        },
-      }
+      return fail({
+        reason: "multiple_matches",
+        message: `"${domain}" matches ${matches.length} sites in this account — cannot pick one automatically.`,
+        candidates,
+      })
     }
-    site = matches[0]
+    site = matches[0]!
     server = await client.getServer(site.server_id)
   } catch (err) {
     if (err instanceof ApiError && err.status === 401) {
-      return {
-        ok: false,
-        result: {
-          ok: false,
-          domain,
-          reason: "token_rejected",
-          message: "Saved API token was rejected (401) — it may be expired or revoked.",
-          remedy: "Run `spinuptui login` to save a fresh token.",
-        },
-      }
+      return fail({
+        reason: "token_rejected",
+        message: "Saved API token was rejected (401) — it may be expired or revoked.",
+        remedy: "Run `spinuptui login` to save a fresh token.",
+      })
     }
     const message = err instanceof ApiError ? err.message : `Unexpected error: ${(err as Error).message}`
-    return { ok: false, result: { ok: false, domain, reason: "api_error", message } }
+    return fail({ reason: "api_error", message })
   }
 
   if (!server.ip_address) {
-    return {
-      ok: false,
-      result: {
-        ok: false,
-        domain,
-        reason: "server_has_no_ip",
-        message: `Server "${server.name}" has no IP address on file.`,
-      },
-    }
+    return fail({ reason: "server_has_no_ip", message: `Server "${server.name}" has no IP address on file.` })
   }
 
+  return { ok: true, site, server }
+}
+
+// Domain -> site -> server -> SSH target/port, with no live connectivity check.
+// Split out of resolveSshAccess so callers that are about to run a real command
+// (which is itself a connectivity test) don't pay for a redundant probe first.
+export async function resolveSshTargetInfo(
+  domain: string,
+  client: SpinupWPClientLike,
+  cfg: AppConfig,
+): Promise<SshTargetResolution> {
+  const resolved = await resolveSiteByDomain(domain, client, cfg)
+  if (!resolved.ok) return resolved
+
+  const { site, server } = resolved
   const target = resolveSiteSshTarget(site, server, cfg.sshUser)
   const port = server.ssh_port && server.ssh_port !== 22 ? server.ssh_port : null
 

--- a/src/lib/links.ts
+++ b/src/lib/links.ts
@@ -1,0 +1,23 @@
+// Local working-copy links, read/written outside the React store.
+//
+// The TUI's store owns an authoritative in-memory Map and persists the whole
+// map on every change (see store.tsx's persistLinks), so it doesn't need these.
+// The CLI has no store: it reads the config once and writes a single link back,
+// merging rather than replacing so a concurrent TUI session's other links
+// survive. Both paths end up in the same config key (`localSites`).
+
+import { loadConfig, saveConfig } from "../config.ts"
+import { normalizeLink, type LocalLink } from "./local.ts"
+
+// The link recorded for a site id, if any.
+export function readLink(siteId: number): LocalLink | undefined {
+  const raw = loadConfig().localSites[String(siteId)]
+  return raw ? normalizeLink(raw) : undefined
+}
+
+// Merge one link into the stored set. Re-reads the config immediately before
+// writing so we don't clobber links made since this process started.
+export async function writeLink(siteId: number, link: LocalLink): Promise<void> {
+  const current = loadConfig().localSites
+  await saveConfig({ localSites: { ...current, [String(siteId)]: normalizeLink(link) } })
+}


### PR DESCRIPTION
> Recreated from **#56**, which GitHub closed automatically when its base branch (#54) was merged and deleted. Same branch, same commits, now based on `main`.

Drives the two local-working-copy engines the TUI already uses (`lib/localSetup.ts`, `lib/dbSync.ts`) from the command line, so a site can be pulled down for local dev from a script or an agent without opening the TUI.

```
spinuptui pull files <domain> [path] [--url <local url>] [--server <name>] [--json]
spinuptui pull db <domain> [--url <local url>] [--server <name>] --yes [--json]
```

### Output contract
Follows `ssh-exec`'s shape rather than inventing one: **stdout is the machine channel** (with `--json`, exactly one result object; exit code mirrors `ok`), **stderr is human progress**, in both modes — so stdout stays trivially parseable for an agent while a person watching a ten-minute rsync can see it isn't hung. Failures carry a stable `reason` plus a `remedy` naming the exact command that fixes them:

```
$ spinuptui pull files bedrock.spinuptui.com ~/dev/bedrock.spinuptui.com
→ Resolving bedrock.spinuptui.com …
"bedrock.spinuptui.com" matches 2 sites in this account — cannot pick one automatically.
  · web1.spinuptui.com (site 252037)
  · web2.spinuptui.com (site 253297)
Pick one with --server, e.g. `--server web1.spinuptui.com`.
```

### Safety
- **`pull db` is gated twice** — `"localSync": true` in config (the same opt-in the TUI enforces) **and** `--yes`. Both are checked *before any network call*, so a typo'd domain in a script bounces off the gate rather than off a fleet lookup.
- **`pull files` refuses a site that already has a local copy** instead of re-syncing over local work, and refuses a non-empty destination.
- **The default path is only derived when exactly one `localRoots` entry exists.** With several configured (they're commonly split by stack) it's required — guessing would file a standard-WP site under Bedrock.

### The local-credentials problem, both halves of it
A pulled copy is never immediately syncable, for opposite reasons per stack, and both used to surface as cryptic `mysqldump` errors several steps later:

- **File pull** brings the site's real `wp-config.php` down, **production credentials and all**. Harmless in itself — SpinupWP's `DB_HOST` is localhost, so nothing local can reach production's database through them — but local wp-cli then authenticates as the *production* DB user and is denied.
- **Git clone** brings **no `.env`** at all, since Bedrock/Radicle keep credentials there and it's deliberately not in the repo. wp-cli runs with empty DB settings and dies on `mysqldump: unknown variable 'pass='`.

Both are now stated on the `pull files` that creates the copy (naming the exact file), and caught again on `pull db` — the missing `.env` up front as `reason: "missing_env"`, a denied login with a `remedy` explaining the likely cause. #54 carries the matching notes on the TUI's clone screen.

### Refactors
- `cliSsh.ts`'s domain→site/server lookup is extracted as `resolveSiteByDomain`, so `ssh`, `ssh-exec` and `pull` fail identically on an unknown/ambiguous domain, a rejected token, or an IP-less server. It gained optional `--server` narrowing, which `ssh`/`ssh-exec` don't pass — their output is unchanged.
- New `lib/links.ts` merges a single link into `config.localSites` (re-reading immediately before write, so a concurrent TUI session's links survive). The store keeps persisting its own authoritative map.

### Testing
`bun run typecheck` green. **Both paths live-tested end to end against real sites**, each followed by a successful `pull db` and verified in MySQL.

**`pub.spinuptui.com`** — Standard WP, non-git → the rsync path:

```
→ Source: rsync …:/sites/pub.spinuptui.com/files/ (excluding uploads and the caching drop-ins)
→ Getting the code down …
→ Linked pub.spinuptui.com → /Users/…/pub.spinuptui.com
Warning: /Users/…/wp-config.php came from production and still holds its database credentials. …
```

120 MB in ~10s. On disk: root-webroot layout preserved with `wp-config.php` alongside core, and the remote's `wp-content/uploads/` **and** `object-cache.php` both absent locally while everything else came down.

**`bedrock.spinuptui.com`** — Bedrock, git-deployed → the clone path:

```
→ Source: git clone git@github.com:…
→ Getting the code down …   → composer install …
Pulled … (git, composer install ran) and linked it.
Warning: No .env in the checkout — Bedrock/Radicle keep database credentials and WP_HOME there …
```

`composer install` built `web/wp` correctly. This site is also the one that exists on two servers, which is how the disambiguation gap surfaced.

**`pull db` after each**: local pre-import backup written, production dump downloaded, imported, URLs rewritten. Verified in MySQL — the site's real table prefix handled, `home`/`siteurl` on the local URL, and **zero** rows left containing the production domain.

Also verified: every usage error, both `pull db` gates, `site_not_found`, `multiple_matches` (with and without `--server`, including an unmatched value), `already_linked`, `ambiguous_dest`, `dest_not_empty`, `not_linked`, `missing_env`, and both output modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SG3orBudWnfTif1maqAeH3
